### PR TITLE
Generate-readiness gate + fast thin-check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,6 @@ ci-skip.db
 
 # Playwright MCP artifacts
 .playwright-mcp/
+
+# Superpowers brainstorm artifacts
+.superpowers/

--- a/docs/superpowers/specs/2026-06-05-design-empty-state-redesign.md
+++ b/docs/superpowers/specs/2026-06-05-design-empty-state-redesign.md
@@ -1,0 +1,92 @@
+# /design empty-state redesign — design
+
+Date: 2026-06-05
+Branch: `feat/readiness-gate` (rides alongside the readiness-gate + fast-readiness work)
+Status: approved (brainstormed with visual companion 2026-06-05). NOT yet implemented.
+
+## Problem
+
+The `/design` empty state is cluttered and unfocused:
+
+- The input sits at the very bottom of the screen — far from where attention lands.
+- The "Generations" column is always shown, even with no images ("No images yet").
+- Generate and Compare are visible before there's anything to generate from.
+- The generating-state copy ("rendering" / rotating filler) reads as off.
+
+The page should open as a single, centered idea box and reveal the working
+machinery (chat column, Generations, Generate/Compare) only once it's useful.
+
+## Approved design — Layout A: centered composer
+
+### Empty state (no chat messages, no images)
+
+Shows ONLY:
+
+- Page chrome: PRNTD bar + breadcrumb + page title **"Start designing"**.
+- Vertically + horizontally centered:
+  - Hero heading: **"What shall we draw together?"**
+  - Subphrase: **"Describe it in plain words. Refine as we go."**
+  - The input + **Send** button.
+- **No** Generations column. **No** Generate/Compare buttons. **No** visible example chips on load.
+
+### Delayed suggestions
+
+- Example chips are hidden initially.
+- After **4 seconds of inactivity** (input empty and untouched), a quiet
+  **"Need a suggestion?"** label fades in with ~3 example chips
+  (e.g. "Minimalist mountain landscape", "Retro sunset, palm trees",
+  "Geometric wolf head"). Clicking a chip fills the input.
+- The moment the user types, the suggestion block disappears. (Re-arming after
+  it's been shown once is unnecessary — once they've engaged, drop it.)
+
+### Submit behavior (chat-first — the simple model)
+
+- Enter / Send submits the text as a **chat message** (`sendChatMessage`).
+  No "smart routing", no direct-generate from the empty box.
+- The first message transitions the view from the centered empty state to the
+  **existing two-column working layout** (chat + Generations). That working
+  view is unchanged: Generate/Compare appear there, behind the readiness gate
+  already built on this branch.
+
+### Generating message
+
+- Replace the rotating filler with a plain status while an image renders:
+  **"Drawing your design…"** alongside the existing spinner.
+- Keep the chat "Thinking…" indicator as-is (it's the chat reply, not a render).
+- Surface a real error state if the render fails (retry affordance already
+  exists on `/preview`; mirror that intent here if not present).
+
+## What drives "empty vs working"
+
+The split is a pure function of content: **empty state when there are zero chat
+messages AND zero images; working layout otherwise.** No new persisted flag —
+derive it from the data `page.tsx` already loads (`messages`, `images`).
+
+## Components touched
+
+- `src/app/design/page.tsx` — branch between the centered empty state and the
+  two-column working layout based on `messages.length === 0 && images.length === 0`.
+  Conditionally render the Generations column / `ImageGallery` only when there's
+  content (or while generating).
+- `src/app/design/chat-panel.tsx` — centered empty-state composer (heading,
+  subphrase, input, Send only); the 4s-inactivity "Need a suggestion?" reveal;
+  hide Generate/Compare while in the empty state.
+- `src/app/design/image-gallery.tsx` — not shown in the empty state; "Drawing
+  your design…" generating copy.
+
+## Testing
+
+- Mostly presentational → manual smoke on `/design`.
+- The one piece of real logic worth a unit test: the empty-vs-working predicate
+  (zero messages AND zero images → empty), as a pure helper.
+- The 4s reveal is a timer effect — verified by smoke, not unit test.
+
+## Out of scope
+
+- The working two-column layout itself (unchanged).
+- The readiness gate and the fast `assessReadiness` latency fix — already
+  implemented on this branch; this spec only changes the empty state + the
+  generating copy.
+- Mobile-specific reflow tuning beyond "centered composer collapses sensibly on
+  a phone" — phone-first, but no bespoke mobile mockup yet.
+```

--- a/src/app/design/actions.ts
+++ b/src/app/design/actions.ts
@@ -10,7 +10,7 @@ import {
   order as orderTable,
 } from "@/lib/db/schema";
 import { eq } from "drizzle-orm";
-import { chatAboutDesign, constructFluxPrompt } from "@/lib/ai";
+import { chatAboutDesign, constructFluxPrompt, assessReadiness } from "@/lib/ai";
 import { uploadDesignImage } from "@/lib/r2";
 import { getGenerator, GENERATORS, DEFAULT_GENERATOR_ID } from "@/lib/generators/registry";
 import {
@@ -73,7 +73,10 @@ export async function sendChatMessage(designId: string, userMessage: string) {
     .set({ updatedAt: new Date() })
     .where(eq(designTable.id, designId));
 
-  return { message: aiResponse.message };
+  return {
+    message: aiResponse.message,
+    readyToGenerate: aiResponse.readyToGenerate,
+  };
 }
 
 /**
@@ -128,6 +131,21 @@ export async function generateDesign(
       ]
     : messages;
 
+  // Fast pre-check: if the idea is too thin to render, ask for the missing
+  // piece in ~1s (Haiku) instead of paying the heavy constructFluxPrompt
+  // round-trip just to surface a clarifying question. Fails open.
+  const readiness = await assessReadiness(messagesForPrompt, images, userMessage);
+  if (!readiness.ready) {
+    await persistClarification(designId, userMessage, readiness.question);
+    return {
+      message: readiness.question,
+      imageUrl: null,
+      imageId: null,
+      generationNumber: found.generationCount,
+      readyToGenerate: false,
+    };
+  }
+
   let aiResponse;
   try {
     aiResponse = await constructFluxPrompt(
@@ -147,6 +165,7 @@ export async function generateDesign(
       imageUrl: null,
       imageId: null,
       generationNumber: found.generationCount,
+      readyToGenerate: false,
     };
   }
 
@@ -213,6 +232,7 @@ export async function generateDesign(
     imageUrl: r2Url,
     imageId: newImageId,
     generationNumber: newGeneration,
+    readyToGenerate: true,
   };
 }
 
@@ -418,6 +438,14 @@ export async function compareGenerators(designId: string, userMessage?: string) 
     ? [...messages, { id: "pending", designId, role: "user", content: userMessage, imageId: null, createdAt: new Date() }]
     : messages;
 
+  // Same fast thin-check as generateDesign — Compare runs two models, so a
+  // dead-click here is even costlier; bail in ~1s before any heavy work.
+  const readiness = await assessReadiness(messagesForPrompt, images, userMessage);
+  if (!readiness.ready) {
+    await persistClarification(designId, userMessage, readiness.question);
+    return { message: readiness.question, images: [], readyToGenerate: false };
+  }
+
   let aiResponse;
   try {
     aiResponse = await constructFluxPrompt(messagesForPrompt, images, userMessage);
@@ -428,7 +456,7 @@ export async function compareGenerators(designId: string, userMessage?: string) 
 
   if (isClarificationOnly(aiResponse.fluxPrompt)) {
     await persistClarification(designId, userMessage, aiResponse.message);
-    return { message: aiResponse.message, images: [] };
+    return { message: aiResponse.message, images: [], readyToGenerate: false };
   }
 
   const anchorUrl =
@@ -492,7 +520,7 @@ export async function compareGenerators(designId: string, userMessage?: string) 
     })
     .where(eq(designTable.id, designId));
 
-  return { message: summary, images: ok };
+  return { message: summary, images: ok, readyToGenerate: true };
 }
 
 /**

--- a/src/app/design/chat-panel.tsx
+++ b/src/app/design/chat-panel.tsx
@@ -55,6 +55,7 @@ export function ChatPanel({
   onGenerate,
   onCompare,
   activeGenerator,
+  readyToGenerate,
   onUploadImage,
 }: {
   messages: ChatMessage[];
@@ -65,6 +66,7 @@ export function ChatPanel({
   onGenerate: (message?: string) => void;
   onCompare: (message?: string) => void;
   activeGenerator: string;
+  readyToGenerate: boolean;
   onUploadImage: (base64: string, fileName: string) => void;
 }) {
   const urlByImageId = useMemo(
@@ -144,6 +146,12 @@ export function ChatPanel({
   }
 
   const busy = loading || generating;
+  // Soft nudge: until Claude judges the idea concrete (subject + style),
+  // Generate sits as a secondary button and a style hint shows — it pops to
+  // primary when ready. Always clickable; the fast thin-check catches a
+  // too-thin click in ~1s rather than greying the button into looking broken.
+  const notReadyTitle = "Add a style (e.g. watercolor, vintage, bold vector) to sharpen the idea — Generate still works.";
+  const showStyleHint = !readyToGenerate && messages.length > 0;
 
   return (
     <div
@@ -243,6 +251,13 @@ export function ChatPanel({
         <div ref={messagesEndRef} />
       </div>
 
+      {/* Style hint — shown while the idea isn't concrete enough yet */}
+      {showStyleHint && (
+        <div className="px-4 pt-2 text-xs text-text-muted">
+          Add a style — watercolor, vintage, bold vector — to sharpen the idea.
+        </div>
+      )}
+
       {/* Input */}
       <form onSubmit={handleSend} className="p-4 border-t border-border flex gap-2">
         <button
@@ -275,8 +290,10 @@ export function ChatPanel({
         </Button>
         <Button
           type="button"
+          variant={readyToGenerate ? "primary" : "secondary"}
           onClick={handleGenerate}
           disabled={busy || (messages.length === 0 && !input.trim())}
+          title={readyToGenerate ? undefined : notReadyTitle}
         >
           Generate
         </Button>
@@ -290,7 +307,11 @@ export function ChatPanel({
             onCompare(msg);
           }}
           disabled={busy || (messages.length === 0 && !input.trim())}
-          title={`Generate with all models (current: ${activeGenerator})`}
+          title={
+            readyToGenerate
+              ? `Generate with all models (current: ${activeGenerator})`
+              : notReadyTitle
+          }
         >
           Compare
         </Button>

--- a/src/app/design/page.tsx
+++ b/src/app/design/page.tsx
@@ -48,9 +48,13 @@ function DesignPageInner() {
   const [publishImageId, setPublishImageId] = useState<string | null>(null);
   const [drawerOpen, setDrawerOpen] = useState(false);
   const [activeGenerator, setActiveGenerator] = useState("ideogram");
+  // Soft nudge: Generate/Compare dim until Claude judges the idea concrete
+  // (subject + style). A design with existing renders starts ready.
+  const [readyToGenerate, setReadyToGenerate] = useState(false);
 
   const refreshGallery = useCallback(async () => {
     const { sources, productGroups } = await getDesignGallery(designId.current);
+    setReadyToGenerate(sources.length > 0);
     setImages(
       sources.map((s, i) => ({
         id: s.id,
@@ -102,6 +106,7 @@ function DesignPageInner() {
         ...prev,
         makeOptimisticMessage("assistant", result.message),
       ]);
+      setReadyToGenerate(result.readyToGenerate);
     } catch {
       setMessages((prev) => [
         ...prev,
@@ -124,6 +129,7 @@ function DesignPageInner() {
         ...prev,
         makeOptimisticMessage("assistant", result.message, result.imageId),
       ]);
+      setReadyToGenerate(result.readyToGenerate);
       // Claude may answer with a clarifying question instead of an image
       // (no imageUrl) — just show the message, no gallery/drawer changes.
       if (result.imageUrl) {
@@ -150,11 +156,12 @@ function DesignPageInner() {
       setMessages((prev) => [...prev, makeOptimisticMessage("user", userMessage)]);
     }
     try {
-      const { message, images: compared } = await compareGenerators(designId.current, userMessage);
+      const { message, images: compared, readyToGenerate: ready } = await compareGenerators(designId.current, userMessage);
       setMessages((prev) => [
         ...prev,
         makeOptimisticMessage("assistant", message),
       ]);
+      setReadyToGenerate(ready);
       // Empty when Claude asked a clarifying question instead of comparing.
       if (compared.length) {
         await refreshGallery();
@@ -286,6 +293,7 @@ function DesignPageInner() {
           onGenerate={handleGenerate}
           onCompare={handleCompare}
           activeGenerator={activeGenerator}
+          readyToGenerate={readyToGenerate}
           onUploadImage={handleUploadImage}
         />
         <ImageGallery

--- a/src/lib/__tests__/ai.test.ts
+++ b/src/lib/__tests__/ai.test.ts
@@ -77,6 +77,178 @@ describe("chatAboutDesign", () => {
     const userMessages = call.messages.filter((m: any) => m.role === "user");
     expect(userMessages.length).toBeGreaterThanOrEqual(1);
   });
+
+  it("parses message and readyToGenerate from valid JSON", async () => {
+    const mockCreate = await getMockCreate();
+    mockCreate.mockResolvedValue({
+      content: [{
+        type: "text",
+        text: JSON.stringify({
+          message: "Watercolor fox, got it. Ready when you are.",
+          readyToGenerate: true,
+        }),
+      }],
+    });
+
+    const { chatAboutDesign } = await import("../ai");
+    const result = await chatAboutDesign("a watercolor fox", [], []);
+
+    expect(result.message).toBe("Watercolor fox, got it. Ready when you are.");
+    expect(result.readyToGenerate).toBe(true);
+  });
+
+  it("returns readyToGenerate false when the idea is still thin", async () => {
+    const mockCreate = await getMockCreate();
+    mockCreate.mockResolvedValue({
+      content: [{
+        type: "text",
+        text: JSON.stringify({
+          message: "What style are you after — clean vector, watercolor, vintage?",
+          readyToGenerate: false,
+        }),
+      }],
+    });
+
+    const { chatAboutDesign } = await import("../ai");
+    const result = await chatAboutDesign("a fox", [], []);
+
+    expect(result.message).toContain("What style");
+    expect(result.readyToGenerate).toBe(false);
+  });
+
+  it("parses JSON wrapped in code fences", async () => {
+    const mockCreate = await getMockCreate();
+    mockCreate.mockResolvedValue({
+      content: [{
+        type: "text",
+        text: '```json\n{"message":"ready","readyToGenerate":true}\n```',
+      }],
+    });
+
+    const { chatAboutDesign } = await import("../ai");
+    const result = await chatAboutDesign("anything", [], []);
+
+    expect(result.message).toBe("ready");
+    expect(result.readyToGenerate).toBe(true);
+  });
+
+  it("falls back to raw text and not-ready on non-JSON response", async () => {
+    const mockCreate = await getMockCreate();
+    mockCreate.mockResolvedValue({
+      content: [{ type: "text", text: "Just plain conversational text." }],
+    });
+
+    const { chatAboutDesign } = await import("../ai");
+    const result = await chatAboutDesign("anything", [], []);
+
+    expect(result.message).toBe("Just plain conversational text.");
+    expect(result.readyToGenerate).toBe(false);
+  });
+
+  it("treats a non-boolean readyToGenerate as false", async () => {
+    const mockCreate = await getMockCreate();
+    mockCreate.mockResolvedValue({
+      content: [{
+        type: "text",
+        text: JSON.stringify({ message: "hmm", readyToGenerate: "yes" }),
+      }],
+    });
+
+    const { chatAboutDesign } = await import("../ai");
+    const result = await chatAboutDesign("anything", [], []);
+
+    expect(result.readyToGenerate).toBe(false);
+  });
+});
+
+describe("assessReadiness", () => {
+  beforeEach(async () => {
+    const mockCreate = await getMockCreate();
+    mockCreate.mockReset();
+  });
+
+  it("returns ready=false and a question when the idea is thin", async () => {
+    const mockCreate = await getMockCreate();
+    mockCreate.mockResolvedValue({
+      content: [{
+        type: "text",
+        text: JSON.stringify({
+          ready: false,
+          question: "What style — watercolor, vintage, bold vector?",
+        }),
+      }],
+    });
+
+    const { assessReadiness } = await import("../ai");
+    const result = await assessReadiness([], [], "a fox");
+
+    expect(result.ready).toBe(false);
+    expect(result.question).toContain("What style");
+  });
+
+  it("returns ready=true for a concrete subject + style", async () => {
+    const mockCreate = await getMockCreate();
+    mockCreate.mockResolvedValue({
+      content: [{ type: "text", text: JSON.stringify({ ready: true, question: "" }) }],
+    });
+
+    const { assessReadiness } = await import("../ai");
+    const result = await assessReadiness(
+      [],
+      [],
+      "a fierce minimal geometric fox, clean black vector on white"
+    );
+
+    expect(result.ready).toBe(true);
+  });
+
+  it("uses the fast Haiku model, not Sonnet", async () => {
+    const mockCreate = await getMockCreate();
+    mockCreate.mockResolvedValue({
+      content: [{ type: "text", text: JSON.stringify({ ready: true, question: "" }) }],
+    });
+
+    const { assessReadiness } = await import("../ai");
+    await assessReadiness([], [], "anything");
+
+    const call = mockCreate.mock.calls[0][0];
+    expect(call.model).toContain("haiku");
+  });
+
+  it("fails open (ready=true) on a non-JSON response", async () => {
+    const mockCreate = await getMockCreate();
+    mockCreate.mockResolvedValue({
+      content: [{ type: "text", text: "not json at all" }],
+    });
+
+    const { assessReadiness } = await import("../ai");
+    const result = await assessReadiness([], [], "anything");
+
+    expect(result.ready).toBe(true);
+  });
+
+  it("treats a missing ready flag as ready (fail open)", async () => {
+    const mockCreate = await getMockCreate();
+    mockCreate.mockResolvedValue({
+      content: [{ type: "text", text: JSON.stringify({ question: "hmm" }) }],
+    });
+
+    const { assessReadiness } = await import("../ai");
+    const result = await assessReadiness([], [], "anything");
+
+    expect(result.ready).toBe(true);
+  });
+
+  it("fails open (ready=true) when the API call throws", async () => {
+    const mockCreate = await getMockCreate();
+    mockCreate.mockRejectedValue(new Error("Haiku unavailable"));
+
+    const { assessReadiness } = await import("../ai");
+    const result = await assessReadiness([], [], "anything");
+
+    expect(result.ready).toBe(true);
+    expect(result.question).toBe("");
+  });
 });
 
 describe("generateOrderName", () => {

--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -12,7 +12,17 @@ function buildImageGalleryContext(images: DesignImage[]): string {
 
 const CHAT_SYSTEM_PROMPT = `You are a t-shirt design advisor for PRNTD. Help users refine their design ideas through conversation. You do NOT generate images — the user clicks "Generate" when ready.
 
-Style rules for your responses:
+Output format — respond with raw JSON only (no markdown fences around the JSON itself):
+{
+  "message": "Your conversational reply (this is the field the user reads; it may contain markdown — see style rules below)",
+  "readyToGenerate": true | false
+}
+
+Readiness rubric for "readyToGenerate":
+- Set true ONLY when the conversation has pinned down BOTH a concrete subject (the WHAT — what's depicted) AND a concrete visual style/medium (the HOW — e.g. clean vector, watercolor, vintage screen-print, hand-drawn ink). A subject with no style is NOT ready — that is the case that produces a clarifying question instead of an image.
+- Otherwise set false, and make "message" the question or nudge that moves toward whichever of subject/style is still missing.
+
+Style rules for the "message" field:
 - Be terse and professional. 2-4 short sentences max, then options if relevant.
 - When suggesting directions, ALWAYS number them for easy reference:
   1. Option one
@@ -31,7 +41,7 @@ The image model is text-to-image. It does not subtract — telling it "no X" ten
 - "less busy" → "open composition, clear focal point, generous negative space"
 Acknowledge the user's request in their words ("Got it — closed mouth, no tongue"), but think in affirmative visual targets. Carry the affirmative target forward when reasoning about follow-ups.
 
-CRITICAL: NEVER return JSON, code blocks, or structured data.
+CRITICAL: The "message" field is conversational prose for the user — never put JSON, code blocks, or structured data INSIDE "message". The only JSON is the outer envelope described in Output format.
 
 What the UI actually offers (do NOT invent other features):
 - A chat box (this conversation).
@@ -147,7 +157,7 @@ export async function chatAboutDesign(
   userMessage: string,
   chatHistory: ChatMessage[],
   images: DesignImage[]
-): Promise<{ message: string }> {
+): Promise<{ message: string; readyToGenerate: boolean }> {
   const { messages, galleryContext } = buildMessages(
     chatHistory,
     images,
@@ -161,9 +171,75 @@ export async function chatAboutDesign(
     messages,
   });
 
-  const text =
+  let text =
     response.content[0].type === "text" ? response.content[0].text : "";
-  return { message: text };
+
+  // Strip markdown code fences if present, then parse the JSON envelope.
+  // Parse failure (or a non-boolean flag) degrades safely: show the raw
+  // text and leave the Generate button greyed (readyToGenerate=false).
+  text = text.replace(/^```(?:json)?\s*\n?/m, "").replace(/\n?```\s*$/m, "").trim();
+
+  try {
+    const parsed = JSON.parse(text);
+    return {
+      message: typeof parsed.message === "string" ? parsed.message : text,
+      readyToGenerate: parsed.readyToGenerate === true,
+    };
+  } catch {
+    return { message: text, readyToGenerate: false };
+  }
+}
+
+const READINESS_SYSTEM_PROMPT = `You judge whether a t-shirt design idea is concrete enough to generate an image. Reply with raw JSON only (no markdown fences):
+{ "ready": true | false, "question": "if not ready, ONE short question asking for whichever of subject or style is missing; empty string if ready" }
+
+Ready ONLY when BOTH are clear:
+- SUBJECT — what is depicted.
+- STYLE/medium — e.g. clean vector, watercolor, vintage screen-print, hand-drawn ink, bold graphic.
+A clear subject with no style is NOT ready: set ready=false and ask for the style (you may offer 3-5 style examples). Keep "question" to 1-2 sentences. When genuinely uncertain, lean ready=true — a real idea should never be blocked.`;
+
+/**
+ * Fast pre-check used by Generate/Compare to decide "render vs ask" without
+ * paying the heavy constructFluxPrompt round-trip. Runs on Haiku with a tiny
+ * prompt (~1s) instead of Sonnet + a 45-line system prompt + 1024 tokens
+ * (~6s). Fails OPEN: any parse problem or a missing flag resolves to
+ * ready=true so a concrete prompt is never blocked by a hiccup —
+ * constructFluxPrompt's own clarification guard remains the backstop.
+ */
+export async function assessReadiness(
+  chatHistory: ChatMessage[],
+  images: DesignImage[],
+  userMessage?: string
+): Promise<{ ready: boolean; question: string }> {
+  const { messages, galleryContext } = buildMessages(
+    chatHistory,
+    images,
+    userMessage
+  );
+
+  try {
+    const response = await anthropic.messages.create({
+      model: "claude-haiku-4-5-20251001",
+      max_tokens: 256,
+      system: READINESS_SYSTEM_PROMPT + galleryContext,
+      messages,
+    });
+
+    let text =
+      response.content?.[0]?.type === "text" ? response.content[0].text : "";
+    text = text.replace(/^```(?:json)?\s*\n?/m, "").replace(/\n?```\s*$/m, "").trim();
+
+    const parsed = JSON.parse(text);
+    return {
+      ready: parsed.ready !== false,
+      question: typeof parsed.question === "string" ? parsed.question : "",
+    };
+  } catch (err) {
+    // Fail open: a parse problem, outage, or model error must never block a
+    // real idea. constructFluxPrompt's own guard remains the backstop.
+    console.error("assessReadiness failed, treating as ready:", err);
+    return { ready: true, question: "" };
+  }
 }
 
 const NAME_SYSTEM_PROMPT = `You name t-shirt designs for an order management system. Look at the image and respond with 2–4 words that identify it at a glance.


### PR DESCRIPTION
## What

**Readiness gate (soft nudge).** `chatAboutDesign` returns `{ message, readyToGenerate }` via a JSON envelope (subject+style rubric, safe-parse fallback). `generateDesign`/`compareGenerators` return the flag; `page.tsx` threads it to `chat-panel`, where Generate renders as a secondary button that **pops to primary when ready**, with a style hint — always clickable, never greyed-into-looking-broken.

**Fast thin-check (`assessReadiness`, Haiku ~1s).** Generate/Compare now bail to a clarifying question in ~1s instead of paying the ~6s Sonnet prompt-builder just to discover the idea is too thin. **Fails open** on any error (parse/outage/model) — `constructFluxPrompt`'s existing guard stays as backstop. Happy path unchanged (the ~1s Haiku is nothing next to a ~20s render).

## Verified

- 238 tests (incl. 6 for `assessReadiness`: thin/ready/code-fence/non-JSON/missing-flag/API-error fail-open), lint clean, `npm run build` compiles.
- Local smoke: thin "a fox" + Generate returned the style question in ~1–2s (was ~6s).

## Notes

- Additive and fail-open — default Generate/Compare behavior is preserved; a Haiku hiccup degrades to the prior (slow-but-correct) path.
- Also lands the spec for the `/design` empty-state redesign (centered composer, delayed suggestions, "Drawing your design…" message) — approved, **not yet implemented**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)