### PR TITLE
feat(feedback): adopt Loop widget page capture (ibuild4you #72)

### DIFF
--- a/src/app/admin/orders/[id]/page.tsx
+++ b/src/app/admin/orders/[id]/page.tsx
@@ -175,8 +175,8 @@ export default function OrderDetailPage() {
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
         {/* Left column */}
         <div className="space-y-4">
-          {/* Customer */}
-          <Card className="p-4">
+          {/* Customer — data-loop-redact keeps this PII out of feedback page captures */}
+          <Card className="p-4" data-loop-redact="">
             <h3 className="text-xs text-text-muted uppercase mb-2">Customer</h3>
             <p className="text-sm">{order.userEmail}</p>
             {order.shippingName && (

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -259,7 +259,8 @@ export default function AdminPage() {
         <p className="text-text-faint">No orders.</p>
       ) : (
         <div className="overflow-x-auto">
-          <table className="w-full text-sm text-left">
+          {/* data-loop-redact: rows carry customer names/locations — keep out of feedback page captures */}
+          <table className="w-full text-sm text-left" data-loop-redact="">
             <thead className="border-b text-text-faint text-xs uppercase">
               <tr>
                 <th className="py-3 pr-4">Order</th>

--- a/src/components/feedback-launcher.tsx
+++ b/src/components/feedback-launcher.tsx
@@ -10,7 +10,8 @@ export function FeedbackLauncher({ projectId }: { projectId: string }) {
   const [open, setOpen] = useState(false);
 
   return (
-    <div className="fixed bottom-4 right-4 z-50 print:hidden">
+    // data-loop-redact: the launcher is widget chrome — exclude it from its own page capture.
+    <div className="fixed bottom-4 right-4 z-50 print:hidden" data-loop-redact="">
       {open && (
         <div className="mb-2 w-72 max-w-[calc(100vw-2rem)] rounded-lg border border-border bg-surface-raised p-4 shadow-lg">
           <div className="mb-3 flex items-center justify-between">

--- a/src/components/feedback-widget.tsx
+++ b/src/components/feedback-widget.tsx
@@ -9,6 +9,7 @@ import {
   type FeedbackContext,
   type FeedbackType,
 } from "@/lib/feedback/payload";
+import { buildPageCapture } from "@/lib/feedback/capture";
 
 const TYPES: ReadonlyArray<{ value: FeedbackType; label: string }> = [
   { value: "bug", label: "Bug" },
@@ -39,6 +40,11 @@ export function FeedbackWidget({
   const [website, setWebsite] = useState(""); // honeypot — must stay empty
   const [status, setStatus] = useState<Status>("idle");
   const [error, setError] = useState<string | null>(null);
+  // Structural page snapshot rides along by default — it's previewable below,
+  // contains no typed values by construction, and the user is already
+  // mid-explicit-action (reporting about this very page).
+  const [includeCapture, setIncludeCapture] = useState(true);
+  const [capturePreview, setCapturePreview] = useState<string | null>(null);
   const renderedAtRef = useRef<number>(0);
 
   // Capture render time once. Server rejects submissions younger than ~2s
@@ -70,8 +76,12 @@ export function FeedbackWidget({
         typeof window !== "undefined" ? `${window.innerWidth}x${window.innerHeight}` : "",
       renderedAt: renderedAtRef.current || Date.now(),
     };
+    const capture =
+      includeCapture && typeof document !== "undefined"
+        ? buildPageCapture(document, window.location)
+        : null;
     const payload = {
-      ...buildFeedbackPayload({ projectId, type, body, submitterEmail }, ctx),
+      ...buildFeedbackPayload({ projectId, type, body, submitterEmail }, ctx, capture),
       website, // honeypot — sourced from state so a bot filling it gets caught
     };
 
@@ -111,7 +121,13 @@ export function FeedbackWidget({
   }
 
   return (
-    <form onSubmit={handleSubmit} className="space-y-3" aria-label="Send feedback">
+    <form
+      onSubmit={handleSubmit}
+      className="space-y-3"
+      aria-label="Send feedback"
+      // The widget excludes itself from its own page capture.
+      data-loop-redact=""
+    >
       <div className="flex gap-1">
         {TYPES.map((t) => (
           <button
@@ -168,6 +184,38 @@ export function FeedbackWidget({
         onChange={(e) => setWebsite(e.target.value)}
         style={{ position: "absolute", left: "-9999px", width: "1px", height: "1px", opacity: 0 }}
       />
+
+      {/*
+        Consent moment for the structural snapshot. The preview shows the
+        exact text that would be sent — the consent artifact IS the payload.
+      */}
+      <div className="space-y-1">
+        <label className="flex items-center gap-2 text-xs text-text-muted">
+          <input
+            type="checkbox"
+            checked={includeCapture}
+            onChange={(e) => setIncludeCapture(e.target.checked)}
+          />
+          Include a snapshot of this page&apos;s structure
+        </label>
+        {includeCapture && (
+          <details
+            onToggle={(e) => {
+              if ((e.target as HTMLDetailsElement).open && typeof document !== "undefined") {
+                const cap = buildPageCapture(document, window.location);
+                setCapturePreview(`${cap.route} — ${cap.title}\n${cap.outline}`);
+              }
+            }}
+          >
+            <summary className="cursor-pointer text-xs text-text-muted hover:text-foreground">
+              What&apos;s included?
+            </summary>
+            <pre className="mt-1 max-h-32 overflow-auto whitespace-pre-wrap rounded-md border border-border bg-surface p-2 text-[10px] leading-tight text-text-muted">
+              {capturePreview ?? ""}
+            </pre>
+          </details>
+        )}
+      </div>
 
       {error && (
         <p className="text-xs text-red-400" role="alert">

--- a/src/lib/feedback/__tests__/capture.test.ts
+++ b/src/lib/feedback/__tests__/capture.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { buildPageCapture, OUTLINE_MAX_CHARS } from "../capture";
+
+// Widget-side page capture (ported from ibuild4you). A pure DOM walk that
+// produces a structural outline (headings, landmarks, control labels, counts)
+// and NEVER user-typed values. Privacy is the contract here: most of these
+// tests assert what does NOT appear.
+
+function setBody(html: string) {
+  document.body.innerHTML = html;
+}
+
+const loc = { pathname: "/checkout" };
+
+beforeEach(() => {
+  document.body.innerHTML = "";
+  document.title = "Checkout — PRNTD";
+});
+
+describe("buildPageCapture — basics", () => {
+  it("captures version, route (path only) and title", () => {
+    setBody("<h1>Checkout</h1>");
+    const cap = buildPageCapture(document, loc);
+    expect(cap.v).toBe(1);
+    expect(cap.route).toBe("/checkout");
+    expect(cap.title).toBe("Checkout — PRNTD");
+  });
+
+  it("lists h1–h3 headings in document order, tagged by level", () => {
+    setBody("<h1>Checkout</h1><h2>Contact</h2><h3>Shipping address</h3><h2>Payment</h2>");
+    const { outline } = buildPageCapture(document, loc);
+    const h1 = outline.indexOf("h1: Checkout");
+    const h2a = outline.indexOf("h2: Contact");
+    const h3 = outline.indexOf("h3: Shipping address");
+    const h2b = outline.indexOf("h2: Payment");
+    expect(h1).toBeGreaterThanOrEqual(0);
+    expect(h2a).toBeGreaterThan(h1);
+    expect(h3).toBeGreaterThan(h2a);
+    expect(h2b).toBeGreaterThan(h3);
+  });
+
+  it("ignores h4–h6 (structure, not detail)", () => {
+    setBody("<h1>Top</h1><h4>Fine print</h4>");
+    const { outline } = buildPageCapture(document, loc);
+    expect(outline).not.toContain("Fine print");
+  });
+
+  it("captures nav landmarks with their accessible name and link labels", () => {
+    setBody(
+      '<nav aria-label="Main"><a href="/">Home</a><a href="/offers">Offers</a><a href="/contact">Contact</a></nav>',
+    );
+    const { outline } = buildPageCapture(document, loc);
+    expect(outline).toContain("nav (Main): Home | Offers | Contact");
+  });
+
+  it("captures button labels, deduplicated", () => {
+    setBody(
+      '<button>Place order</button><button>Cancel</button><button>Cancel</button><input type="submit" value="Apply coupon">',
+    );
+    const { outline } = buildPageCapture(document, loc);
+    expect(outline).toContain("buttons: Place order | Cancel | Apply coupon");
+  });
+
+  it("captures form field labels", () => {
+    setBody(
+      '<form><label for="em">Email</label><input id="em" type="email">' +
+        "<label>Card number<input type='text'></label>" +
+        '<input type="text" placeholder="Promo code"></form>',
+    );
+    const { outline } = buildPageCapture(document, loc);
+    expect(outline).toContain("fields: Email | Card number | Promo code");
+  });
+
+  it("counts tables and long lists instead of dumping their content", () => {
+    const rows = Array.from({ length: 12 }, (_, i) => `<tr><td>row ${i}</td></tr>`).join("");
+    const items = Array.from({ length: 8 }, (_, i) => `<li>item ${i}</li>`).join("");
+    setBody(`<table>${rows}</table><ul>${items}</ul>`);
+    const { outline } = buildPageCapture(document, loc);
+    expect(outline).toContain("table: 12 rows");
+    expect(outline).toContain("list: 8 items");
+    expect(outline).not.toContain("row 3");
+    expect(outline).not.toContain("item 5");
+  });
+
+  it("does not count short lists or lists inside nav", () => {
+    setBody(
+      '<nav><ul><li><a href="/">Home</a></li><li><a href="/a">A</a></li><li><a href="/b">B</a></li><li><a href="/c">C</a></li></ul></nav>' +
+        "<ul><li>one</li><li>two</li></ul>",
+    );
+    const { outline } = buildPageCapture(document, loc);
+    expect(outline).not.toContain("list:");
+  });
+});
+
+describe("buildPageCapture — privacy (what must NOT leak)", () => {
+  it("never captures input values", () => {
+    setBody(
+      '<form><label for="em">Email</label><input id="em" type="email" value="sam@secret.com">' +
+        "<textarea>my private note</textarea></form>",
+    );
+    const { outline } = buildPageCapture(document, loc);
+    expect(outline).not.toContain("sam@secret.com");
+    expect(outline).not.toContain("my private note");
+  });
+
+  it("skips password and hidden inputs entirely (not even their labels)", () => {
+    setBody(
+      '<form><label for="pw">Password</label><input id="pw" type="password">' +
+        '<input type="hidden" name="csrf" value="tok123"></form>',
+    );
+    const { outline } = buildPageCapture(document, loc);
+    expect(outline).not.toContain("Password");
+    expect(outline).not.toContain("tok123");
+    expect(outline).not.toContain("csrf");
+  });
+
+  it("never captures non-heading body text", () => {
+    setBody("<h1>Invoice</h1><p>Client owes $12,345 due Friday</p>");
+    const { outline } = buildPageCapture(document, loc);
+    expect(outline).not.toContain("12,345");
+  });
+
+  it("excludes anything under data-loop-redact (the host-app escape hatch)", () => {
+    setBody(
+      "<h1>Deals</h1><section data-loop-redact><h2>Acme Corp offer</h2><button>Accept $50k</button></section>",
+    );
+    const { outline } = buildPageCapture(document, loc);
+    expect(outline).toContain("h1: Deals");
+    expect(outline).not.toContain("Acme");
+    expect(outline).not.toContain("50k");
+  });
+
+  it("excludes hidden and aria-hidden elements", () => {
+    setBody(
+      '<h2 hidden>Secret A</h2><div aria-hidden="true"><h2>Secret B</h2></div><h2>Visible</h2>',
+    );
+    const { outline } = buildPageCapture(document, loc);
+    expect(outline).not.toContain("Secret A");
+    expect(outline).not.toContain("Secret B");
+    expect(outline).toContain("h2: Visible");
+  });
+});
+
+describe("buildPageCapture — caps", () => {
+  it("truncates individual item text", () => {
+    setBody(`<h1>${"x".repeat(300)}</h1>`);
+    const { outline } = buildPageCapture(document, loc);
+    const line = outline.split("\n").find((l) => l.startsWith("h1:"))!;
+    expect(line.length).toBeLessThanOrEqual(90);
+    expect(line).toContain("…");
+  });
+
+  it("caps the whole outline", () => {
+    const headings = Array.from(
+      { length: 400 },
+      (_, i) => `<h2>Section ${i} lorem ipsum dolor</h2>`,
+    ).join("");
+    setBody(headings);
+    const { outline } = buildPageCapture(document, loc);
+    expect(outline.length).toBeLessThanOrEqual(OUTLINE_MAX_CHARS);
+  });
+
+  it("collapses whitespace in captured text", () => {
+    setBody("<h1>  Multi\n   line\ttitle  </h1>");
+    const { outline } = buildPageCapture(document, loc);
+    expect(outline).toContain("h1: Multi line title");
+  });
+});

--- a/src/lib/feedback/capture.ts
+++ b/src/lib/feedback/capture.ts
@@ -1,0 +1,130 @@
+// Widget-side page capture for Loop — mirrors ibuild4you's lib/feedback/capture.ts.
+//
+// A pure DOM walk that turns the page the user is looking at into a small
+// structural outline the intake agent can reason over: route, title, headings,
+// nav links, button/field labels, and counts for repeated structures. It is
+// deliberately structure-only — the privacy contract is that user-typed values,
+// non-heading body text, and query strings NEVER appear in the output. Any
+// subtree with a `data-loop-redact` attribute is excluded entirely.
+
+export interface PageCapture {
+  v: 1;
+  route: string; // location.pathname only — host + query stripped
+  title: string;
+  outline: string;
+}
+
+// Server-side caps mirror these (ibuild4you app/api/feedback/route.ts).
+export const ROUTE_MAX_CHARS = 300;
+export const TITLE_MAX_CHARS = 200;
+export const OUTLINE_MAX_CHARS = 4000;
+
+const ITEM_MAX_CHARS = 80;
+const MAX_HEADINGS = 30;
+const MAX_LABELS_PER_LINE = 15;
+
+function clean(s: string | null | undefined): string {
+  const t = (s ?? "").replace(/\s+/g, " ").trim();
+  return t.length <= ITEM_MAX_CHARS ? t : t.slice(0, ITEM_MAX_CHARS - 1).trimEnd() + "…";
+}
+
+// Excluded: redacted subtrees (host escape hatch), hidden/aria-hidden elements.
+// closest() checks the element itself and its ancestors.
+function isExcluded(el: Element): boolean {
+  return el.closest('[data-loop-redact],[hidden],[aria-hidden="true"]') !== null;
+}
+
+function joinLabels(prefix: string, labels: string[]): string | null {
+  const seen = new Set<string>();
+  const unique = labels.filter((l) => {
+    if (!l || seen.has(l)) return false;
+    seen.add(l);
+    return true;
+  });
+  if (unique.length === 0) return null;
+  return `${prefix}: ${unique.slice(0, MAX_LABELS_PER_LINE).join(" | ")}`;
+}
+
+function buttonLabel(el: Element): string {
+  if (el instanceof HTMLInputElement) return clean(el.value); // submit/button inputs label via value
+  return clean(el.getAttribute("aria-label") || el.textContent);
+}
+
+function fieldLabel(el: Element): string {
+  // .labels covers both <label for=…> and wrapping <label> associations.
+  const labels = (el as HTMLInputElement).labels;
+  if (labels && labels.length > 0) {
+    // Label text minus the control's own value/content.
+    const copy = labels[0].cloneNode(true) as HTMLElement;
+    copy.querySelectorAll("input,select,textarea").forEach((c) => c.remove());
+    const text = clean(copy.textContent);
+    if (text) return text;
+  }
+  return clean(el.getAttribute("aria-label") || el.getAttribute("placeholder"));
+}
+
+// Build the structural outline of the current page. `loc` is passed in (rather
+// than read from a global) so this stays pure and unit-testable.
+export function buildPageCapture(doc: Document, loc: { pathname: string }): PageCapture {
+  const lines: string[] = [];
+
+  // Headings h1–h3, document order. h4+ is detail, not structure.
+  const headings = Array.from(doc.querySelectorAll("h1,h2,h3"))
+    .filter((el) => !isExcluded(el))
+    .slice(0, MAX_HEADINGS);
+  for (const h of headings) {
+    const text = clean(h.textContent);
+    if (text) lines.push(`${h.tagName.toLowerCase()}: ${text}`);
+  }
+
+  // Nav landmarks with their link labels.
+  for (const nav of Array.from(doc.querySelectorAll('nav,[role="navigation"]'))) {
+    if (isExcluded(nav)) continue;
+    const links = Array.from(nav.querySelectorAll("a"))
+      .filter((a) => !isExcluded(a))
+      .map((a) => clean(a.textContent));
+    const name = clean(nav.getAttribute("aria-label"));
+    const line = joinLabels(name ? `nav (${name})` : "nav", links);
+    if (line) lines.push(line);
+  }
+
+  // Button labels — what can the user do on this page?
+  const buttons = Array.from(
+    doc.querySelectorAll('button,[role="button"],input[type="submit"],input[type="button"]'),
+  )
+    .filter((el) => !isExcluded(el))
+    .map(buttonLabel);
+  const buttonLine = joinLabels("buttons", buttons);
+  if (buttonLine) lines.push(buttonLine);
+
+  // Form field LABELS only — never values. Password/hidden skipped entirely.
+  const fields = Array.from(doc.querySelectorAll("input,select,textarea"))
+    .filter((el) => {
+      const type = el.getAttribute("type")?.toLowerCase();
+      if (type === "password" || type === "hidden" || type === "submit" || type === "button") {
+        return false;
+      }
+      return !isExcluded(el);
+    })
+    .map(fieldLabel);
+  const fieldLine = joinLabels("fields", fields);
+  if (fieldLine) lines.push(fieldLine);
+
+  // Repeated structures as counts, not content.
+  for (const table of Array.from(doc.querySelectorAll("table")).slice(0, 5)) {
+    if (isExcluded(table)) continue;
+    lines.push(`table: ${table.querySelectorAll("tr").length} rows`);
+  }
+  for (const list of Array.from(doc.querySelectorAll("ul,ol")).slice(0, 10)) {
+    if (isExcluded(list) || list.closest('nav,[role="navigation"]')) continue;
+    const count = list.querySelectorAll(":scope > li").length;
+    if (count >= 4) lines.push(`list: ${count} items`);
+  }
+
+  return {
+    v: 1,
+    route: (loc.pathname || "/").slice(0, ROUTE_MAX_CHARS),
+    title: clean(doc.title).slice(0, TITLE_MAX_CHARS),
+    outline: lines.join("\n").slice(0, OUTLINE_MAX_CHARS),
+  };
+}

--- a/src/lib/feedback/payload.ts
+++ b/src/lib/feedback/payload.ts
@@ -2,6 +2,8 @@
 // The widget POSTs this shape to https://ibuild4you.com/api/feedback.
 // If the contract changes upstream, update this file to match.
 
+import type { PageCapture } from "./capture";
+
 export type FeedbackType = "bug" | "idea" | "other";
 
 // Mirror the server-side cap (ibuild4you app/api/feedback/route.ts).
@@ -37,6 +39,9 @@ export interface FeedbackPayload {
   viewport: string;
   website: ""; // honeypot — must stay empty; bots fill it
   _ts: number; // render time; server checks min/max age (2s–24h)
+  // Optional structural page capture (./capture.ts). Additive — servers that
+  // predate it ignore it; omitting it is always valid.
+  capture?: PageCapture;
 }
 
 export type ValidationResult =
@@ -76,6 +81,7 @@ export function validateFeedbackInput(input: FeedbackInput): ValidationResult {
 export function buildFeedbackPayload(
   input: FeedbackInput,
   ctx: FeedbackContext,
+  capture?: PageCapture | null,
 ): FeedbackPayload {
   const submitterEmail = input.submitterEmail?.trim().toLowerCase();
   return {
@@ -88,5 +94,6 @@ export function buildFeedbackPayload(
     viewport: ctx.viewport,
     website: "",
     _ts: ctx.renderedAt,
+    ...(capture ? { capture } : {}),
   };
 }


### PR DESCRIPTION
Adopts the upgraded Loop wire contract from the 2026-07-04 ibuild4you handoff.

- New `src/lib/feedback/capture.ts` — pure DOM walk producing a structural page outline (route, title, h1–h3, nav links, button/field labels, table/list counts). Privacy contract: user-typed values, body text, and query strings never appear. Ported test suite (16 tests) asserts what must NOT leak.
- `payload.ts` gains the optional `capture` field (additive — server ignores absence).
- Widget: on-by-default "include snapshot" checkbox with a "What's included?" preview showing the exact text sent; the form and launcher exclude themselves via `data-loop-redact`.
- PII redaction: admin order-detail Customer card and admin orders table marked `data-loop-redact` (defense-in-depth — capture never takes cell/body text today).

Verified end-to-end from local dev: POST to https://ibuild4you.com/api/feedback returned 201 with `capture` present in the body and widget chrome absent from the outline. Lint 0 errors, 440 tests pass, build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HrvM3mNXB9y16166EgXsv7