### PR TITLE
fix: clear cart on payment, not at Stripe-session creation (#38)

### DIFF
--- a/src/app/cart/actions.ts
+++ b/src/app/cart/actions.ts
@@ -260,7 +260,9 @@ export async function checkoutCart(): Promise<{
     .set({ stripeSessionId: checkoutSession.id })
     .where(eq(orderTable.id, newOrder.id));
 
-  await clearCart();
+  // The cart is NOT cleared here (#38): backing out of Stripe returns to the
+  // cancel URL /cart, which must still hold the items. The webhook clears the
+  // purchased lines on checkout.session.completed.
 
   return { url: checkoutSession.url };
 }

--- a/src/lib/__tests__/money-path.integration.test.ts
+++ b/src/lib/__tests__/money-path.integration.test.ts
@@ -354,6 +354,16 @@ describe("money path — checkout.session.completed", () => {
       },
     ]);
 
+    // The cart still holds the purchased lines (checkoutCart no longer clears
+    // at session creation, #38) plus one line added mid-checkout that the
+    // webhook must NOT touch.
+    const [d3] = await db.insert(schema.design).values({ userId }).returning();
+    await db.insert(schema.cartItem).values([
+      { userId, designId: d1.id, productId: "bella-canvas-3001", size: "M", color: "Black" },
+      { userId, designId: d2.id, productId: "bella-canvas-3001", size: "L", color: "White" },
+      { userId, designId: d3.id, productId: "bella-canvas-3001", size: "S", color: "Red" },
+    ]);
+
     const createPrintfulOrder = vi
       .fn()
       .mockResolvedValue({ id: 8888, costs: { total: "25.00" } });
@@ -397,6 +407,14 @@ describe("money path — checkout.session.completed", () => {
     expect(byType.sale).toBe(43.55);
     expect(byType.cogs).toBe(-25.0);
     expect(entries.filter((e) => e.type === "cogs")).toHaveLength(1);
+
+    // #38: payment cleared exactly the purchased cart lines; the line added
+    // mid-checkout survives.
+    const remaining = await db.query.cartItem.findMany({
+      where: eq(schema.cartItem.userId, userId),
+    });
+    expect(remaining).toHaveLength(1);
+    expect(remaining[0].designId).toBe(d3.id);
   });
 
   it("Printful failure leaves the order paid with no COGS and design not ordered", async () => {

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -201,7 +201,9 @@ export const orderItem = sqliteTable("order_item", {
  * Persistent cart (#26 Stage B). Keyed by user — one cart per account, anon or
  * real — so it survives the guest→account claim (re-parented in auth.ts's
  * onLinkAccount alongside design/order). One row per line the customer added;
- * checkout turns these into an order + order_item rows, then clears them.
+ * checkout turns these into an order + order_item rows, and the Stripe webhook
+ * clears the purchased lines on payment (#38) — never at session creation, so
+ * backing out of checkout keeps the cart.
  */
 export const cartItem = sqliteTable("cart_item", {
   id: text("id").primaryKey().$defaultFn(() => crypto.randomUUID()),

--- a/src/lib/webhook-handlers.ts
+++ b/src/lib/webhook-handlers.ts
@@ -1,5 +1,6 @@
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import {
+  cartItem as cartItemTable,
   order as orderTable,
   orderItem as orderItemTable,
 } from "@/lib/db/schema";
@@ -123,6 +124,23 @@ export async function handleStripeCheckoutCompleted(
   const orderItems = await deps.db.query.orderItem.findMany({
     where: eq(orderItemTable.orderId, orderId),
   });
+
+  // #38: the cart survives Stripe-session creation, so backing out of checkout
+  // returns to an intact /cart. Payment is the point of no return — clear the
+  // purchased lines here, matched per line so a single-item /order purchase
+  // (no order_item rows today) or anything added to the cart mid-checkout is
+  // untouched. Runs even if fulfillment fails below: the customer paid.
+  for (const item of orderItems) {
+    await deps.db.delete(cartItemTable).where(
+      and(
+        eq(cartItemTable.userId, foundOrder.userId),
+        eq(cartItemTable.designId, item.designId),
+        eq(cartItemTable.productId, item.productId),
+        eq(cartItemTable.size, item.size),
+        eq(cartItemTable.color, item.color)
+      )
+    );
+  }
 
   return submitOrderFulfillment(foundOrder, orderItems, session.shipping, deps);
 }


### PR DESCRIPTION
Fixes #38 (confirmed-unintentional): `checkoutCart` cleared the cart when it created the Stripe session, so backing out of checkout landed on an empty `/cart`.

- The clear moves to `handleStripeCheckoutCompleted`, after the order is marked paid and before fulfillment (the customer paid even if Printful fails).
- Matched per purchased `order_item` line (`userId` + design + product + size + color) rather than wiping the whole cart — a single-item `/order` purchase (which writes no `order_item` rows today) and lines added mid-checkout are untouched. Survives Phase 1b (always-write-order_item) unchanged.
- Idempotent redelivery is covered by the existing `status !== "pending" → skipped` guard upstream of the clear.

Tests: cart money-path integration test seeds three cart rows (two purchased + one mid-checkout addition) and asserts only the purchased lines clear. 442 tests, lint, build green. The cart e2e spec stops at the checkout sign-in gate, so it never exercised the old clear — no e2e change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HrvM3mNXB9y16166EgXsv7