### PR TITLE
fix: honest + correct Compare counts (#19)

### DIFF
--- a/src/app/design/actions.ts
+++ b/src/app/design/actions.ts
@@ -29,6 +29,7 @@ import {
 import { prefetchProductMockups } from "@/app/preview/actions";
 import { DEFAULT_PRODUCT_ID } from "@/lib/products";
 import { imageReferencedByOrders } from "@/lib/design-publish";
+import { compareSummary, dedupeById } from "@/lib/compare";
 import type { ChatMessage } from "@/lib/db/schema";
 
 async function getOrCreateDesign(designId: string, userId: string) {
@@ -402,7 +403,10 @@ export async function getDesignGallery(
     getDesignSourceImages(designId),
     getDesignPlacementRenders(designId),
   ]);
-  return { sources, productGroups };
+  // Guard against a duplicate row ever reaching the gallery — the header
+  // count and the mobile FAB badge both derive from this list, so a dupe
+  // would make them disagree (#19).
+  return { sources: dedupeById(sources), productGroups };
 }
 
 export async function approveDesign(designId: string) {
@@ -497,7 +501,13 @@ export async function compareGenerators(designId: string, userMessage?: string) 
   const ok = results.filter((r): r is NonNullable<typeof r> => r !== null);
   if (ok.length === 0) throw new Error("All generators failed");
 
-  const summary = `Compared ${ok.length} generators — tap one to keep working with it.`;
+  // Summarize honestly: name the styles that didn't come back rather than
+  // silently undercounting (#19 — "Compared 1 generators"). results is
+  // index-aligned with the generators we ran.
+  const gens = Object.values(GENERATORS);
+  const succeeded = gens.filter((_, i) => results[i] !== null).map((g) => g.label);
+  const failed = gens.filter((_, i) => results[i] === null).map((g) => g.label);
+  const summary = compareSummary(succeeded, failed);
   if (userMessage) {
     await insertChatMessage({ designId, role: "user", content: userMessage });
   }

--- a/src/lib/__tests__/compare.test.ts
+++ b/src/lib/__tests__/compare.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from "vitest";
+import { compareSummary, dedupeById } from "@/lib/compare";
+
+describe("compareSummary", () => {
+  it("reports a clean two-style compare with plural grammar", () => {
+    expect(compareSummary(["Ideogram", "Recraft"], [])).toBe(
+      "Drew 2 styles — tap one to keep working with it."
+    );
+  });
+
+  it("uses singular grammar for a single success (no '1 styles')", () => {
+    expect(compareSummary(["Ideogram"], [])).toBe(
+      "Drew 1 style — tap it to keep working with it."
+    );
+  });
+
+  it("is honest about a partial failure and names the missing style", () => {
+    // This is the #19 case: one generator failed silently, the old copy said
+    // "Compared 1 generators".
+    expect(compareSummary(["Ideogram"], ["Recraft"])).toBe(
+      "Drew 1 of 2 styles — Recraft didn't return an image. Tap it to keep working with it."
+    );
+  });
+
+  it("names multiple failures with an oxford-comma list and plural verb", () => {
+    expect(compareSummary(["Ideogram"], ["Recraft", "Flux"])).toBe(
+      "Drew 1 of 3 styles — Recraft and Flux didn't return images. Tap it to keep working with it."
+    );
+  });
+
+  it("keeps 'tap one' when more than one succeeded alongside a failure", () => {
+    expect(compareSummary(["Ideogram", "Recraft"], ["Flux"])).toBe(
+      "Drew 2 of 3 styles — Flux didn't return an image. Tap one to keep working with it."
+    );
+  });
+
+  it("formats a three-name failure list with an oxford comma", () => {
+    expect(compareSummary(["Ideogram"], ["A", "B", "C"])).toBe(
+      "Drew 1 of 4 styles — A, B, and C didn't return images. Tap it to keep working with it."
+    );
+  });
+
+  it("falls back to a retry nudge when nothing succeeded", () => {
+    expect(compareSummary([], ["Ideogram", "Recraft"])).toBe(
+      "No styles came back — try again?"
+    );
+  });
+});
+
+describe("dedupeById", () => {
+  it("returns the list unchanged when ids are unique", () => {
+    const items = [{ id: "a" }, { id: "b" }, { id: "c" }];
+    expect(dedupeById(items)).toEqual(items);
+  });
+
+  it("drops later items that repeat an id, keeping the first and order", () => {
+    const a1 = { id: "a", n: 1 };
+    const b = { id: "b", n: 2 };
+    const a2 = { id: "a", n: 3 };
+    expect(dedupeById([a1, b, a2])).toEqual([a1, b]);
+  });
+
+  it("handles an empty list", () => {
+    expect(dedupeById([])).toEqual([]);
+  });
+});

--- a/src/lib/compare.ts
+++ b/src/lib/compare.ts
@@ -1,0 +1,68 @@
+/**
+ * Pure helpers for the multi-generator Compare flow on /design.
+ *
+ * Compare runs the same prompt through every registered generator. Some may
+ * fail (rate limit, model error) while others succeed, so the chat summary
+ * has to count honestly and read grammatically — "Compared 1 generators" was
+ * the bug (#19). Kept pure and separate from the server action so the wording
+ * and the gallery de-dup are unit-testable without API keys.
+ */
+
+/** "A" | "A and B" | "A, B, and C" */
+function formatList(items: string[]): string {
+  if (items.length === 0) return "";
+  if (items.length === 1) return items[0];
+  if (items.length === 2) return `${items[0]} and ${items[1]}`;
+  return `${items.slice(0, -1).join(", ")}, and ${items[items.length - 1]}`;
+}
+
+/**
+ * Build the chat summary for a Compare run from the generator labels that
+ * succeeded and those that failed. Reports partial failure plainly and names
+ * which styles didn't come back. Wording uses "styles" to match the
+ * "Compare styles" button label.
+ *
+ * `succeeded` and `failed` are display labels (e.g. "Ideogram", "Recraft").
+ */
+export function compareSummary(succeeded: string[], failed: string[]): string {
+  const total = succeeded.length + failed.length;
+
+  // The caller throws before summarizing when nothing succeeds; this branch
+  // keeps the helper total in case it's reused elsewhere.
+  if (succeeded.length === 0) {
+    return "No styles came back — try again?";
+  }
+
+  const drew =
+    succeeded.length === 1 ? "Drew 1 style" : `Drew ${succeeded.length} styles`;
+  // Lowercase form follows the em-dash; capitalized form starts a new
+  // sentence after the partial-failure note.
+  const tap =
+    succeeded.length === 1
+      ? "tap it to keep working with it."
+      : "tap one to keep working with it.";
+
+  if (failed.length === 0) {
+    return `${drew} — ${tap}`;
+  }
+
+  const verb = failed.length === 1 ? "didn't return an image" : "didn't return images";
+  const Tap = tap.charAt(0).toUpperCase() + tap.slice(1);
+  return `Drew ${succeeded.length} of ${total} styles — ${formatList(failed)} ${verb}. ${Tap}`;
+}
+
+/**
+ * Drop any item whose id has already been seen, preserving order. A guard so
+ * a duplicate design_image row can never surface twice in the gallery (and so
+ * the gallery count the header and mobile badge both read stays correct).
+ * Today the source query returns each row once; this keeps it that way if a
+ * future join ever fans out.
+ */
+export function dedupeById<T extends { id: string }>(items: T[]): T[] {
+  const seen = new Set<string>();
+  return items.filter((item) => {
+    if (seen.has(item.id)) return false;
+    seen.add(item.id);
+    return true;
+  });
+}


### PR DESCRIPTION
Closes #19.

The multi-generator **Compare** flow miscounted and miscommunicated its results. This lands the deterministic fixes + unit tests. **Live Compare verification is left to a human** — the cloud session has no `ANTHROPIC` / `REPLICATE` / `IDEOGRAM` keys, so it can't fire a real Compare to reproduce.

## Static-analysis findings

1. **Ungrammatical / dishonest summary (real bug, fixed).** `compareGenerators` built `Compared ${ok.length} generators — …`, so when one generator failed silently (caught + logged as `compareGenerators <id> failed:`) it read "Compared **1 generators**" with no hint that the other failed. The count was technically right (successes) but misleading.

2. **"Duplicate Ideogram images" = data artifact, not a happy-path code bug.** Each generator inserts exactly one `design_image` per run, each with a distinct uuid and a distinct R2 key (`{generationCount+1+i}.png`). The "4 copies of the raccoon" in the smoke test were *distinct rows* accumulated across repeated Compare clicks while Recraft was 422'ing — every run persisted its Ideogram render. With the Recraft style fix already on main, a clean Compare adds one row per generator. There's no remaining duplicate-*insertion* in the happy path, so the fix here is honest reporting + a defensive de-dup guard rather than removing a phantom insert. **Needs live confirmation** (see checklist).

3. **Badge (3) vs header (2) can't diverge in code.** The mobile FAB badge (`page.tsx`) and the "Generations (N)" header (`image-gallery.tsx`) both read `images.length` from the *same* `images` state. They cannot disagree within a render; the observed mismatch reflected the duplicate-row data state at different refresh moments. The de-dup guard keeps the shared source clean.

## Changes

- **`src/lib/compare.ts` (new, pure + unit-tested):**
  - `compareSummary(succeeded, failed)` — pluralizes correctly and names the styles that didn't come back: `"Drew 2 styles — tap one to keep working with it."` / `"Drew 1 of 2 styles — Recraft didn't return an image. Tap it to keep working with it."` Wording uses **"styles"** to match the new **Compare styles** button label.
  - `dedupeById(items)` — order-preserving guard so a duplicate row can never surface twice in the gallery (and the header count + mobile badge stay in agreement).
- **`src/app/design/actions.ts`:**
  - `compareGenerators` now derives succeeded/failed generator **labels** (index-aligned with `results`) and builds the summary via `compareSummary`.
  - `getDesignGallery` wraps its `sources` in `dedupeById`.
- **`src/lib/__tests__/compare.test.ts`** — 10 tests covering singular/plural, partial failure, oxford-comma failure lists, and de-dup ordering.

## On the "generator fails in Compare but succeeds in single Generate" question
Static read: both paths call the same adapter with the same prompt/aspect; the only structural difference is Compare runs the adapters in `Promise.all` (parallel), so a per-account **rate limit** is the most plausible transient cause of one leg failing. Nothing deterministic to fix in code — so this PR makes the summary honest about partial failure instead of pretending it didn't happen. Confirm against real logs if it recurs.

## Gate (cloud)
- `npm run lint` — 0 errors (18 pre-existing warnings)
- `npm test` — 252 passed (incl. 10 new `compare` tests)
- `npm run build` — compiles + type-checks + static-generates clean

## Verify locally (needs API keys — left to human)
- [ ] Run a **clean Compare** (both generators succeeding) → exactly **one Ideogram + one Recraft** added, tagged; no duplicate Ideogram rows.
- [ ] Confirm the chat summary reads **"Drew 2 styles — tap one to keep working with it."**
- [ ] Force a partial failure (e.g. one generator erroring) → summary names the missing style, e.g. **"Drew 1 of 2 styles — Recraft didn't return an image. Tap it to keep working with it."**
- [ ] Mobile: the FAB badge count matches the "Generations (N)" header after a Compare.

https://claude.ai/code/session_01AbrLddrjPBRs2sSe5fGu1u

---
_Generated by [Claude Code](https://claude.ai/code/session_01AbrLddrjPBRs2sSe5fGu1u)_