### PR TITLE
fix(chat): stop raw JSON envelope leaking into /design replies

### DIFF
--- a/scripts/clean-chat-envelopes.ts
+++ b/scripts/clean-chat-envelopes.ts
@@ -1,0 +1,51 @@
+/**
+ * Rewrite assistant chat_message rows that were stored with a raw JSON
+ * envelope embedded (the prose + {"message": ...} doubling seen on /design,
+ * 2026-06-09). The fixed parser stops new pollution; this cleans what's
+ * already persisted, since the chat panel renders stored content verbatim.
+ *
+ * Idempotent — rows whose content has no parseable envelope are untouched.
+ * Dry run by default; pass --apply to write.
+ *
+ *   npx tsx scripts/clean-chat-envelopes.ts          # report only
+ *   npx tsx scripts/clean-chat-envelopes.ts --apply  # rewrite rows
+ */
+import { config } from "dotenv";
+config({ path: ".env.local" });
+
+import { createClient } from "@libsql/client";
+import { extractChatEnvelope } from "../src/lib/ai";
+
+const apply = process.argv.includes("--apply");
+
+(async () => {
+  const c = createClient({
+    url: process.env.DATABASE_URL!,
+    authToken: process.env.DATABASE_AUTH_TOKEN,
+  });
+  console.log(`DB: ${process.env.DATABASE_URL}\nmode: ${apply ? "APPLY" : "dry run"}\n`);
+
+  const res = await c.execute(
+    `SELECT id, content FROM chat_message
+     WHERE role = 'assistant' AND content LIKE '%"message"%'`
+  );
+
+  let fixed = 0;
+  for (const row of res.rows) {
+    const id = row.id as string;
+    const content = row.content as string;
+    const envelope = extractChatEnvelope(content);
+    // Only rewrite when there's prose around the envelope (the doubling bug)
+    // or the row is a bare stored envelope; skip rows already clean.
+    if (!envelope || envelope.message === content) continue;
+    fixed++;
+    console.log(`${id}: ${content.length} chars → ${envelope.message.length}`);
+    if (apply) {
+      await c.execute({
+        sql: "UPDATE chat_message SET content = ? WHERE id = ?",
+        args: [envelope.message, id],
+      });
+    }
+  }
+  console.log(`\n${fixed} row(s) ${apply ? "rewritten" : "would be rewritten"} of ${res.rows.length} candidates`);
+})();

--- a/src/lib/__tests__/ai.test.ts
+++ b/src/lib/__tests__/ai.test.ts
@@ -159,6 +159,65 @@ describe("chatAboutDesign", () => {
 
     expect(result.readyToGenerate).toBe(false);
   });
+
+  it("salvages the envelope when the model emits prose followed by JSON", async () => {
+    const mockCreate = await getMockCreate();
+    const prose = "Got it — yin-yang floss dance.\n\nWhat **style**?";
+    mockCreate.mockResolvedValue({
+      content: [{
+        type: "text",
+        text: `${prose}\n\n${JSON.stringify({ message: prose, readyToGenerate: true })}`,
+      }],
+    });
+
+    const { chatAboutDesign } = await import("../ai");
+    const result = await chatAboutDesign("anything", [], []);
+
+    // The envelope's message only — never the doubled prose+JSON blob.
+    expect(result.message).toBe(prose);
+    expect(result.readyToGenerate).toBe(true);
+  });
+
+  it("strips an embedded envelope from assistant history before resending", async () => {
+    const mockCreate = await getMockCreate();
+    mockCreate.mockResolvedValue({
+      content: [{
+        type: "text",
+        text: '{"message":"ok","readyToGenerate":false}',
+      }],
+    });
+
+    // A polluted row: a past parse failure stored prose + raw envelope.
+    const polluted = `Pick a style.\n\n{ "message": "Pick a style.", "readyToGenerate": false }`;
+    const { chatAboutDesign } = await import("../ai");
+    await chatAboutDesign(
+      "vintage",
+      [msg("user", "a wolf"), msg("assistant", polluted)],
+      []
+    );
+
+    const sent = mockCreate.mock.calls[0][0].messages;
+    const assistant = sent.find((m: { role: string }) => m.role === "assistant");
+    expect(assistant.content).toBe("Pick a style.");
+    expect(assistant.content).not.toContain("readyToGenerate");
+  });
+});
+
+describe("extractChatEnvelope", () => {
+  it("returns null for plain prose", async () => {
+    const { extractChatEnvelope } = await import("../ai");
+    expect(extractChatEnvelope("No JSON here, just chat.")).toBeNull();
+  });
+
+  it("parses an envelope whose message contains braces", async () => {
+    const { extractChatEnvelope } = await import("../ai");
+    const envelope = JSON.stringify({
+      message: "Use {curly} accents",
+      readyToGenerate: false,
+    });
+    const result = extractChatEnvelope(`Lead-in text.\n${envelope}`);
+    expect(result?.message).toBe("Use {curly} accents");
+  });
 });
 
 describe("assessReadiness", () => {

--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -105,6 +105,34 @@ Refinements:
 - When refining a previous design, reference its prompt (shown as "Prompt used: ..." in the gallery context). Make only the specific changes requested. Preserve the rest.
 - Set "referenceImage" to the design number being refined — the image will be passed to the model as a visual reference for style and composition consistency.`;
 
+/**
+ * Pull the chat JSON envelope out of a reply that mixes prose with JSON. The
+ * model occasionally emits its conversational text AND the envelope instead
+ * of the envelope alone; the prose is a duplicate of envelope.message, so the
+ * envelope wins. Returns null when no parseable envelope is present.
+ */
+export function extractChatEnvelope(
+  text: string
+): { message: string; readyToGenerate: boolean } | null {
+  const start = text.search(/\{\s*"message"\s*:/);
+  if (start === -1) return null;
+  for (const end of [text.length, text.lastIndexOf("}") + 1]) {
+    if (end <= start) continue;
+    try {
+      const parsed = JSON.parse(text.slice(start, end));
+      if (typeof parsed.message === "string") {
+        return {
+          message: parsed.message,
+          readyToGenerate: parsed.readyToGenerate === true,
+        };
+      }
+    } catch {
+      // try the next candidate slice
+    }
+  }
+  return null;
+}
+
 function buildMessages(
   chatHistory: ChatMessage[],
   images: DesignImage[],
@@ -118,15 +146,20 @@ function buildMessages(
   const promptByImageId = new Map(images.map((img) => [img.id, img.prompt]));
 
   const raw = chatHistory.map((msg) => {
+    // Heal polluted history: an assistant row saved with an embedded JSON
+    // envelope (a past parse failure) teaches the model to imitate the broken
+    // prose+JSON format on every later turn — strip it before it goes back in.
+    const content =
+      msg.role === "assistant"
+        ? (extractChatEnvelope(msg.content)?.message ?? msg.content)
+        : msg.content;
     const fluxPrompt =
       msg.role === "assistant" && msg.imageId
         ? promptByImageId.get(msg.imageId)
         : null;
     return {
       role: msg.role as "user" | "assistant",
-      content: fluxPrompt
-        ? `${msg.content}\n\nPrompt used: ${fluxPrompt}`
-        : msg.content,
+      content: fluxPrompt ? `${content}\n\nPrompt used: ${fluxPrompt}` : content,
     };
   });
 
@@ -186,6 +219,10 @@ export async function chatAboutDesign(
       readyToGenerate: parsed.readyToGenerate === true,
     };
   } catch {
+    // Mixed prose + envelope (the model sometimes emits both) — salvage the
+    // envelope rather than showing the user the raw JSON blob.
+    const envelope = extractChatEnvelope(text);
+    if (envelope) return envelope;
     return { message: text, readyToGenerate: false };
   }
 }


### PR DESCRIPTION
Prod bug (screenshot 2026-06-09): /design chat replies render prose then the raw `{"message": ..., "readyToGenerate": ...}` envelope.

Cause: the model sometimes emits prose + envelope instead of pure JSON; `JSON.parse` fails, the fallback shows the whole blob, the blob is persisted, and later turns imitate the broken format from history (cascading).

Fix:
- `extractChatEnvelope` salvages the envelope from mixed output (new fallback step)
- `buildMessages` strips embedded envelopes from assistant history before resending — stops the cascade and heals polluted threads at the model boundary
- `scripts/clean-chat-envelopes.ts` rewrites already-stored rows (dry-run by default; prod run pending)

4 new tests; 326 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)