### PR TITLE
Style-neutral image prompts + reorder ordered designs

### DIFF
--- a/src/app/design/actions.ts
+++ b/src/app/design/actions.ts
@@ -101,7 +101,11 @@ export async function generateDesign(
   // Generate image and attempt background removal
   let replicateUrl;
   try {
-    replicateUrl = await generateImage(aiResponse.fluxPrompt, refImageUrl);
+    replicateUrl = await generateImage(
+      aiResponse.fluxPrompt,
+      refImageUrl,
+      aiResponse.negativePrompt
+    );
   } catch (err) {
     console.error("generateImage failed:", err);
     throw new Error("Image generation failed");

--- a/src/app/designs/page.tsx
+++ b/src/app/designs/page.tsx
@@ -9,7 +9,6 @@ type Design = Awaited<ReturnType<typeof getUserDesigns>>[number];
 
 
 function getDesignHref(design: Design) {
-  if (design.status === "ordered") return "/orders";
   return `/design?id=${design.id}`;
 }
 
@@ -96,13 +95,18 @@ export default function DesignsPage() {
                       {design.generationCount} generation{design.generationCount !== 1 ? "s" : ""}
                     </span>
                     {design.status === "ordered" ? (
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        onClick={() => handleArchive(design.id)}
-                      >
-                        Archive
-                      </Button>
+                      <div className="flex items-center gap-2">
+                        <Link href={`/preview?id=${design.id}`}>
+                          <Button size="sm">Reorder</Button>
+                        </Link>
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          onClick={() => handleArchive(design.id)}
+                        >
+                          Archive
+                        </Button>
+                      </div>
                     ) : (
                       <Button
                         variant="danger"

--- a/src/lib/__tests__/ai.test.ts
+++ b/src/lib/__tests__/ai.test.ts
@@ -244,4 +244,73 @@ describe("constructFluxPrompt", () => {
     const call = mockCreate.mock.calls[0][0];
     expect(call.system).toContain('#1: "sunset"');
   });
+
+  it("captures negativePrompt when Claude provides one", async () => {
+    const mockCreate = await getMockCreate();
+    mockCreate.mockResolvedValue({
+      content: [{
+        type: "text",
+        text: JSON.stringify({
+          message: "Generating your brushy design",
+          fluxPrompt: "sumi-e brush calligraphy, hand-painted, white background",
+          negativePrompt: "clean vector, smooth gradients, digital font, polished illustration",
+          referenceImage: null,
+        }),
+      }],
+    });
+
+    const { constructFluxPrompt } = await import("../ai");
+    const result = await constructFluxPrompt(
+      [{ role: "user", content: "Hand-painted thought bubble" }],
+      []
+    );
+
+    expect(result.negativePrompt).toContain("clean vector");
+    expect(result.fluxPrompt).toContain("sumi-e");
+  });
+
+  it("defaults negativePrompt to null when missing", async () => {
+    const mockCreate = await getMockCreate();
+    mockCreate.mockResolvedValue({
+      content: [{
+        type: "text",
+        text: JSON.stringify({
+          message: "Generating",
+          fluxPrompt: "vector illustration",
+          referenceImage: null,
+        }),
+      }],
+    });
+
+    const { constructFluxPrompt } = await import("../ai");
+    const result = await constructFluxPrompt(
+      [{ role: "user", content: "anything" }],
+      []
+    );
+
+    expect(result.negativePrompt).toBeNull();
+  });
+
+  it("treats empty-string negativePrompt as null", async () => {
+    const mockCreate = await getMockCreate();
+    mockCreate.mockResolvedValue({
+      content: [{
+        type: "text",
+        text: JSON.stringify({
+          message: "Generating",
+          fluxPrompt: "vector illustration",
+          negativePrompt: "   ",
+          referenceImage: null,
+        }),
+      }],
+    });
+
+    const { constructFluxPrompt } = await import("../ai");
+    const result = await constructFluxPrompt(
+      [{ role: "user", content: "anything" }],
+      []
+    );
+
+    expect(result.negativePrompt).toBeNull();
+  });
 });

--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -29,35 +29,42 @@ Print constraints you know:
 - Flat graphics and illustrations over photographic styles
 - Text works well — Ideogram handles typography`;
 
-const GENERATE_SYSTEM_PROMPT = `You are a t-shirt design assistant for PRNTD. Your job is to translate the user's conversation into a detailed Ideogram image generation prompt.
+const GENERATE_SYSTEM_PROMPT = `You are a t-shirt design assistant for PRNTD. Your job is to translate the user's conversation into an Ideogram image generation prompt.
 
-Read the conversation to understand what the user wants, then respond with raw JSON (no markdown, no code fences):
+Read the conversation to understand what the user wants — both the SUBJECT and the AESTHETIC — then respond with raw JSON (no markdown, no code fences):
 {
   "message": "Brief acknowledgment of what you're generating",
   "fluxPrompt": "Detailed image generation prompt for Ideogram",
+  "negativePrompt": "Optional. Things to push the model AWAY from. Use when the user asks for an aesthetic the model tends to ignore (see Style section below). Empty string if not needed.",
   "referenceImage": null or number (e.g. 2) — set this to the # of a previous design if the user is refining/building on it
 }
 
-Print specifications (always follow these):
+Print specifications (always follow these — these are physics, not taste):
 - DTG printing, 12" x 16" print area
-- Design should work on a plain white background (background will be removed)
+- Design renders on a plain white background (background will be removed before printing)
 - Always include "white background, isolated design" in the prompt
-- Favor open, breathable compositions — avoid dense block prints
-- Moderate ink coverage, clean lines, high contrast
+- Favor open, breathable compositions — avoid dense block prints (technical: ink coverage matters for DTG)
+- Output must be a flat graphic / artwork only — NEVER a picture of a t-shirt. Never include "t-shirt" or "shirt" or "mockup" in the prompt. Use "graphic design", "illustration", "artwork", "print design", or the user's stated medium.
 
-Guidelines for Ideogram prompts:
-- CRITICAL: Output must be flat graphic/artwork only — NOT a picture of a t-shirt. Never include "t-shirt" in the prompt. Use "graphic design", "illustration", "artwork", or "print design"
-- Default to illustration, vector art, or clean graphic styles
-- Favor clean, wearable aesthetics
-- Centered compositions with breathing room
-- Stay faithful to what the user asked for
+Style — be faithful to the user's intent:
+- DO NOT default to clean / vector / digital illustration unless the user asks for it.
+- If the user asks for hand-painted, brushy, watercolor, distressed, screen-print, sumi-e, pen-and-ink, charcoal, vintage, handmade, scratchy, woodcut, lithograph, halftone, riso, zine, etc. — write that into the prompt with concrete texture cues, and use the negativePrompt field to push AWAY from "clean vector, smooth gradients, digital font, polished illustration, perfect curves".
+- If the user asks for clean / minimal / vector / flat / modern / corporate — write that.
+- If the user is silent on style, ASK before generating rather than guessing.
+- Style vocabulary translation tips:
+  - "brushy" / "hand-painted" → "sumi-e brush strokes, uneven ink pressure, ink pooling at stroke ends, raw bristle texture, imperfect edges"
+  - "distressed" / "vintage" → "halftone screen-print, deliberate ink gaps, slight registration offset, worn texture, faded mid-tones"
+  - "hand-drawn" → "pencil or pen lines with slight wobble, no perfect curves, visible mark-making"
+  - "punk zine" → "cut-and-paste collage, photocopied texture, deliberate misalignment, stark high contrast"
+- Never override the user's stated style because you think a different style would print better. The user gets what they asked for. If a style genuinely conflicts with print constraints (e.g. fine photographic gradients on DTG), explain that to the user in the chat — don't silently re-style.
 
 Text in designs:
-- Ideogram handles text well — include when requested
-- Specify exact text in quotes with "clean, legible typography"
+- Ideogram handles text well — include when requested.
+- Specify exact text in quotes. For typography, MATCH THE USER'S STYLE INTENT — if they want hand-painted, write "hand-lettered brush calligraphy with uneven ink pressure", not "clean legible typography".
 
-IMPORTANT — Refinements:
-When refining a previous design, reference its prompt (shown as "Prompt used: ..." or in the gallery context). Make only the specific changes requested. Preserve everything else. Set "referenceImage" to the design number being refined — the image will be passed to the model as a visual reference for style and composition consistency.`;
+Refinements:
+- When refining a previous design, reference its prompt (shown as "Prompt used: ..." in the gallery context). Make only the specific changes requested. Preserve the rest.
+- Set "referenceImage" to the design number being refined — the image will be passed to the model as a visual reference for style and composition consistency.`;
 
 function buildMessages(
   chatHistory: ChatMessage[],
@@ -161,7 +168,12 @@ export async function constructFluxPrompt(
   chatHistory: ChatMessage[],
   images: DesignImage[],
   userMessage?: string
-): Promise<{ message: string; fluxPrompt: string; referenceImage: number | null }> {
+): Promise<{
+  message: string;
+  fluxPrompt: string;
+  negativePrompt: string | null;
+  referenceImage: number | null;
+}> {
   const { messages, galleryContext } = buildMessages(
     chatHistory,
     images,
@@ -186,6 +198,7 @@ export async function constructFluxPrompt(
     return {
       message: "Let me generate that for you.",
       fluxPrompt: "graphic design illustration, white background, isolated design, high quality, printable",
+      negativePrompt: null,
       referenceImage: null,
     };
   }
@@ -195,15 +208,20 @@ export async function constructFluxPrompt(
 
   try {
     const parsed = JSON.parse(text);
+    const negative = typeof parsed.negativePrompt === "string" && parsed.negativePrompt.trim()
+      ? parsed.negativePrompt.trim()
+      : null;
     return {
       message: parsed.message,
       fluxPrompt: parsed.fluxPrompt,
+      negativePrompt: negative,
       referenceImage: parsed.referenceImage ?? null,
     };
   } catch {
     return {
       message: text,
       fluxPrompt: `graphic design illustration, white background, isolated design, high quality, printable`,
+      negativePrompt: null,
       referenceImage: null,
     };
   }

--- a/src/lib/replicate.ts
+++ b/src/lib/replicate.ts
@@ -4,7 +4,8 @@ const replicate = new Replicate();
 
 export async function generateImage(
   prompt: string,
-  referenceImageUrl?: string
+  referenceImageUrl?: string,
+  negativePrompt?: string | null
 ): Promise<string> {
   const input: Record<string, unknown> = {
     prompt,
@@ -14,6 +15,10 @@ export async function generateImage(
 
   if (referenceImageUrl) {
     input.style_reference_images = [referenceImageUrl];
+  }
+
+  if (negativePrompt) {
+    input.negative_prompt = negativePrompt;
   }
 
   const output = await replicate.run("ideogram-ai/ideogram-v3-turbo", {


### PR DESCRIPTION
Closes #8 (image generation style bias)
Partially addresses #2 (designs routing for ordered designs)

## Issue #8 — image generation style bias

The Claude system prompt at `src/lib/ai.ts` explicitly biased toward "clean illustration, vector art, clean lines, clean typography." Result: when the user asked for hand-painted brushwork, Claude obediently wrote an Ideogram prompt that included "clean illustration, vector art" alongside the user's words, and Ideogram delivered exactly that.

### Changes

- **Rewrote `GENERATE_SYSTEM_PROMPT`** to be style-neutral. Print-spec constraints (DTG, white background, breathable composition, "isolated design") are kept as hard rules. Style now follows the user's stated intent — explicitly forbids defaulting to clean/vector unless asked.
- **Added a style vocabulary translation guide** so Claude knows that "brushy" means "sumi-e brush strokes with ink pooling at stroke ends," "distressed" means "halftone screen-print with deliberate ink gaps," etc.
- **Added `negativePrompt`** to the JSON shape Claude returns. Claude can now provide a negative prompt like `"clean vector, smooth gradients, digital font, polished illustration"` when the user asks for imperfection. Wired through `constructFluxPrompt` → `generateDesign` → `generateImage` → Ideogram's `negative_prompt` parameter.
- **3 new tests** for negativePrompt parsing: present, absent, whitespace-only.

### Out of scope (issue #8 follow-ups)

- Style reference image library — still on the table for a future PR. Higher quality-bar but more involved.

## Issue #2 — reorder ordered designs

Clicking an ordered design previously redirected to `/orders`, with no way to reopen the design or buy another variant.

### Changes

- **Drop the redirect** in `getDesignHref`. Ordered designs now open their full `/design` thread (chat + image gallery), same as drafts.
- **Add an explicit "Reorder" button** on ordered design cards in `/designs`. Goes straight to `/preview?id={id}` so the user can skip the chat re-entry and just pick a variant + check out. Multiple `order` rows can already reference the same `design.id`, so no schema work needed.

### Out of scope (issue #2 follow-ups)

- The richer fork-with-`parent_design_id` model from issue #2 (read-only past view + "Make another like this" forks a new draft) is deferred. The simpler approach handles the reorder use case for now without a schema change. We can revisit fork semantics if/when the marketplace work in #6 makes lineage matter.

## Test plan

- [x] 148/148 tests passing locally
- [x] Lint clean (0 errors, 24 warnings — all pre-existing)
- [ ] After merge: open `/designs`, click an ordered design — should land on `/design?id=...` with the chat thread loaded, not redirect to `/orders`
- [ ] On an ordered design card, click "Reorder" — should land on `/preview?id=...`
- [ ] Generate a new design with an aesthetic prompt like "hand-painted thought bubble in brush calligraphy" — output should be visibly more brushy/imperfect than current production

🤖 Generated with [Claude Code](https://claude.com/claude-code)