### PR TITLE
Auto-name orders from design image, surface in emails and UI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,9 @@ npm run lint         # ESLint
 npm test             # Vitest run (no watch)
 npm run db:push      # Push Drizzle schema to Turso
 npm run db:studio    # Drizzle Studio (database GUI)
+npm test             # Run all tests (Vitest)
+npm run test:watch   # Vitest in watch mode
+npx vitest run src/lib/__tests__/pricing.test.ts  # Run a single test file
 ```
 
 ## Tooling & CI
@@ -58,12 +61,22 @@ Vercel preview deploys on PRs require the PR author's GitHub user to be authoriz
 ### Route Structure (linear flow with breadcrumbs)
 
 ```
-/                → Landing page
-/design          → Chat + AI design generation (core loop)
-/preview         → Design on shirt mockup, refine/approve
-/order           → Size, color, quality, pricing breakdown
-/order/confirm   → Stripe checkout + confirmation
+/                       → Landing page
+/design                 → Chat + AI design generation (core loop)
+/designs                → Past design threads (auth-protected)
+/preview                → Design on shirt mockup, refine/approve
+/order                  → Size, color, pricing breakdown
+/order/confirm          → Stripe checkout + confirmation
+/orders                 → Customer order history with status/tracking
+/admin                  → Admin order list with filters, financial summary
+/admin/orders/[id]      → Admin order detail, ledger timeline, classification
+/(auth)/sign-in         → Sign in
+/(auth)/sign-up         → Sign up
+/(auth)/forgot-password → Initiate password reset
+/(auth)/reset-password  → Complete password reset
 ```
+
+Auth is checked in `src/middleware.ts` via session cookie. `/admin` is additionally gated by `ADMIN_EMAIL` env var (checked server-side in the page/actions).
 
 ### Core Loop (`/design` → `/preview`)
 
@@ -83,6 +96,16 @@ Stripe Checkout Session → redirect → webhook confirms payment → triggers P
 - **R2**: all generated images kept so user can revisit previous generations
 - **Printful**: product catalog, mockup generation, order submission, status webhooks
 - **Stripe**: checkout sessions, payment webhooks
+
+### Conventions
+
+- **Server Actions**: every page directory has a sibling `actions.ts` containing `"use server"` functions. API routes under `src/app/api/` are for webhooks only.
+- **Path alias**: `@` maps to `src/` (configured in `tsconfig.json` and `vitest.config.ts`).
+- **Claude API (Sonnet 4.6)**: messages must end with a user turn — no assistant prefill. The API rejects requests where the last message role is `assistant`. See `src/lib/ai.ts:buildMessages` for the workaround.
+- **Product catalog**: config-driven in `src/lib/products.ts`. Adding a product requires only a new entry in the `PRODUCTS` array with Printful variant IDs — preview, order, and checkout flows pick it up automatically. Variant discovery scripts live in `scripts/`.
+- **Pricing**: `total = baseCost × 1.5`. Generation cost is tracked on the `design` row for internal accounting but is not included in the customer-facing price.
+- **Ledger**: append-only financial log (`ledger_entry` table). Entry types: `sale`, `stripe_fee`, `cogs`, `refund`, `refund_cogs_reversal`. Ledger starts April 1, 2026 — no backfill for earlier orders.
+- **`order.quality`**: deprecated column kept nullable for historical orders. Do not use in new code.
 
 ## Environment Variables
 
@@ -106,47 +129,6 @@ PRINTFUL_DRY_RUN        # "true" to short-circuit Printful order submission (loc
 ```
 
 ## Known Issues / Next Steps
-
-### Done
-
-- ~~Mobile layout for design page~~ — gallery collapses into slide-in drawer on mobile, floating toggle button
-- ~~Sign out accessible from all pages~~ — SiteHeader is now auth-aware on every page
-- ~~Migrate existing pages to design system components~~ — all pages use Button, Badge, Card, Input from `src/components/ui/`
-- ~~Order tracking infrastructure~~ — updatedAt, stripePaymentIntentId, trackingNumber/URL on order table
-- ~~Printful webhook handler~~ — /api/webhooks/printful handles package_shipped and order_failed
-- ~~User-facing /orders page~~ — order history with status badges and tracking links
-- ~~Admin retry for stuck orders~~ — retry button on paid-status orders in admin table
-- ~~Fix nav and confirm page~~ — Orders link in header, confirm page links to /orders instead of promising emails
-- ~~Extract testable business logic~~ — pricing, order state machine, webhook handlers in src/lib/ with 28 tests
-- ~~Transactional emails via Resend~~ — order confirmation + shipping notification, fire-and-forget from webhooks
-- ~~Password reset flow~~ — Better-Auth sendResetPassword + Resend, /forgot-password and /reset-password pages
-- ~~Email domain~~ — switched to orders@prntd.org via Resend Pro with Cloudflare DNS
-- ~~Printful webhook registered~~ — via API (`POST /webhooks`) for package_shipped and order_failed
-- ~~Image upload in design chat~~ — drag-and-drop + file picker, stored in R2, visible to Claude in gallery context
-- ~~Printful webhook: order_canceled~~ — auto-updates status, zeroes cost
-- ~~Order archiving~~ — soft-delete, blocks archiving shipped/Printful orders
-- ~~Printful cost tracking~~ — stores actual fulfillment cost from API, backfilled via sync script
-- ~~Accounting foundation~~ — append-only ledger_entry table, order tags, admin financial summary (revenue/fees/COGS/profit)
-- ~~Order reconciliation~~ — all orders matched against Printful billing, 4 ghost orders identified and canceled
-- ~~Order classification system~~ — single-select classification (customer/sample/test/owner-use) separate from freeform tags, financial summary filtering by classification, admin reference section. Ledger starts April 1, 2026 (no backfill of pre-ledger orders).
-- ~~Composable admin filter/sort~~ — useReducer-driven FilterState, client-side summary computation with ledger+fallback, multi-select classification, sortable columns, 26 tests in admin-filters.test.ts
-- ~~Order detail page~~ — `/admin/orders/[id]` with full order info, ledger timeline, classification/tag management
-- ~~Customer order filters~~ — Active/Canceled/All status filter on /orders page, canceled Badge variant
-- ~~Build fix~~ — excluded scripts/ from tsconfig to prevent type collisions
-- ~~Stripe fee backfill~~ — all orders have complete ledger entries (sale + stripe_fee + cogs), fallback logic removed
-- ~~Multi-product plumbing~~ — productId wired through preview/order/checkout, colors/sizes/labels from product config, SHIRT_COLORS deleted
-- ~~Product catalog~~ — 3 products: Classic Tee (13 colors), Box Tee (5 colors), Clear iPhone Case (13 models)
-- ~~Product selector UI~~ — product picker cards on /preview, background preloads all mockups (throttled 3 concurrent), rotating loading messages, instant switching when cached
-- ~~Discount code plumbing~~ — allow_promotion_codes on checkout, webhook captures discountCode/discountAmount, ledger uses actual amount paid. "Launch Special" coupon (50% off) created in Stripe with nico-codes and atlas codes.
-- ~~Preview page overhaul~~ — deferred mockup rendering (no eager preload), image scale slider, product silhouettes with print area overlay, color picker moved above preview, iPhone case mockup fix
-- ~~Test coverage expansion~~ — 84 → 121 tests: ledger, chat-utils, products, AI prompt parsing, discount webhook path
-- ~~Remove quality selector~~ — stripped standard/premium from pricing, order page, checkout, webhooks, email, admin, tests. Schema field kept nullable for historical orders.
-- ~~Admin Recover action for stuck pending orders~~ — replays Stripe webhook flow via shared `handleStripeCheckoutCompleted`; extracted `sendPostOrderEmails` helper; structured `{ok, reason}` response so admin alerts show actual failure reason (e.g., "Stripe session is not paid"). 14 new TDD tests.
-- ~~Drop generation cost from customer-facing price~~ — baseCost × 1.5 only; generationCost still tracked on design row for internal use. Fixes order page breakdown where line items didn't sum to total.
-- ~~Admin list shows time to the minute~~ — easier Stripe cross-reference.
-- ~~Claude model swap~~ — `claude-sonnet-4-20250514` → `claude-sonnet-4-6` with Sonnet 4.6 compatibility fixes (no assistant prefill, useEffect loop)
-- ~~Women's Relaxed Tee~~ — Bella+Canvas 6400, 22 colors, S–3XL, Printful product ID 360, variant fetch script at `scripts/fetch-variants-6400.ts`
-- ~~Product catalog~~ — now 4 products: Classic Tee, Box Tee, Women's Relaxed Tee, Clear iPhone Case
 
 **Discount codes + promo (remaining)**
 - Test end-to-end checkout with a promo code on local dev + Stripe test mode (see validation checklist in memory)

--- a/src/app/admin/actions.ts
+++ b/src/app/admin/actions.ts
@@ -11,6 +11,7 @@ import {
 } from "@/lib/db/schema";
 import { eq, desc, isNull, isNotNull, sum, count, and } from "drizzle-orm";
 import { createOrder } from "@/lib/printful";
+import { generateOrderName } from "@/lib/ai";
 import { getProductOrThrow, getVariantId } from "@/lib/products";
 import { assertTransition } from "@/lib/order-state";
 import { ORDER_CLASSIFICATIONS, type OrderClassification } from "@/lib/order-classification";
@@ -52,6 +53,7 @@ export async function getOrders() {
       classification: orderTable.classification,
       archivedAt: orderTable.archivedAt,
       createdAt: orderTable.createdAt,
+      displayName: orderTable.displayName,
       userEmail: userTable.email,
       designImageUrl: designTable.currentImageUrl,
       designId: orderTable.designId,
@@ -217,6 +219,7 @@ export async function recoverPendingOrder(
         handleStripeCheckoutCompleted(sessionData, {
           db,
           createPrintfulOrder: createOrder,
+          generateOrderName,
         }),
 
       sendEmails: (id) =>
@@ -387,6 +390,7 @@ export async function getAdminData() {
         classification: orderTable.classification,
         archivedAt: orderTable.archivedAt,
         createdAt: orderTable.createdAt,
+        displayName: orderTable.displayName,
         userEmail: userTable.email,
         designImageUrl: designTable.currentImageUrl,
         designId: orderTable.designId,
@@ -446,6 +450,7 @@ export async function getOrderDetail(orderId: string) {
         archivedAt: orderTable.archivedAt,
         createdAt: orderTable.createdAt,
         updatedAt: orderTable.updatedAt,
+        displayName: orderTable.displayName,
         userEmail: userTable.email,
         designImageUrl: designTable.currentImageUrl,
         designId: orderTable.designId,

--- a/src/app/admin/orders/[id]/page.tsx
+++ b/src/app/admin/orders/[id]/page.tsx
@@ -150,8 +150,11 @@ export default function OrderDetailPage() {
       </Link>
 
       {/* Header */}
-      <div className="flex items-center gap-3 mb-6">
-        <h1 className="text-xl font-bold font-mono">{order.id.slice(0, 8)}</h1>
+      <div className="flex items-center gap-3 mb-6 flex-wrap">
+        <h1 className="text-xl font-bold">{order.displayName ?? order.id.slice(0, 8)}</h1>
+        {order.displayName && (
+          <span className="text-sm font-mono text-text-muted">{order.id.slice(0, 8)}</span>
+        )}
         <Badge variant={order.status}>{order.status}</Badge>
         {order.classification && (
           <span className="text-xs px-2 py-0.5 rounded bg-surface-raised text-text-muted">

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -297,13 +297,16 @@ export default function AdminPage() {
                     key={order.id}
                     className={`hover:bg-surface-raised ${order.archivedAt ? "opacity-50" : ""}`}
                   >
-                    <td className="py-3 pr-4 font-mono text-xs">
+                    <td className="py-3 pr-4 text-xs">
                       <Link
                         href={`/admin/orders/${order.id}`}
                         className="text-blue-400 hover:underline"
                       >
-                        {order.id.slice(0, 8)}
+                        {order.displayName ?? <span className="font-mono">{order.id.slice(0, 8)}</span>}
                       </Link>
+                      {order.displayName && (
+                        <div className="font-mono text-text-faint text-[10px] mt-0.5">{order.id.slice(0, 8)}</div>
+                      )}
                     </td>
                     <td className="py-3 pr-4">
                       <div className="flex flex-wrap items-center gap-1">

--- a/src/app/api/webhooks/printful/route.ts
+++ b/src/app/api/webhooks/printful/route.ts
@@ -31,7 +31,7 @@ export async function POST(request: NextRequest) {
     if (result.action === "shipped" && result.orderId) {
       try {
         const orderWithUser = await db
-          .select({ email: userTable.email })
+          .select({ email: userTable.email, displayName: orderTable.displayName })
           .from(orderTable)
           .innerJoin(userTable, eq(orderTable.userId, userTable.id))
           .where(eq(orderTable.id, result.orderId))
@@ -43,6 +43,7 @@ export async function POST(request: NextRequest) {
             orderId: result.orderId,
             trackingNumber: result.trackingNumber ?? null,
             trackingUrl: result.trackingUrl ?? null,
+            displayName: orderWithUser.displayName,
           });
           console.log(`Order ${result.orderId}: shipping email sent to ${orderWithUser.email}`);
         }

--- a/src/app/api/webhooks/stripe/route.ts
+++ b/src/app/api/webhooks/stripe/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { stripe } from "@/lib/stripe";
 import { db } from "@/lib/db";
 import { createOrder } from "@/lib/printful";
+import { generateOrderName } from "@/lib/ai";
 import {
   handleStripeCheckoutCompleted,
   type StripeSessionData,
@@ -93,6 +94,7 @@ export async function POST(request: NextRequest) {
       const result = await handleStripeCheckoutCompleted(sessionData, {
         db,
         createPrintfulOrder: createOrder,
+        generateOrderName,
       });
       console.log(`Stripe event ${event.id}: order ${orderId} → ${result.action}`);
 

--- a/src/app/orders/actions.ts
+++ b/src/app/orders/actions.ts
@@ -24,6 +24,7 @@ export async function getUserOrders() {
       trackingUrl: orderTable.trackingUrl,
       createdAt: orderTable.createdAt,
       archivedAt: orderTable.archivedAt,
+      displayName: orderTable.displayName,
       designImageUrl: designTable.currentImageUrl,
     })
     .from(orderTable)

--- a/src/app/orders/page.tsx
+++ b/src/app/orders/page.tsx
@@ -122,13 +122,17 @@ export default function OrdersPage() {
                   {/* Order details */}
                   <div className="flex-1 min-w-0">
                     <div className="flex items-center justify-between gap-2 mb-1">
-                      <div className="flex items-center gap-2">
+                      <div className="flex items-center gap-2 min-w-0">
                         <Badge variant={order.status}>
                           {statusLabel[order.status] ?? order.status}
                         </Badge>
-                        <span className="text-xs text-text-faint font-mono">
-                          {order.id.slice(0, 8)}
-                        </span>
+                        {order.displayName ? (
+                          <span className="text-sm font-medium truncate">{order.displayName}</span>
+                        ) : (
+                          <span className="text-xs text-text-faint font-mono">
+                            {order.id.slice(0, 8)}
+                          </span>
+                        )}
                       </div>
                       <span className="text-sm font-medium">
                         ${order.totalPrice.toFixed(2)}
@@ -137,6 +141,9 @@ export default function OrdersPage() {
 
                     <p className="text-sm text-text-muted">
                       {order.size} / {order.color}
+                      {order.displayName && (
+                        <span className="text-xs text-text-faint font-mono ml-2">{order.id.slice(0, 8)}</span>
+                      )}
                     </p>
 
                     <div className="flex items-center justify-between mt-1">

--- a/src/lib/__tests__/ai.test.ts
+++ b/src/lib/__tests__/ai.test.ts
@@ -64,6 +64,74 @@ describe("chatAboutDesign", () => {
   });
 });
 
+describe("generateOrderName", () => {
+  beforeEach(async () => {
+    const mockCreate = await getMockCreate();
+    mockCreate.mockReset();
+  });
+
+  it("returns the trimmed name from a vision response", async () => {
+    const mockCreate = await getMockCreate();
+    mockCreate.mockResolvedValue({
+      content: [{ type: "text", text: "Artificial Idiot" }],
+    });
+
+    const { generateOrderName } = await import("../ai");
+    const name = await generateOrderName("https://example.com/x.png");
+
+    expect(name).toBe("Artificial Idiot");
+    // Verify the call sent an image content block
+    const call = mockCreate.mock.calls[0][0];
+    expect(call.messages[0].content[0].type).toBe("image");
+    expect(call.messages[0].content[0].source.url).toBe("https://example.com/x.png");
+  });
+
+  it("strips surrounding quotes and trailing periods", async () => {
+    const mockCreate = await getMockCreate();
+    mockCreate.mockResolvedValue({
+      content: [{ type: "text", text: '"Blue Mountain Landscape."' }],
+    });
+
+    const { generateOrderName } = await import("../ai");
+    const name = await generateOrderName("https://example.com/x.png");
+    expect(name).toBe("Blue Mountain Landscape");
+  });
+
+  it("returns null on empty response", async () => {
+    const mockCreate = await getMockCreate();
+    mockCreate.mockResolvedValue({ content: [{ type: "text", text: "   " }] });
+
+    const { generateOrderName } = await import("../ai");
+    const name = await generateOrderName("https://example.com/x.png");
+    expect(name).toBeNull();
+  });
+
+  it("returns null and logs on API error", async () => {
+    const mockCreate = await getMockCreate();
+    mockCreate.mockRejectedValue(new Error("Anthropic down"));
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const { generateOrderName } = await import("../ai");
+    const name = await generateOrderName("https://example.com/x.png");
+
+    expect(name).toBeNull();
+    expect(errSpy).toHaveBeenCalled();
+    errSpy.mockRestore();
+  });
+
+  it("caps overly long names at 60 chars", async () => {
+    const mockCreate = await getMockCreate();
+    const longName = "A".repeat(120);
+    mockCreate.mockResolvedValue({
+      content: [{ type: "text", text: longName }],
+    });
+
+    const { generateOrderName } = await import("../ai");
+    const name = await generateOrderName("https://example.com/x.png");
+    expect(name?.length).toBeLessThanOrEqual(60);
+  });
+});
+
 describe("constructFluxPrompt", () => {
   beforeEach(async () => {
     const mockCreate = await getMockCreate();

--- a/src/lib/__tests__/order-emails.test.ts
+++ b/src/lib/__tests__/order-emails.test.ts
@@ -9,6 +9,7 @@ function createDeps(overrides: Partial<OrderEmailDeps> = {}): OrderEmailDeps {
       color: "Black",
       totalPrice: 30.0,
       discountCode: null,
+      displayName: null,
     }),
     sendOrderConfirmation: vi.fn().mockResolvedValue(undefined),
     sendOwnerOrderAlert: vi.fn().mockResolvedValue(undefined),
@@ -29,6 +30,7 @@ describe("sendPostOrderEmails", () => {
       size: "M",
       color: "Black",
       total: 30.0,
+      displayName: null,
     });
     expect(deps.sendOwnerOrderAlert).toHaveBeenCalledWith({
       orderId: "order-1",
@@ -37,6 +39,7 @@ describe("sendPostOrderEmails", () => {
       color: "Black",
       total: 30.0,
       discountCode: null,
+      displayName: null,
     });
   });
 
@@ -48,6 +51,7 @@ describe("sendPostOrderEmails", () => {
         color: "White",
         totalPrice: 15.0,
         discountCode: "nico-codes",
+        displayName: null,
       }),
     });
 
@@ -55,6 +59,28 @@ describe("sendPostOrderEmails", () => {
 
     expect(deps.sendOwnerOrderAlert).toHaveBeenCalledWith(
       expect.objectContaining({ discountCode: "nico-codes", total: 15.0 })
+    );
+  });
+
+  it("forwards displayName to both customer and owner emails", async () => {
+    const deps = createDeps({
+      loadOrderForEmail: vi.fn().mockResolvedValue({
+        email: "user@example.com",
+        size: "M",
+        color: "Black",
+        totalPrice: 30.0,
+        discountCode: null,
+        displayName: "Artificial Idiot",
+      }),
+    });
+
+    await sendPostOrderEmails("order-3", deps);
+
+    expect(deps.sendOrderConfirmation).toHaveBeenCalledWith(
+      expect.objectContaining({ displayName: "Artificial Idiot" })
+    );
+    expect(deps.sendOwnerOrderAlert).toHaveBeenCalledWith(
+      expect.objectContaining({ displayName: "Artificial Idiot" })
     );
   });
 

--- a/src/lib/__tests__/webhook-handlers.test.ts
+++ b/src/lib/__tests__/webhook-handlers.test.ts
@@ -81,6 +81,7 @@ describe("handleStripeCheckoutCompleted", () => {
     const result = await handleStripeCheckoutCompleted(baseSession(), {
       db: mockDb,
       createPrintfulOrder: mockCreateOrder,
+      generateOrderName: vi.fn().mockResolvedValue(null),
     });
 
     expect(result.action).toBe("submitted");
@@ -96,6 +97,7 @@ describe("handleStripeCheckoutCompleted", () => {
     const result = await handleStripeCheckoutCompleted(baseSession(), {
       db: mockDb,
       createPrintfulOrder: vi.fn(),
+      generateOrderName: vi.fn().mockResolvedValue(null),
     });
 
     expect(result.action).toBe("skipped");
@@ -110,6 +112,7 @@ describe("handleStripeCheckoutCompleted", () => {
       handleStripeCheckoutCompleted(baseSession(), {
         db: mockDb,
         createPrintfulOrder: vi.fn(),
+        generateOrderName: vi.fn().mockResolvedValue(null),
       })
     ).rejects.toThrow("Order order-1 not found");
   });
@@ -123,6 +126,7 @@ describe("handleStripeCheckoutCompleted", () => {
     const result = await handleStripeCheckoutCompleted(baseSession(), {
       db: mockDb,
       createPrintfulOrder: vi.fn(),
+      generateOrderName: vi.fn().mockResolvedValue(null),
     });
 
     expect(result.action).toBe("paid");
@@ -143,6 +147,7 @@ describe("handleStripeCheckoutCompleted", () => {
     const result = await handleStripeCheckoutCompleted(session, {
       db: mockDb,
       createPrintfulOrder: mockCreateOrder,
+      generateOrderName: vi.fn().mockResolvedValue(null),
     });
 
     expect(result.action).toBe("submitted");
@@ -163,7 +168,7 @@ describe("handleStripeCheckoutCompleted", () => {
 
     const result = await handleStripeCheckoutCompleted(
       baseSession({ amountTotal: null, discount: null }),
-      { db: mockDb, createPrintfulOrder: mockCreateOrder },
+      { db: mockDb, createPrintfulOrder: mockCreateOrder, generateOrderName: vi.fn().mockResolvedValue(null) },
     );
 
     expect(result.action).toBe("submitted");
@@ -171,6 +176,45 @@ describe("handleStripeCheckoutCompleted", () => {
     expect(setCall.totalPrice).toBe(40.0);
     expect(setCall.discountCode).toBeNull();
     expect(setCall.discountAmount).toBeNull();
+  });
+
+  it("persists displayName from generateOrderName before submitting to Printful", async () => {
+    const mockDb = createMockDb({
+      orderFindFirst: vi.fn().mockResolvedValue(pendingOrder),
+      designFindFirst: vi.fn().mockResolvedValue(designWithImage),
+    });
+    const mockCreateOrder = vi.fn().mockResolvedValue({ id: "pf_999" });
+    const mockGenerate = vi.fn().mockResolvedValue("Artificial Idiot");
+
+    const result = await handleStripeCheckoutCompleted(baseSession(), {
+      db: mockDb,
+      createPrintfulOrder: mockCreateOrder,
+      generateOrderName: mockGenerate,
+    });
+
+    expect(result.action).toBe("submitted");
+    expect(mockGenerate).toHaveBeenCalledWith(designWithImage.currentImageUrl);
+    // One of the update calls should set displayName
+    const setCalls = mockDb._mocks.updateSet.mock.calls.map((c: any[]) => c[0]);
+    expect(setCalls.some((c: any) => c.displayName === "Artificial Idiot")).toBe(true);
+  });
+
+  it("submits successfully when generateOrderName returns null", async () => {
+    const mockDb = createMockDb({
+      orderFindFirst: vi.fn().mockResolvedValue(pendingOrder),
+      designFindFirst: vi.fn().mockResolvedValue(designWithImage),
+    });
+    const mockCreateOrder = vi.fn().mockResolvedValue({ id: "pf_111" });
+
+    const result = await handleStripeCheckoutCompleted(baseSession(), {
+      db: mockDb,
+      createPrintfulOrder: mockCreateOrder,
+      generateOrderName: vi.fn().mockResolvedValue(null),
+    });
+
+    expect(result.action).toBe("submitted");
+    const setCalls = mockDb._mocks.updateSet.mock.calls.map((c: any[]) => c[0]);
+    expect(setCalls.some((c: any) => "displayName" in c)).toBe(false);
   });
 
   it("returns paid_printful_failed when Printful errors", async () => {
@@ -183,6 +227,7 @@ describe("handleStripeCheckoutCompleted", () => {
     const result = await handleStripeCheckoutCompleted(baseSession(), {
       db: mockDb,
       createPrintfulOrder: mockCreateOrder,
+      generateOrderName: vi.fn().mockResolvedValue(null),
     });
 
     expect(result.action).toBe("paid_printful_failed");

--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -120,6 +120,43 @@ export async function chatAboutDesign(
   return { message: text };
 }
 
+const NAME_SYSTEM_PROMPT = `You name t-shirt designs for an order management system. Look at the image and respond with 2–4 words that identify it at a glance.
+
+Rules:
+- If the design contains prominent text, return that text verbatim (trim to 4 words max).
+- Otherwise, describe the subject concisely (e.g. "Blue Mountain Landscape", "Skull With Roses").
+- Title Case. No quotes, no punctuation, no trailing period.
+- Respond with only the name. No preamble, no explanation.`;
+
+export async function generateOrderName(imageUrl: string): Promise<string | null> {
+  try {
+    const response = await anthropic.messages.create({
+      model: "claude-sonnet-4-6",
+      max_tokens: 32,
+      system: NAME_SYSTEM_PROMPT,
+      messages: [
+        {
+          role: "user",
+          content: [
+            { type: "image", source: { type: "url", url: imageUrl } },
+            { type: "text", text: "Name this design." },
+          ],
+        },
+      ],
+    });
+
+    const text =
+      response.content?.[0]?.type === "text" ? response.content[0].text : "";
+    const cleaned = text.trim().replace(/^["']|["']$/g, "").replace(/\.$/, "");
+    if (!cleaned) return null;
+    // Cap at 60 chars to keep email subjects sane
+    return cleaned.length > 60 ? cleaned.slice(0, 60).trim() : cleaned;
+  } catch (err) {
+    console.error("generateOrderName failed:", err);
+    return null;
+  }
+}
+
 export async function constructFluxPrompt(
   chatHistory: ChatMessage[],
   images: DesignImage[],

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -67,6 +67,7 @@ export const order = sqliteTable("order", {
   size: text("size").notNull(),
   color: text("color").notNull(),
   productId: text("product_id").notNull().default("bella-canvas-3001"),
+  displayName: text("display_name"),
   quality: text("quality"),  // deprecated — kept for historical orders
   totalPrice: real("total_price").notNull(),
   status: text("status", { enum: ["pending", "paid", "submitted", "shipped", "delivered", "canceled"] }).notNull().default("pending"),

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -30,18 +30,24 @@ export async function sendOrderConfirmation(params: {
   size: string;
   color: string;
   total: number;
+  displayName?: string | null;
 }) {
   const shortId = params.orderId.slice(0, 8);
+  const label = params.displayName ?? shortId;
+  const nameRow = params.displayName
+    ? `<tr><td style="padding: 8px 0; color: #888;">Design</td><td style="padding: 8px 0; text-align: right;">${params.displayName}</td></tr>`
+    : "";
 
   await resend.emails.send({
     from: FROM,
     to: params.to,
-    subject: `Order confirmed — ${shortId}`,
+    subject: `Order confirmed — ${label} (${params.color} ${params.size})`,
     html: `
       <div style="font-family: system-ui, sans-serif; max-width: 480px; margin: 0 auto; padding: 24px;">
         <h2 style="margin: 0 0 16px;">Your order is confirmed</h2>
         <p style="color: #555; margin: 0 0 24px;">We're printing your custom t-shirt now.</p>
         <table style="width: 100%; border-collapse: collapse; margin-bottom: 24px;">
+          ${nameRow}
           <tr><td style="padding: 8px 0; color: #888;">Order</td><td style="padding: 8px 0; text-align: right; font-family: monospace;">${shortId}</td></tr>
           <tr><td style="padding: 8px 0; color: #888;">Shirt</td><td style="padding: 8px 0; text-align: right;">${params.color} / ${params.size}</td></tr>
           <tr style="border-top: 1px solid #eee;"><td style="padding: 8px 0; font-weight: 600;">Total</td><td style="padding: 8px 0; text-align: right; font-weight: 600;">$${params.total.toFixed(2)}</td></tr>
@@ -60,20 +66,26 @@ export async function sendOwnerOrderAlert(params: {
   color: string;
   total: number;
   discountCode?: string | null;
+  displayName?: string | null;
 }) {
   const shortId = params.orderId.slice(0, 8);
+  const label = params.displayName ?? shortId;
   const discountLine = params.discountCode
     ? `<tr><td style="padding: 4px 0; color: #888;">Discount</td><td style="padding: 4px 0; text-align: right;">${params.discountCode}</td></tr>`
+    : "";
+  const nameRow = params.displayName
+    ? `<tr><td style="padding: 4px 0; color: #888;">Design</td><td style="padding: 4px 0; text-align: right;">${params.displayName}</td></tr>`
     : "";
 
   await resend.emails.send({
     from: FROM,
     to: process.env.OWNER_EMAIL ?? "nico@prntd.org",
-    subject: `New order ${shortId} — $${params.total.toFixed(2)}`,
+    subject: `New order: ${label} — ${params.color} ${params.size} — $${params.total.toFixed(2)}`,
     html: `
       <div style="font-family: system-ui, sans-serif; max-width: 480px; margin: 0 auto; padding: 24px;">
         <h2 style="margin: 0 0 16px;">New order</h2>
         <table style="width: 100%; border-collapse: collapse;">
+          ${nameRow}
           <tr><td style="padding: 4px 0; color: #888;">Order</td><td style="padding: 4px 0; text-align: right; font-family: monospace;">${shortId}</td></tr>
           <tr><td style="padding: 4px 0; color: #888;">Customer</td><td style="padding: 4px 0; text-align: right;">${params.customerEmail}</td></tr>
           <tr><td style="padding: 4px 0; color: #888;">Product</td><td style="padding: 4px 0; text-align: right;">${params.color} / ${params.size}</td></tr>
@@ -91,8 +103,10 @@ export async function sendShippingNotification(params: {
   orderId: string;
   trackingNumber: string | null;
   trackingUrl: string | null;
+  displayName?: string | null;
 }) {
   const shortId = params.orderId.slice(0, 8);
+  const label = params.displayName ?? shortId;
 
   const trackingHtml = params.trackingUrl
     ? `<p><a href="${params.trackingUrl}" style="display: inline-block; padding: 10px 20px; background: #18181b; color: #fff; text-decoration: none; border-radius: 6px;">Track your package</a></p>
@@ -104,11 +118,11 @@ export async function sendShippingNotification(params: {
   await resend.emails.send({
     from: FROM,
     to: params.to,
-    subject: `Your shirt shipped — ${shortId}`,
+    subject: `Your shirt shipped — ${label}`,
     html: `
       <div style="font-family: system-ui, sans-serif; max-width: 480px; margin: 0 auto; padding: 24px;">
         <h2 style="margin: 0 0 16px;">Your shirt is on the way</h2>
-        <p style="color: #555; margin: 0 0 24px;">Order ${shortId} has shipped.</p>
+        <p style="color: #555; margin: 0 0 24px;">${params.displayName ? `"${params.displayName}" (order ${shortId})` : `Order ${shortId}`} has shipped.</p>
         ${trackingHtml}
         <p style="color: #999; font-size: 12px; margin-top: 32px;">PRNTD &mdash; prntd.org</p>
       </div>

--- a/src/lib/order-emails.ts
+++ b/src/lib/order-emails.ts
@@ -9,6 +9,7 @@ export type OrderEmailPayload = {
   color: string;
   totalPrice: number;
   discountCode: string | null;
+  displayName: string | null;
 };
 
 export type OrderEmailDeps = {
@@ -46,6 +47,7 @@ export async function sendPostOrderEmails(
       size: payload.size,
       color: payload.color,
       total: payload.totalPrice,
+      displayName: payload.displayName,
     });
     console.log(`Order ${orderId}: confirmation email sent to ${payload.email}`);
   } catch (err) {
@@ -60,6 +62,7 @@ export async function sendPostOrderEmails(
       color: payload.color,
       total: payload.totalPrice,
       discountCode: payload.discountCode,
+      displayName: payload.displayName,
     });
   } catch (err) {
     console.error(`sendPostOrderEmails: owner alert failed for ${orderId}:`, err);
@@ -86,6 +89,7 @@ export function createDefaultOrderEmailDeps(
           color: orderTable.color,
           totalPrice: orderTable.totalPrice,
           discountCode: orderTable.discountCode,
+          displayName: orderTable.displayName,
         })
         .from(orderTable)
         .innerJoin(userTable, eq(orderTable.userId, userTable.id))

--- a/src/lib/webhook-handlers.ts
+++ b/src/lib/webhook-handlers.ts
@@ -8,11 +8,13 @@ import { assertTransition } from "@/lib/order-state";
 import { recordSale, recordCOGS, recordCancellation } from "@/lib/ledger";
 import type { createOrder } from "@/lib/printful";
 import type { db as appDb } from "@/lib/db";
+import type { generateOrderName } from "@/lib/ai";
 
 // Dependency interface for testability
 export type WebhookDeps = {
   db: typeof appDb;
   createPrintfulOrder: typeof createOrder;
+  generateOrderName: typeof generateOrderName;
 };
 
 // Stripe checkout.session.completed payload (after retrieval)
@@ -109,6 +111,14 @@ export async function handleStripeCheckoutCompleted(
   if (!foundDesign?.currentImageUrl) {
     console.error(`Order ${orderId}: design ${designId} has no image`);
     return { action: "paid" };
+  }
+
+  const displayName = await deps.generateOrderName(foundDesign.currentImageUrl);
+  if (displayName) {
+    await deps.db
+      .update(orderTable)
+      .set({ displayName, updatedAt: new Date() })
+      .where(eq(orderTable.id, orderId));
   }
 
   const product = getProductOrThrow(foundOrder.productId ?? "bella-canvas-3001");


### PR DESCRIPTION
## Summary
- Adds `generateOrderName()` in `src/lib/ai.ts` — Claude vision call on the final design image, returns a short 2–4 word name (or `null` on error). Used to make orders identifiable at a glance instead of `3cd9d356`.
- Runs in the Stripe webhook flow after payment confirmation, before emails fire, so subject lines can use it.
- Threads the name into customer confirmation, owner alert, and shipping notification subject lines + bodies.
- Surfaces the name in admin order list, admin order detail header, and the customer `/orders` page. Short ID kept as a secondary label everywhere.
- Falls back gracefully: if the vision call fails or returns nothing, `displayName` stays `null` and every surface uses the existing short-ID display.

## Schema change ⚠️
Adds a nullable `display_name` column to the `order` table. **Requires `npm run db:push` against prod before deploying this PR**, otherwise the webhook will fail trying to write to a non-existent column.

Backfill: not done. Historical orders will keep falling back to short ID. Easy to add later if useful.

## Decisions made
- **Vision call vs. chat-history extraction**: went with vision. Single accurate code path; ~$0.003 per order; runs server-side after payment so latency isn't user-facing.
- **Storage**: `order.display_name` rather than `design.display_name` — name is for order display, generated at order time, lives with the order.
- **When to generate**: in the webhook, not at order creation. Avoids spending tokens on abandoned checkouts.
- **Cap at 60 chars** to keep email subjects sane if the model returns something long.

## Tests
- 145/145 passing (was 137).
- 5 new tests for `generateOrderName` (happy path, quote/period stripping, empty response, API error, length cap).
- 1 new test verifying `sendPostOrderEmails` forwards `displayName` to both senders.
- 2 new tests verifying the webhook persists displayName when generated and skips the update when generation returns null.
- Updated existing webhook + order-emails tests for the new dep + payload field.

## Test plan
- [ ] Run `npm run db:push` against prod **before** merging/deploying
- [ ] Local end-to-end: place a test order via Stripe test mode, verify `display_name` is populated and emails contain it in the subject
- [ ] Spot-check admin list and `/orders` for both new orders (with name) and historical orders (fallback to short ID)
- [ ] Verify shipping email subject uses the name once a Printful `package_shipped` webhook lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)