### PR TITLE
Playwright E2E in CI (cicd Phase 3)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,3 +48,44 @@ jobs:
           R2_SECRET_ACCESS_KEY: ci-skip
           R2_BUCKET_NAME: ci-skip
           ADMIN_EMAIL: ci-skip@example.com
+
+  # Browser E2E against the Vercel preview deploy (CI/CD roadmap Phase 3).
+  # Not a required check yet — let the suite prove itself stable first
+  # (Phase 4 gates it). Needs three repo secrets:
+  #   VERCEL_AUTOMATION_BYPASS_SECRET — Deployment Protection bypass token
+  #   PREVIEW_DATABASE_URL / PREVIEW_DATABASE_AUTH_TOKEN — prntd-preview Turso
+  e2e:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - run: npm ci
+
+      - name: Wait for Vercel preview deploy
+        id: preview
+        uses: patrickedqvist/wait-for-vercel-preview@v1.3.2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          max_timeout: 600
+
+      - run: npx playwright install --with-deps chromium
+
+      - run: npx playwright test
+        env:
+          E2E_BASE_URL: ${{ steps.preview.outputs.url }}
+          VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
+          DATABASE_URL: ${{ secrets.PREVIEW_DATABASE_URL }}
+          DATABASE_AUTH_TOKEN: ${{ secrets.PREVIEW_DATABASE_AUTH_TOKEN }}
+
+      - uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: playwright-report
+          path: playwright-report
+          retention-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,12 +67,37 @@ jobs:
 
       - run: npm ci
 
+      # Find the preview URL via the GitHub deployments API, then poll it
+      # ready WITH the Deployment Protection bypass header (the off-the-shelf
+      # wait actions probe without it and 401 forever).
       - name: Wait for Vercel preview deploy
         id: preview
-        uses: patrickedqvist/wait-for-vercel-preview@v1.3.2
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          max_timeout: 600
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BYPASS: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
+          SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          for i in $(seq 1 60); do
+            url=$(gh api "repos/${{ github.repository }}/deployments?sha=$SHA&environment=Preview" \
+              --jq '.[0].id' 2>/dev/null | xargs -I{} gh api \
+              "repos/${{ github.repository }}/deployments/{}/statuses" \
+              --jq '[.[] | select(.state=="success")][0].environment_url' 2>/dev/null)
+            [ -n "$url" ] && [ "$url" != "null" ] && break
+            echo "waiting for preview deployment ($i)…"; sleep 10
+          done
+          if [ -z "$url" ] || [ "$url" = "null" ]; then
+            echo "no successful Preview deployment found for $SHA" >&2; exit 1
+          fi
+          echo "preview: $url"
+          for i in $(seq 1 30); do
+            code=$(curl -s -o /dev/null -w "%{http_code}" \
+              -H "x-vercel-protection-bypass: $BYPASS" "$url")
+            echo "GET $code ($i)"
+            [ "$code" = "200" ] && break
+            sleep 5
+          done
+          [ "$code" = "200" ] || { echo "preview never returned 200" >&2; exit 1; }
+          echo "url=$url" >> "$GITHUB_OUTPUT"
 
       - run: npx playwright install --with-deps chromium
 

--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,7 @@ ci-skip.db
 
 # Claude Code local settings + runtime files
 .claude/
+
+# Playwright E2E artifacts
+/test-results/
+/playwright-report/

--- a/docs/cicd-roadmap.md
+++ b/docs/cicd-roadmap.md
@@ -9,11 +9,12 @@ gated on all-green before it can reach prod.
 - **CI** (`.github/workflows/ci.yml`): lint → typecheck → test+coverage → build,
   on every PR + push to main. Solid baseline. Coverage measured, not gated.
 - **Vercel**: preview deploy per PR; prod on merge to main.
-- **DB isolation**: `prntd-dev` Turso branch for local dev (#27); prod separate.
-  Preview deploys currently point at **prod** Turso (risk) and miss Preview-scope
-  API keys (ANTHROPIC/REPLICATE Production-only → `/design` 500s on preview).
-- **Tests**: unit + real-DB integration (in-memory libSQL from live schema).
-  No automated browser E2E — done by hand via Playwright today.
+- **DB isolation**: `prntd-dev` Turso branch for local dev (#27); Preview +
+  Development deploys on an isolated `prntd-preview` branch; only Production
+  touches prod. Preview-scope API keys fixed (Phase 1 done 2026-06-09).
+- **Tests**: unit + real-DB integration (in-memory libSQL from live schema),
+  plus Playwright E2E in `e2e/` (guest funnel + cart, mobile-first projects)
+  run locally via `npm run e2e` and in CI against the PR's preview deploy.
 - **Flags**: `MULTI_PLACEMENT_ENABLED`, `GUEST_FUNNEL_ENABLED`, `CART_ENABLED` —
   env-gated rollout, the right primitive for ship-dark-then-flip.
 
@@ -49,13 +50,22 @@ merge to main
 - A reset helper to truncate transient tables (cart_item, generation_usage,
   test-classified orders) between runs.
 
-### Phase 3 — E2E in CI (code + infra)
-- Add `@playwright/test`; port today's hand-run flows (guest funnel claim, cart
-  → bundled shipping → checkout gate) into `e2e/`.
-- Run E2E against the Vercel preview URL in a `e2e` GitHub job (after deploy),
-  or against `next build && next start` with a seeded ephemeral DB.
-- Per-PR ephemeral Turso branch: `turso db create prntd-pr-<n> --from-db prntd-dev`,
-  seed, run, destroy. Keeps E2E hermetic.
+### Phase 3 — E2E in CI (code + infra) — landed 2026-06-09
+- ✅ `@playwright/test` + `e2e/` suite: guest funnel (anon session, open
+  funnel, gated personal routes) and cart (two items, bundled-shipping
+  invariant, sign-in gate at checkout). Specs seed designs owned by the
+  browser's anonymous user directly in the dev/preview DB
+  (`e2e/helpers/db.ts`, same never-prod guard as the seed script) and clean
+  up after themselves. Two projects: mobile (Pixel 7, primary) + desktop.
+- ✅ `e2e` job in ci.yml: waits for the Vercel preview deploy, runs Playwright
+  against it with the Deployment Protection bypass header. PR-only — note a
+  direct push to main never triggers it. Secrets: `VERCEL_AUTOMATION_BYPASS_SECRET`,
+  `PREVIEW_DATABASE_URL`, `PREVIEW_DATABASE_AUTH_TOKEN` (set 2026-06-09).
+- ✅ `GUEST_FUNNEL_ENABLED`/`CART_ENABLED` added to Vercel Preview scope.
+- Local run: `npm run e2e` (boots `next dev -p 3100` with flags on, dev DB).
+- Still open: per-PR ephemeral Turso branch (`turso db create prntd-pr-<n>
+  --from-db prntd-dev`, seed, run, destroy) — today all PRs share
+  `prntd-preview`; fine while PR volume is one-at-a-time.
 
 ### Phase 4 — gates + ratchet
 - Coverage threshold in `vitest.config` (start at the current baseline, ratchet

--- a/e2e/cart.spec.ts
+++ b/e2e/cart.spec.ts
@@ -1,0 +1,70 @@
+/**
+ * Multi-item cart (#26 Stage B), as a guest: seed two designs owned by the
+ * browser's anonymous user, add both to the cart from /order, check the
+ * bundled-shipping invariant (charged once per order, flat across items), and
+ * hit the purchase gate (guests are sent to sign-in at checkout).
+ */
+import { test, expect, type Page } from "@playwright/test";
+import {
+  userIdForSessionCookie,
+  seedDesign,
+  cleanupDesigns,
+} from "./helpers/db";
+import { waitForSessionCookie } from "./helpers/session";
+
+const PRODUCT = "bella-canvas-3001";
+
+async function shippingAmount(page: Page): Promise<number> {
+  const row = page.getByText("Shipping (bundled)").locator("..");
+  const text = await row.innerText();
+  const match = text.match(/\$(\d+\.\d{2})/);
+  expect(match, `no $ amount in shipping row: ${text}`).toBeTruthy();
+  return Number(match![1]);
+}
+
+async function addToCartFromOrderPage(page: Page, designId: string) {
+  await page.goto(
+    `/order?id=${designId}&product=${PRODUCT}&color=Black&size=M`
+  );
+  // Pricing loads via a server action; the button is live before that, so
+  // wait for the total row to know the page is fully wired.
+  await expect(page.getByText("Total")).toBeVisible({ timeout: 30_000 });
+  await page.getByRole("button", { name: "Add to cart" }).click();
+  await page.waitForURL(/\/cart/);
+}
+
+test("guest cart: two items, bundled shipping, sign-in gate at checkout", async ({
+  page
+}, testInfo) => {
+  // Unique per run + project so parallel/mobile+desktop runs don't collide.
+  const key = `${Date.now()}-${testInfo.project.name}`;
+  const seeded: string[] = [];
+
+  try {
+    // Mint the anonymous session, then seed designs it owns (designs are
+    // owner-scoped; a guest can only order its own).
+    await page.goto("/design");
+    const cookie = await waitForSessionCookie(page);
+    const userId = await userIdForSessionCookie(cookie);
+    seeded.push(await seedDesign(userId, `${key}-a`));
+    seeded.push(await seedDesign(userId, `${key}-b`));
+
+    // First item.
+    await addToCartFromOrderPage(page, seeded[0]);
+    await expect(page.locator("ul > li")).toHaveCount(1, { timeout: 30_000 });
+    const oneItemShipping = await shippingAmount(page);
+
+    // Second item — bundled shipping must not scale with item count.
+    await addToCartFromOrderPage(page, seeded[1]);
+    await expect(page.locator("ul > li")).toHaveCount(2, { timeout: 30_000 });
+    const twoItemShipping = await shippingAmount(page);
+    expect(twoItemShipping).toBe(oneItemShipping);
+
+    // Purchase gate: a guest checking out is sent to sign-in, not Stripe.
+    await page.getByRole("button", { name: /^Checkout/ }).click();
+    await page.waitForURL(/\/sign-in/);
+    expect(page.url()).toContain("next=");
+  } finally {
+    await cleanupDesigns(seeded);
+  }
+});

--- a/e2e/guest-funnel.spec.ts
+++ b/e2e/guest-funnel.spec.ts
@@ -1,0 +1,30 @@
+/**
+ * Guest funnel (#26 Stage A): the design → preview → order surface is open to
+ * signed-out visitors, who get an anonymous Better-Auth session; personal
+ * record routes stay behind sign-in.
+ */
+import { test, expect } from "@playwright/test";
+import { waitForSessionCookie } from "./helpers/session";
+
+test("/design loads for a signed-out visitor", async ({ page }) => {
+  await page.goto("/design");
+  await expect(page).not.toHaveURL(/sign-in/);
+  // Empty-state hero composer is the whole page when there's no content.
+  await expect(
+    page.getByPlaceholder(/Describe your design/).first()
+  ).toBeVisible();
+});
+
+test("a guest on /design gets an anonymous session", async ({ page }) => {
+  await page.goto("/design");
+  await waitForSessionCookie(page);
+});
+
+test("personal routes still redirect signed-out visitors to sign-in", async ({
+  page,
+}) => {
+  await page.goto("/designs");
+  await expect(page).toHaveURL(/sign-in/);
+  await page.goto("/orders");
+  await expect(page).toHaveURL(/sign-in/);
+});

--- a/e2e/helpers/db.ts
+++ b/e2e/helpers/db.ts
@@ -1,0 +1,87 @@
+/**
+ * Direct DB access for E2E tests, against the same dev/preview Turso the app
+ * under test uses. Lets a spec seed a design owned by the anonymous user the
+ * browser just minted (designs are owner-scoped, so a guest can only order
+ * its own), and clean up after itself.
+ */
+import { createClient, type Client } from "@libsql/client";
+
+let cached: Client | null = null;
+
+function db(): Client {
+  if (cached) return cached;
+  const url = process.env.DATABASE_URL ?? "";
+  if (!url) {
+    throw new Error("DATABASE_URL not set — e2e needs the dev/preview DB");
+  }
+  // Same guard as scripts/seed-dev-db.ts: never touch prod.
+  const isSafe =
+    url.startsWith("file:") ||
+    url.includes("prntd-dev") ||
+    url.includes("prntd-preview");
+  if (!isSafe) {
+    throw new Error(`Refusing to run e2e against a non-dev DB: ${url}`);
+  }
+  cached = createClient({ url, authToken: process.env.DATABASE_AUTH_TOKEN });
+  return cached;
+}
+
+/**
+ * Resolve the user id behind a Better-Auth session cookie. The cookie value
+ * is `<token>.<signature>`; the session table stores the bare token.
+ */
+export async function userIdForSessionCookie(
+  cookieValue: string
+): Promise<string> {
+  const token = decodeURIComponent(cookieValue).split(".")[0];
+  const res = await db().execute({
+    sql: "SELECT user_id FROM session WHERE token = ?",
+    args: [token],
+  });
+  const userId = res.rows[0]?.user_id;
+  if (typeof userId !== "string") {
+    throw new Error("No session row found for the browser's session cookie");
+  }
+  return userId;
+}
+
+const PLACEHOLDER_IMAGE = "https://placehold.co/1024x1024/png";
+
+/** Seed a draft design (with a primary image) owned by `userId`. */
+export async function seedDesign(userId: string, key: string): Promise<string> {
+  const designId = `e2e-${key}`;
+  const imageId = `e2e-${key}-img`;
+  const c = db();
+  await c.execute({
+    sql: `INSERT INTO design (id, user_id, status, primary_image_id, generation_count, generation_cost, created_at, updated_at)
+          VALUES (?, ?, 'draft', ?, 1, 0, unixepoch(), unixepoch())
+          ON CONFLICT(id) DO UPDATE SET user_id = excluded.user_id, primary_image_id = excluded.primary_image_id`,
+    args: [designId, userId, imageId],
+  });
+  await c.execute({
+    sql: `INSERT INTO design_image (id, design_id, aspect_ratio, image_url, is_approved, is_hidden, created_at)
+          VALUES (?, ?, '1:1', ?, 0, 0, unixepoch())
+          ON CONFLICT(id) DO UPDATE SET image_url = excluded.image_url`,
+    args: [imageId, designId, PLACEHOLDER_IMAGE],
+  });
+  return designId;
+}
+
+/** Remove everything a spec seeded (cart items first — FK to design). */
+export async function cleanupDesigns(designIds: string[]): Promise<void> {
+  if (designIds.length === 0) return;
+  const c = db();
+  const placeholders = designIds.map(() => "?").join(",");
+  await c.execute({
+    sql: `DELETE FROM cart_item WHERE design_id IN (${placeholders})`,
+    args: designIds,
+  });
+  await c.execute({
+    sql: `DELETE FROM design_image WHERE design_id IN (${placeholders})`,
+    args: designIds,
+  });
+  await c.execute({
+    sql: `DELETE FROM design WHERE id IN (${placeholders})`,
+    args: designIds,
+  });
+}

--- a/e2e/helpers/session.ts
+++ b/e2e/helpers/session.ts
@@ -1,0 +1,23 @@
+import { expect, type Page } from "@playwright/test";
+
+/**
+ * Wait for the Better-Auth session cookie the guest funnel mints client-side
+ * (ensureGuestSession) and return its value.
+ */
+export async function waitForSessionCookie(page: Page): Promise<string> {
+  let value = "";
+  await expect
+    .poll(
+      async () => {
+        const cookies = await page.context().cookies();
+        const session = cookies.find((c) =>
+          c.name.endsWith("better-auth.session_token")
+        );
+        value = session?.value ?? "";
+        return Boolean(session);
+      },
+      { timeout: 15_000 }
+    )
+    .toBe(true);
+  return value;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "stripe": "^20.4.1"
       },
       "devDependencies": {
+        "@playwright/test": "1.60.0",
         "@tailwindcss/postcss": "^4",
         "@testing-library/jest-dom": "6.9.1",
         "@testing-library/react": "16.3.2",
@@ -3593,6 +3594,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rolldown/pluginutils": {
@@ -11552,6 +11569,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "db:seed": "tsx scripts/seed-dev-db.ts",
     "test": "vitest run",
     "test:watch": "vitest",
-    "test:coverage": "vitest run --coverage"
+    "test:coverage": "vitest run --coverage",
+    "e2e": "playwright test"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.80.0",
@@ -32,6 +33,7 @@
     "stripe": "^20.4.1"
   },
   "devDependencies": {
+    "@playwright/test": "1.60.0",
     "@tailwindcss/postcss": "^4",
     "@testing-library/jest-dom": "6.9.1",
     "@testing-library/react": "16.3.2",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,53 @@
+import { config as loadEnv } from "dotenv";
+import { defineConfig, devices } from "@playwright/test";
+
+// Local runs read DB creds (for the e2e seed helper) from .env.local; CI
+// provides DATABASE_URL/DATABASE_AUTH_TOKEN as job env instead. dotenv never
+// overrides vars already set in the environment.
+loadEnv({ path: ".env.local" });
+
+// Point at a deployed URL (Vercel preview) via E2E_BASE_URL; without it,
+// Playwright starts a local dev server with the funnel flags on.
+// Local port 3100: 3000 is often held by Docker on this machine.
+const remoteURL = process.env.E2E_BASE_URL;
+const baseURL = remoteURL ?? "http://localhost:3100";
+const bypassSecret = process.env.VERCEL_AUTOMATION_BYPASS_SECRET;
+
+export default defineConfig({
+  testDir: "e2e",
+  timeout: 90_000,
+  retries: process.env.CI ? 1 : 0,
+  reporter: process.env.CI
+    ? [["list"], ["html", { open: "never" }]]
+    : [["list"]],
+  use: {
+    baseURL,
+    // Vercel Deployment Protection: the bypass header gets automation past the
+    // 401; set-bypass-cookie carries the bypass across client-side navigation.
+    extraHTTPHeaders: bypassSecret
+      ? {
+          "x-vercel-protection-bypass": bypassSecret,
+          "x-vercel-set-bypass-cookie": "true",
+        }
+      : {},
+    trace: "retain-on-failure",
+  },
+  projects: [
+    // Phone-first project: the product principle is mobile wins, so the
+    // primary E2E viewport is a phone.
+    { name: "mobile", use: { ...devices["Pixel 7"] } },
+    { name: "desktop", use: { ...devices["Desktop Chrome"] } },
+  ],
+  webServer: remoteURL
+    ? undefined
+    : {
+        command: "npm run dev -- -p 3100",
+        url: "http://localhost:3100",
+        reuseExistingServer: true,
+        timeout: 120_000,
+        env: {
+          GUEST_FUNNEL_ENABLED: "true",
+          CART_ENABLED: "true",
+        },
+      },
+});


### PR DESCRIPTION
Browser E2E suite + CI job running it against the PR's Vercel preview deploy.

- `e2e/guest-funnel.spec.ts` — funnel open to signed-out visitors, anon session minted, personal routes gated
- `e2e/cart.spec.ts` — guest cart: two seeded designs, bundled-shipping-stays-flat invariant, sign-in gate at checkout; self-cleaning
- mobile (Pixel 7) primary + desktop projects; `npm run e2e` locally
- `e2e` CI job: waits for the preview deploy, runs with the Deployment Protection bypass header; not a required check yet

This PR is itself the first live test of the job. Follow-up: per-PR ephemeral Turso branch (#31).

🤖 Generated with [Claude Code](https://claude.com/claude-code)