### PR TITLE
feat: maker landing — Type It, Wear It

### DIFF
--- a/e2e/landing.spec.ts
+++ b/e2e/landing.spec.ts
@@ -1,0 +1,47 @@
+/**
+ * Maker landing ("Type It, Wear It"): the signed-out homepage is a composer.
+ * Submitting an idea navigates to /design?prompt=…, which auto-fires Draw-it.
+ * The thin-prompt test uses a deliberately vague idea so the fast readiness
+ * check answers with a clarifying question — CI never pays for a render there.
+ */
+import { test, expect } from "@playwright/test";
+import { EXAMPLES } from "../src/lib/design-examples";
+
+test("signed-out homepage shows the hero composer", async ({ page }) => {
+  await page.goto("/");
+  await expect(
+    page.getByRole("heading", { name: "Type an idea. Wear it." })
+  ).toBeVisible();
+  await expect(page.getByPlaceholder(/Describe your design/)).toBeVisible();
+});
+
+test("a thin prompt seeds /design and gets a clarifying reply", async ({
+  page,
+}) => {
+  await page.goto("/");
+  await page.getByPlaceholder(/Describe your design/).fill("something cool");
+  await page.getByRole("button", { name: "Draw it" }).click();
+
+  await expect(page).toHaveURL(/\/design/);
+  // The seed shows up as the first user turn.
+  await expect(page.getByTestId("chat-message-user").first()).toHaveText(
+    "something cool"
+  );
+  // Thin-check replies with a clarifying question (no image render).
+  await expect(page.getByTestId("chat-message-assistant").first()).toBeVisible({
+    timeout: 30_000,
+  });
+  // The prompt param was stripped on arrival, so refresh/back won't resubmit.
+  expect(new URL(page.url()).searchParams.has("prompt")).toBe(false);
+});
+
+test("tapping an example chip lands on /design with the chip as the first turn", async ({
+  page,
+}) => {
+  await page.goto("/");
+  const chip = EXAMPLES[0];
+  await page.getByRole("button", { name: chip }).click();
+
+  await expect(page).toHaveURL(/\/design/);
+  await expect(page.getByTestId("chat-message-user").first()).toHaveText(chip);
+});

--- a/src/app/design/chat-panel.tsx
+++ b/src/app/design/chat-panel.tsx
@@ -6,13 +6,7 @@ import type { ChatMessage } from "@/lib/db/schema";
 import type { ChatOption } from "@/lib/ai";
 import type { DesignImage } from "@/lib/design-images";
 import { Button, QuickReply } from "@/components/ui";
-
-const EXAMPLES = [
-  "A minimalist mountain landscape in blue and white",
-  "A retro sunset with palm tree silhouettes",
-  "An abstract geometric wolf head",
-  'Bold text saying "HELLO" in a graffiti style',
-];
+import { EXAMPLES } from "@/lib/design-examples";
 
 export function ChatPanel({
   messages,
@@ -249,6 +243,7 @@ export function ChatPanel({
           return (
             <div
               key={msg.id}
+              data-testid={`chat-message-${msg.role}`}
               className={`flex ${msg.role === "user" ? "justify-end" : "justify-start"}`}
             >
               <div

--- a/src/app/design/page.tsx
+++ b/src/app/design/page.tsx
@@ -81,6 +81,24 @@ function DesignPageInner() {
     ensureGuestSession();
   }, []);
 
+  // Landing seed: /design?prompt=… fires Draw-it once with the seeded idea
+  // (new designs only — never when resuming via ?id=). Ref-guarded so React
+  // Strict Mode's double effect can't fire it twice; the param is stripped
+  // immediately so refresh/back doesn't resubmit — via history.replaceState
+  // (shallow, no router re-render) because a router.replace issued right
+  // before a server-action call gets cancelled by the action. A thin seed is
+  // caught by the fast readiness check inside generateDesign and answered
+  // with a clarifying question instead of a render — no new guard needed.
+  const seedFired = useRef(false);
+  useEffect(() => {
+    const prompt = searchParams.get("prompt");
+    if (!prompt || searchParams.get("id") || seedFired.current) return;
+    seedFired.current = true;
+    window.history.replaceState(null, "", "/design");
+    handleGenerate(prompt);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   // Load existing design if resuming
   const id = searchParams.get("id");
   useEffect(() => {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,10 +2,13 @@ import Link from "next/link";
 import { headers } from "next/headers";
 import { auth } from "@/lib/auth";
 import { HomeHero } from "@/components/home-hero";
+import { MakerHero } from "@/components/maker-hero";
 import { PublishedGrid } from "@/components/published-grid";
 import { getUserDesigns } from "./designs/actions";
 import { getDiscoverFeed } from "./d/actions";
 import { getActivePromo } from "@/lib/promotion";
+import { publishedBackdrop } from "@/lib/blanks";
+import { minRetailPrice } from "@/lib/pricing";
 
 export const dynamic = "force-dynamic";
 
@@ -16,10 +19,60 @@ export default async function Home() {
     auth.api.getSession({ headers: await headers() }),
   ]);
   const isLoggedIn = !!session;
+  // Proof strip under the signed-out hero: real published designs, framed as
+  // what chatting here produces. No invented prompts (recovered designs don't
+  // have them); omitted entirely when the feed is empty.
+  const proof = discover.slice(0, 2);
 
   return (
     <div className="min-h-screen flex flex-col">
-      <HomeHero getRecentDesigns={getUserDesigns} />
+      {isLoggedIn ? (
+        <HomeHero getRecentDesigns={getUserDesigns} />
+      ) : (
+        <MakerHero />
+      )}
+
+      {!isLoggedIn && proof.length > 0 && (
+        <section className="py-12 px-4">
+          <div className="max-w-2xl mx-auto">
+            <h2 className="text-lg font-semibold text-center mb-6">
+              Made by chatting here
+            </h2>
+            <div className="grid grid-cols-2 gap-4">
+              {proof.map((img) => {
+                const backdrop = publishedBackdrop(img.backgroundColor);
+                return (
+                  <Link
+                    key={img.imageId}
+                    href={`/d/${img.imageId}`}
+                    className="group block"
+                  >
+                    <div
+                      className={`aspect-square rounded-md overflow-hidden border border-border group-hover:border-accent transition-colors ${backdrop.className}`}
+                      style={backdrop.style}
+                    >
+                      {/* eslint-disable-next-line @next/next/no-img-element */}
+                      <img
+                        src={img.imageUrl}
+                        alt={img.title ?? "Design"}
+                        className="w-full h-full object-contain"
+                      />
+                    </div>
+                    {img.title && (
+                      <p className="mt-2 text-sm font-medium truncate">
+                        {img.title}
+                      </p>
+                    )}
+                    <p className="text-xs text-text-muted truncate">
+                      by {img.designerName}
+                    </p>
+                  </Link>
+                );
+              })}
+            </div>
+          </div>
+        </section>
+      )}
 
       {promo && (
         <section className="py-4 px-4 bg-accent/10 border-y border-accent/20 text-center">
@@ -53,47 +106,15 @@ export default async function Home() {
         </section>
       )}
 
-      {!isLoggedIn && (
-        <section className="py-16 px-4 border-t border-border">
-          <div className="max-w-4xl mx-auto">
-            <h2 className="text-2xl font-bold text-center mb-12">
-              How it works
-            </h2>
-            <div className="grid md:grid-cols-3 gap-8 text-center">
-              <div className="space-y-3">
-                <div className="text-3xl font-bold text-text-faint">1</div>
-                <h3 className="font-semibold text-lg">Describe</h3>
-                <p className="text-text-muted">
-                  Type what you want printed. A logo, illustration, text —
-                  whatever.
-                </p>
-              </div>
-              <div className="space-y-3">
-                <div className="text-3xl font-bold text-text-faint">2</div>
-                <h3 className="font-semibold text-lg">Refine</h3>
-                <p className="text-text-muted">
-                  Preview the design on the product you want. Ask for changes
-                  until it looks right.
-                </p>
-              </div>
-              <div className="space-y-3">
-                <div className="text-3xl font-bold text-text-faint">3</div>
-                <h3 className="font-semibold text-lg">Order</h3>
-                <p className="text-text-muted">
-                  Pick size and color. Pay. It shows up.
-                </p>
-              </div>
-            </div>
-          </div>
-        </section>
-      )}
-
       <section className="py-16 px-4 bg-surface">
         <div className="max-w-2xl mx-auto text-center space-y-4">
           <h2 className="text-2xl font-bold">Pricing</h2>
           <p className="text-text-muted">
-            Designing is free. You pay when you order. Products start at{" "}
-            <span className="font-semibold text-foreground">$15</span>.
+            Designing is free. You pay when you order. Tees from{" "}
+            <span className="font-semibold text-foreground">
+              ${minRetailPrice().toFixed(2)}
+            </span>
+            .
           </p>
         </div>
       </section>
@@ -108,6 +129,11 @@ export default async function Home() {
           >
             hello@prntd.org
           </a>
+        </p>
+        <p>
+          <Link href="/dashboard" className="underline hover:text-text-muted">
+            Open a shop →
+          </Link>
         </p>
       </footer>
     </div>

--- a/src/components/home-hero.tsx
+++ b/src/components/home-hero.tsx
@@ -32,27 +32,8 @@ export function HomeHero({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [userId]);
 
-  // Logged-out: landing hero
-  if (!session) {
-    return (
-      <main className="flex-1 flex flex-col items-center justify-center px-4">
-        <div className="max-w-2xl text-center space-y-6">
-          <h1 className="text-5xl font-bold tracking-tight">
-            Design custom prints with AI
-          </h1>
-          <p className="text-xl text-text-muted max-w-lg mx-auto">
-            Describe your idea. AI generates an image. Ask for changes, then
-            order it on a shirt, phone case, or more.
-          </p>
-          <Link href="/design">
-            <Button size="lg">Start Designing</Button>
-          </Link>
-        </div>
-      </main>
-    );
-  }
-
-  // Logged-in: personal hero
+  // Signed-in personal hero only — the page renders <MakerHero> for
+  // signed-out visitors (server-side session branch, no client flash).
   const hasDesigns = loaded && designs.length > 0;
 
   return (

--- a/src/components/maker-hero.tsx
+++ b/src/components/maker-hero.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { Button } from "@/components/ui";
+import { EXAMPLES } from "@/lib/design-examples";
+
+/**
+ * Signed-out landing hero — the composer IS the landing. Typing an idea (or
+ * tapping a chip) navigates to /design?prompt=…, which auto-fires Draw-it.
+ * Unlike the in-chat chips (which prefill), landing chips navigate
+ * immediately: here they demo the product.
+ */
+export function MakerHero() {
+  const router = useRouter();
+  const [input, setInput] = useState("");
+
+  function go(text: string) {
+    const msg = text.trim();
+    if (!msg) return;
+    router.push(`/design?prompt=${encodeURIComponent(msg)}`);
+  }
+
+  return (
+    <main className="flex-1 flex flex-col items-center justify-center px-4 py-16 text-center">
+      <div className="w-full max-w-2xl space-y-6">
+        <h1 className="text-4xl sm:text-5xl font-bold tracking-tight">
+          Type an idea. Wear it.
+        </h1>
+        <p className="text-lg text-text-muted max-w-lg mx-auto">
+          AI draws your design in seconds. Free to try — pay only if you
+          order.
+        </p>
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            go(input);
+          }}
+          className="flex gap-2"
+        >
+          <input
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            placeholder="Describe your design..."
+            className="flex-1 min-h-[44px] px-3 py-2 bg-surface border border-border rounded-md text-white placeholder:text-text-faint focus:border-border-hover focus:outline-none"
+          />
+          <Button
+            type="submit"
+            variant="primary"
+            className="min-h-[44px]"
+            disabled={!input.trim()}
+          >
+            Draw it
+          </Button>
+        </form>
+        <div className="flex flex-wrap justify-center gap-2">
+          {EXAMPLES.slice(0, 3).map((example) => (
+            <button
+              key={example}
+              type="button"
+              onClick={() => go(example)}
+              className="text-xs px-3 py-2 min-h-[44px] border border-border rounded-full text-text-muted hover:text-foreground hover:border-border-hover transition-colors"
+            >
+              {example}
+            </button>
+          ))}
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/lib/__tests__/pricing.test.ts
+++ b/src/lib/__tests__/pricing.test.ts
@@ -3,11 +3,12 @@ import {
   computePrice,
   computeOrderTotal,
   estimateShipping,
+  minRetailPrice,
   FLAT_SHIPPING_USD,
   MARGIN_MULTIPLIER,
   BACK_PLACEMENT_UPCHARGE,
 } from "../pricing";
-import { BLANKS } from "../blanks";
+import { ACTIVE_BLANKS, BLANKS } from "../blanks";
 
 describe("computePrice", () => {
   it("prices the default Classic Tee at its fixed retail price, ignoring generation cost", () => {
@@ -137,5 +138,20 @@ describe("estimateShipping", () => {
 
   it("ships nothing for an empty cart", () => {
     expect(estimateShipping(0)).toBe(0);
+  });
+});
+
+describe("minRetailPrice", () => {
+  it("returns the current catalog floor (Classic Tee S–XL retail)", () => {
+    expect(minRetailPrice()).toBe(19.43);
+  });
+
+  it("never exceeds any purchasable price in the active catalog", () => {
+    const floor = minRetailPrice();
+    for (const blank of ACTIVE_BLANKS) {
+      for (const size of blank.sizes) {
+        expect(floor).toBeLessThanOrEqual(computePrice(0, blank.id, size).total);
+      }
+    }
   });
 });

--- a/src/lib/design-examples.ts
+++ b/src/lib/design-examples.ts
@@ -1,0 +1,11 @@
+/**
+ * Example design prompts shared by the landing hero chips (tap = navigate to
+ * /design?prompt= and draw immediately) and the in-chat empty-state chips
+ * (tap = prefill the composer). One list, two jobs.
+ */
+export const EXAMPLES = [
+  "A minimalist mountain landscape in blue and white",
+  "A retro sunset with palm tree silhouettes",
+  "An abstract geometric wolf head",
+  'Bold text saying "HELLO" in a graffiti style',
+];

--- a/src/lib/pricing.ts
+++ b/src/lib/pricing.ts
@@ -2,6 +2,7 @@ import {
   getBlankOrThrow,
   getBaseCost,
   getRetailPrice,
+  ACTIVE_BLANKS,
   DEFAULT_BLANK_ID,
 } from "./blanks";
 
@@ -131,6 +132,24 @@ export function computePrice(
     Math.round((front + (opts.back ? BACK_PLACEMENT_UPCHARGE : 0)) * 100) / 100;
 
   return { baseCost, generationCost, total };
+}
+
+/**
+ * Cheapest customer-facing price across the active catalog (any blank, any
+ * size, front only). Derived from the same computePrice the checkout charges,
+ * so marketing copy like the landing's "Tees from $X" can never go stale.
+ * (Lives here rather than blanks.ts because it needs the margin computation,
+ * and blanks.ts importing pricing.ts would be circular.)
+ */
+export function minRetailPrice(): number {
+  let min = Infinity;
+  for (const blank of ACTIVE_BLANKS) {
+    for (const size of blank.sizes) {
+      const { total } = computePrice(0, blank.id, size);
+      if (total < min) min = total;
+    }
+  }
+  return min;
 }
 
 export type ProceedsBreakdown = {


### PR DESCRIPTION
Implements `docs/maker-landing-plan.md` (both slices, decisions as locked).

## M1 — `/design?prompt=` seed
- Seeded prompt auto-fires **Draw-it** once (Strict-Mode-safe ref guard), new designs only (`?id=` skips).
- Param stripped on arrival via `history.replaceState` so refresh/back never resubmits. (`router.replace` didn't survive here — a replace issued right before a server-action call gets cancelled by the action; caught by the e2e spec on the first local run.)
- Thin seeds ride the existing ~1s readiness check → clarifying question, no wasted render. No server-action changes.

## M2 — landing v2
- New `MakerHero` (signed-out only, server-side session branch — no flash): "Type an idea. Wear it.", composer + primary **Draw it**, first 3 example chips always visible, all targets ≥44px.
- Shared `src/lib/design-examples.ts` — landing chips navigate immediately; in-chat chips still prefill.
- Proof strip: first 2 discover-feed designs on their backdrops under "Made by chatting here"; omitted when the feed is empty. Promo slot + Fresh Prints teaser unchanged; How-it-works deleted.
- `minRetailPrice()` drives the pricing line (stale `$15` → real floor `$19.43`). **Deviation from plan:** it lives in `pricing.ts`, not `blanks.ts` — it needs the margin computation, and `blanks.ts → pricing.ts` would be a circular import. Same pure helper + tests.
- Footer: quiet "Open a shop →" → `/dashboard`.
- `HomeHero` keeps only the signed-in personal hero.

## Tests
- Unit: `minRetailPrice` floor + never-above-any-price sweep; 442 tests green.
- New `e2e/landing.spec.ts`: hero composer visible; thin prompt ("something cool") → lands on `/design`, first user turn shown, clarifying assistant reply, no `?prompt=` residue; chip tap → `/design` with chip as first turn. Chat message rows gained `data-testid`s.
- Local `npm run e2e`: landing + cart + store-compose green. One flake: `guest-funnel › anonymous session (desktop)` times out under full parallel load but passes in isolation (445ms) — pre-existing contention on the anon mint against remote Turso, untouched by this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HrvM3mNXB9y16166EgXsv7