### PR TITLE
feat: money-path idempotency — atomic claims, batched ledger writes, redelivery 200s (#37)

### DIFF
--- a/drizzle/0003_wide_sugar_man.sql
+++ b/drizzle/0003_wide_sugar_man.sql
@@ -1,0 +1,1 @@
+CREATE UNIQUE INDEX `ledger_entry_order_type_unique` ON `ledger_entry` (`order_id`,`type`);

--- a/drizzle/meta/0003_snapshot.json
+++ b/drizzle/meta/0003_snapshot.json
@@ -1,0 +1,1635 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "2ef73922-67e0-4ab7-8c18-6d05f7985dfe",
+  "prevId": "6a92ec4b-6aea-41c7-9ff0-83c5566ccf38",
+  "tables": {
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "cart_item": {
+      "name": "cart_item",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "design_id": {
+          "name": "design_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size": {
+          "name": "size",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "placements": {
+          "name": "placements",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "cart_item_user_id_user_id_fk": {
+          "name": "cart_item_user_id_user_id_fk",
+          "tableFrom": "cart_item",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "cart_item_design_id_design_id_fk": {
+          "name": "cart_item_design_id_design_id_fk",
+          "tableFrom": "cart_item",
+          "tableTo": "design",
+          "columnsFrom": [
+            "design_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "chat_message": {
+      "name": "chat_message",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "design_id": {
+          "name": "design_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image_id": {
+          "name": "image_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "chat_message_design_id_design_id_fk": {
+          "name": "chat_message_design_id_design_id_fk",
+          "tableFrom": "chat_message",
+          "tableTo": "design",
+          "columnsFrom": [
+            "design_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "design": {
+      "name": "design",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'draft'"
+        },
+        "primary_image_id": {
+          "name": "primary_image_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "generation_count": {
+          "name": "generation_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "generation_cost": {
+          "name": "generation_cost",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "mockup_urls": {
+          "name": "mockup_urls",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "original_designer_id": {
+          "name": "original_designer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "forked_from_image_id": {
+          "name": "forked_from_image_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "active_generator_id": {
+          "name": "active_generator_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "design_user_id_user_id_fk": {
+          "name": "design_user_id_user_id_fk",
+          "tableFrom": "design",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "design_image": {
+      "name": "design_image",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "design_id": {
+          "name": "design_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parent_image_id": {
+          "name": "parent_image_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "aspect_ratio": {
+          "name": "aspect_ratio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "placement_id": {
+          "name": "placement_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "generation_cost": {
+          "name": "generation_cost",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "is_approved": {
+          "name": "is_approved",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_hidden": {
+          "name": "is_hidden",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "background_color": {
+          "name": "background_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "generator": {
+          "name": "generator",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "design_image_design_id_design_id_fk": {
+          "name": "design_image_design_id_design_id_fk",
+          "tableFrom": "design_image",
+          "tableTo": "design",
+          "columnsFrom": [
+            "design_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "generation_usage": {
+      "name": "generation_usage",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bucket": {
+          "name": "bucket",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "day": {
+          "name": "day",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "generation_usage_bucket_day": {
+          "name": "generation_usage_bucket_day",
+          "columns": [
+            "bucket",
+            "day"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "ledger_entry": {
+      "name": "ledger_entry",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'USD'"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "ledger_entry_order_type_unique": {
+          "name": "ledger_entry_order_type_unique",
+          "columns": [
+            "order_id",
+            "type"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "ledger_entry_order_id_order_id_fk": {
+          "name": "ledger_entry_order_id_order_id_fk",
+          "tableFrom": "ledger_entry",
+          "tableTo": "order",
+          "columnsFrom": [
+            "order_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "order": {
+      "name": "order",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "design_id": {
+          "name": "design_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "placements": {
+          "name": "placements",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "printful_order_id": {
+          "name": "printful_order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "stripe_session_id": {
+          "name": "stripe_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "size": {
+          "name": "size",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'bella-canvas-3001'"
+        },
+        "store_id": {
+          "name": "store_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "store_product_id": {
+          "name": "store_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "quality": {
+          "name": "quality",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_price": {
+          "name": "total_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "item_price": {
+          "name": "item_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "shipping_price": {
+          "name": "shipping_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tax_collected": {
+          "name": "tax_collected",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "shipping_name": {
+          "name": "shipping_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "shipping_address1": {
+          "name": "shipping_address1",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "shipping_address2": {
+          "name": "shipping_address2",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "shipping_city": {
+          "name": "shipping_city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "shipping_state": {
+          "name": "shipping_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "shipping_zip": {
+          "name": "shipping_zip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "shipping_country": {
+          "name": "shipping_country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "stripe_payment_intent_id": {
+          "name": "stripe_payment_intent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tracking_number": {
+          "name": "tracking_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tracking_url": {
+          "name": "tracking_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "printful_cost": {
+          "name": "printful_cost",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "classification": {
+          "name": "classification",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "discount_code": {
+          "name": "discount_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "discount_amount": {
+          "name": "discount_amount",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "order_user_id_user_id_fk": {
+          "name": "order_user_id_user_id_fk",
+          "tableFrom": "order",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "order_design_id_design_id_fk": {
+          "name": "order_design_id_design_id_fk",
+          "tableFrom": "order",
+          "tableTo": "design",
+          "columnsFrom": [
+            "design_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "order_store_id_store_id_fk": {
+          "name": "order_store_id_store_id_fk",
+          "tableFrom": "order",
+          "tableTo": "store",
+          "columnsFrom": [
+            "store_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "order_store_product_id_product_id_fk": {
+          "name": "order_store_product_id_product_id_fk",
+          "tableFrom": "order",
+          "tableTo": "product",
+          "columnsFrom": [
+            "store_product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "order_item": {
+      "name": "order_item",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "design_id": {
+          "name": "design_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size": {
+          "name": "size",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "placements": {
+          "name": "placements",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "item_price": {
+          "name": "item_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "printful_cost": {
+          "name": "printful_cost",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "order_item_order_id_order_id_fk": {
+          "name": "order_item_order_id_order_id_fk",
+          "tableFrom": "order_item",
+          "tableTo": "order",
+          "columnsFrom": [
+            "order_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "order_item_design_id_design_id_fk": {
+          "name": "order_item_design_id_design_id_fk",
+          "tableFrom": "order_item",
+          "tableTo": "design",
+          "columnsFrom": [
+            "design_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "product": {
+      "name": "product",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "store_id": {
+          "name": "store_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "design_id": {
+          "name": "design_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "blank_id": {
+          "name": "blank_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "placements": {
+          "name": "placements",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "price": {
+          "name": "price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'draft'"
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "product_owner_id_user_id_fk": {
+          "name": "product_owner_id_user_id_fk",
+          "tableFrom": "product",
+          "tableTo": "user",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "product_store_id_store_id_fk": {
+          "name": "product_store_id_store_id_fk",
+          "tableFrom": "product",
+          "tableTo": "store",
+          "columnsFrom": [
+            "store_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "product_design_id_design_id_fk": {
+          "name": "product_design_id_design_id_fk",
+          "tableFrom": "product",
+          "tableTo": "design",
+          "columnsFrom": [
+            "design_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "product_offering": {
+      "name": "product_offering",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "printful_category_id": {
+          "name": "printful_category_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "available_from": {
+          "name": "available_from",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "available_until": {
+          "name": "available_until",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "store": {
+      "name": "store",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "accent_color": {
+          "name": "accent_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'draft'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "store_slug_unique": {
+          "name": "store_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "store_owner_id_user_id_fk": {
+          "name": "store_owner_id_user_id_fk",
+          "tableFrom": "store",
+          "tableTo": "user",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_anonymous": {
+          "name": "is_anonymous",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1782362549622,
       "tag": "0002_spicy_harrier",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "6",
+      "when": 1783284940115,
+      "tag": "0003_wide_sugar_man",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/cart/actions.ts
+++ b/src/app/cart/actions.ts
@@ -191,8 +191,8 @@ export async function getCart(): Promise<CartView> {
  * Turn the cart into an order and a Stripe Checkout session (#26 B4). The auth
  * gate lives here: anonymous guests get { needsAuth } and sign in first (the
  * cart re-parents to them on sign-in, so it survives). Writes the order +
- * order_item rows, charges N product lines + one bundled shipping line, then
- * clears the cart.
+ * order_item rows and charges N product lines + one bundled shipping line;
+ * the cart itself is cleared by the webhook on payment (#38).
  */
 export async function checkoutCart(): Promise<{
   url: string | null;
@@ -210,10 +210,15 @@ export async function checkoutCart(): Promise<{
   // Order-level row. designId/size/color/productId mirror the first line for
   // back-compat with single-item display code; the authoritative per-item data
   // lives in order_item. Price split is order-level (shipping once).
+  // Order + items commit together (#37) — a crash between the two inserts
+  // used to leave an order with no order_item rows, which would fulfill as
+  // single-item once paid. The id is pre-generated so both statements can be
+  // built before the batch.
   const head = view.items[0];
-  const [newOrder] = await db
-    .insert(orderTable)
-    .values({
+  const orderId = crypto.randomUUID();
+  await db.batch([
+    db.insert(orderTable).values({
+      id: orderId,
       userId,
       designId: head.designId,
       productId: head.productId,
@@ -222,25 +227,24 @@ export async function checkoutCart(): Promise<{
       totalPrice: view.total,
       itemPrice: view.itemSubtotal,
       shippingPrice: view.shipping,
-    })
-    .returning();
-
-  await db.insert(orderItemTable).values(
-    view.items.map((i) => ({
-      orderId: newOrder.id,
-      designId: i.designId,
-      productId: i.productId,
-      size: i.size,
-      color: i.color,
-      placements: i.placements,
-      quantity: i.quantity,
-      itemPrice: i.unitPrice,
-    }))
-  );
+    }),
+    db.insert(orderItemTable).values(
+      view.items.map((i) => ({
+        orderId,
+        designId: i.designId,
+        productId: i.productId,
+        size: i.size,
+        color: i.color,
+        placements: i.placements,
+        quantity: i.quantity,
+        itemPrice: i.unitPrice,
+      }))
+    ),
+  ]);
 
   const checkoutSession = await stripe.checkout.sessions.create(
     buildCartCheckoutSessionParams({
-      orderId: newOrder.id,
+      orderId,
       designId: head.designId,
       lineItems: view.items.map((i) => ({
         name: i.productName,
@@ -258,7 +262,7 @@ export async function checkoutCart(): Promise<{
   await db
     .update(orderTable)
     .set({ stripeSessionId: checkoutSession.id })
-    .where(eq(orderTable.id, newOrder.id));
+    .where(eq(orderTable.id, orderId));
 
   // The cart is NOT cleared here (#38): backing out of Stripe returns to the
   // cancel URL /cart, which must still hold the items. The webhook clears the

--- a/src/lib/__tests__/money-path.integration.test.ts
+++ b/src/lib/__tests__/money-path.integration.test.ts
@@ -676,3 +676,257 @@ describe("money path — Printful lifecycle events", () => {
     expect(entries[0].amount).toBe(-24.12);
   });
 });
+
+describe("money path — idempotency (#37)", () => {
+  let db: Db;
+  beforeEach(async () => {
+    db = await createTestDb();
+  });
+
+  it("a redelivery racing the live run rolls back whole: no double claim, no double ledger", async () => {
+    // Simulate the loser of the race: the winner has written the sale/fee rows
+    // but this delivery still read status=pending before the winner's claim
+    // landed. Its batch must trip the (order_id, type) unique index and roll
+    // back the claim with it.
+    const { order, design } = await seed(db);
+    await db.insert(schema.ledgerEntry).values([
+      { orderId: order.id, type: "sale", amount: 24.12, description: "winner" },
+      { orderId: order.id, type: "stripe_fee", amount: -1, description: "winner" },
+    ]);
+
+    const deps = makeDeps(db);
+    const result = await handleStripeCheckoutCompleted(
+      makeSession(order.id, design.id),
+      deps
+    );
+    expect(result.action).toBe("skipped");
+    expect(deps.createPrintfulOrder).not.toHaveBeenCalled();
+
+    // The conditional claim rolled back with the failed inserts.
+    const after = await db.query.order.findFirst({
+      where: eq(schema.order.id, order.id),
+    });
+    expect(after?.status).toBe("pending");
+
+    // Still exactly the winner's rows.
+    const entries = await ledgerFor(db, order.id);
+    expect(entries).toHaveLength(2);
+    expect(entries.every((e) => e.description === "winner")).toBe(true);
+  });
+
+  it("passes the order id to Printful as external_id", async () => {
+    const { order, design } = await seed(db);
+    const deps = makeDeps(db);
+    await handleStripeCheckoutCompleted(makeSession(order.id, design.id), deps);
+    expect(deps.createPrintfulOrder).toHaveBeenCalledWith(
+      expect.objectContaining({ externalId: order.id })
+    );
+  });
+
+  it("promo on a cart order: sale is the discounted total, shipping line intact", async () => {
+    const userId = "promo-cart-user";
+    await db
+      .insert(schema.user)
+      .values({ id: userId, email: "promo@example.com", name: "P" });
+    const [d1] = await db.insert(schema.design).values({ userId }).returning();
+    const [d2] = await db.insert(schema.design).values({ userId }).returning();
+    const [order] = await db
+      .insert(schema.order)
+      .values({
+        userId,
+        designId: d1.id,
+        productId: "bella-canvas-3001",
+        size: "M",
+        color: "Black",
+        itemPrice: 38.86,
+        shippingPrice: 4.69,
+        totalPrice: 43.55,
+        status: "pending",
+      })
+      .returning();
+    await db.insert(schema.orderItem).values([
+      { orderId: order.id, designId: d1.id, productId: "bella-canvas-3001", size: "M", color: "Black", placements: { front: "img-1" }, quantity: 1, itemPrice: 19.43 },
+      { orderId: order.id, designId: d2.id, productId: "bella-canvas-3001", size: "L", color: "White", placements: { front: "img-2" }, quantity: 1, itemPrice: 19.43 },
+    ]);
+
+    // 50% promo discounts the product lines only; shipping stays whole.
+    const result = await handleStripeCheckoutCompleted(
+      makeSession(order.id, d1.id, {
+        amountSubtotal: 1943, // 38.86 → 19.43 after 50%
+        amountShipping: 469,
+        amountTotal: 2412,
+        discount: { code: "HALFOFF", amount: 19.43 },
+      }),
+      makeDeps(db, {
+        resolveImageUrlById: vi
+          .fn()
+          .mockImplementation(async (id: string) => `https://img.example/${id}.png`),
+      })
+    );
+    expect(result.action).toBe("submitted");
+
+    const updated = await db.query.order.findFirst({
+      where: eq(schema.order.id, order.id),
+    });
+    expect(updated?.totalPrice).toBe(24.12);
+    expect(updated?.itemPrice).toBe(19.43);
+    expect(updated?.shippingPrice).toBe(4.69);
+    expect(updated?.discountCode).toBe("HALFOFF");
+
+    const entries = await ledgerFor(db, order.id);
+    const byType = Object.fromEntries(entries.map((e) => [e.type, e.amount]));
+    expect(byType.sale).toBe(24.12);
+    expect(byType.stripe_fee).toBe(-calculateStripeFee(24.12));
+  });
+
+  it("back placement inside a cart line reaches Printful as a second file", async () => {
+    const userId = "back-cart-user";
+    await db
+      .insert(schema.user)
+      .values({ id: userId, email: "back@example.com", name: "B" });
+    const [d1] = await db.insert(schema.design).values({ userId }).returning();
+    const [order] = await db
+      .insert(schema.order)
+      .values({
+        userId,
+        designId: d1.id,
+        productId: "bella-canvas-3001",
+        size: "M",
+        color: "Black",
+        itemPrice: 27.43,
+        shippingPrice: 4.69,
+        totalPrice: 32.12,
+        status: "pending",
+      })
+      .returning();
+    await db.insert(schema.orderItem).values([
+      { orderId: order.id, designId: d1.id, productId: "bella-canvas-3001", size: "M", color: "Black", placements: { front: "img-f", back: "img-b" }, quantity: 1, itemPrice: 27.43 },
+    ]);
+
+    const createPrintfulOrder = vi
+      .fn()
+      .mockResolvedValue({ id: 7777, costs: { total: "18.00" } });
+    const result = await handleStripeCheckoutCompleted(
+      makeSession(order.id, d1.id, {
+        amountSubtotal: 2743,
+        amountShipping: 469,
+        amountTotal: 3212,
+      }),
+      makeDeps(db, {
+        createPrintfulOrder,
+        resolveImageUrlById: vi
+          .fn()
+          .mockImplementation(async (id: string) => `https://img.example/${id}.png`),
+      })
+    );
+    expect(result.action).toBe("submitted");
+
+    const items = createPrintfulOrder.mock.calls[0][0].items as {
+      files: { placement: string; url: string }[];
+    }[];
+    expect(items).toHaveLength(1);
+    const placements = items[0].files.map((f) => f.placement).sort();
+    expect(placements).toEqual(["back", "front"]);
+    expect(items[0].files.find((f) => f.placement === "back")?.url).toBe(
+      "https://img.example/img-b.png"
+    );
+  });
+
+  it("cart order + Printful failure: paid with sale/fee recorded, no COGS, designs not ordered", async () => {
+    const userId = "fail-cart-user";
+    await db
+      .insert(schema.user)
+      .values({ id: userId, email: "fail@example.com", name: "F" });
+    const [d1] = await db.insert(schema.design).values({ userId }).returning();
+    const [d2] = await db.insert(schema.design).values({ userId }).returning();
+    const [order] = await db
+      .insert(schema.order)
+      .values({
+        userId,
+        designId: d1.id,
+        productId: "bella-canvas-3001",
+        size: "M",
+        color: "Black",
+        itemPrice: 38.86,
+        shippingPrice: 4.69,
+        totalPrice: 43.55,
+        status: "pending",
+      })
+      .returning();
+    await db.insert(schema.orderItem).values([
+      { orderId: order.id, designId: d1.id, productId: "bella-canvas-3001", size: "M", color: "Black", placements: { front: "img-1" }, quantity: 1, itemPrice: 19.43 },
+      { orderId: order.id, designId: d2.id, productId: "bella-canvas-3001", size: "L", color: "White", placements: { front: "img-2" }, quantity: 1, itemPrice: 19.43 },
+    ]);
+
+    const result = await handleStripeCheckoutCompleted(
+      makeSession(order.id, d1.id, {
+        amountSubtotal: 3886,
+        amountShipping: 469,
+        amountTotal: 4355,
+      }),
+      makeDeps(db, {
+        createPrintfulOrder: vi.fn().mockRejectedValue(new Error("Printful 500")),
+        resolveImageUrlById: vi
+          .fn()
+          .mockImplementation(async (id: string) => `https://img.example/${id}.png`),
+      })
+    );
+    expect(result.action).toBe("paid_printful_failed");
+
+    const updated = await db.query.order.findFirst({
+      where: eq(schema.order.id, order.id),
+    });
+    expect(updated?.status).toBe("paid");
+
+    for (const id of [d1.id, d2.id]) {
+      const dd = await db.query.design.findFirst({
+        where: eq(schema.design.id, id),
+      });
+      expect(dd?.status).toBe("draft");
+    }
+
+    const entries = await ledgerFor(db, order.id);
+    const types = entries.map((e) => e.type).sort();
+    expect(types).toEqual(["sale", "stripe_fee"]);
+  });
+});
+
+describe("Printful webhook — redelivery (#37)", () => {
+  let db: Db;
+  beforeEach(async () => {
+    db = await createTestDb();
+  });
+
+  it("package_shipped redelivery on a shipped order is acknowledged, not a 400", async () => {
+    const { order } = await seed(db, {
+      status: "shipped",
+      printfulOrderId: "pf-1",
+    });
+    const result = await handlePrintfulEvent(
+      {
+        type: "package_shipped",
+        data: { order: { id: "pf-1" }, shipment: { tracking_number: "T1" } },
+      },
+      { db }
+    );
+    expect(result.action).toBe("ignored");
+    expect(result.orderId).toBe(order.id);
+  });
+
+  it("order_canceled redelivery keeps exactly one refund row", async () => {
+    const { order } = await seed(db, {
+      status: "submitted",
+      printfulOrderId: "pf-2",
+    });
+    const payload = { type: "order_canceled", data: { order: { id: "pf-2" } } };
+
+    const first = await handlePrintfulEvent(payload, { db });
+    expect(first.action).toBe("canceled");
+
+    const second = await handlePrintfulEvent(payload, { db });
+    expect(second.action).toBe("ignored");
+
+    const entries = await ledgerFor(db, order.id);
+    expect(entries.filter((e) => e.type === "refund")).toHaveLength(1);
+  });
+});

--- a/src/lib/__tests__/reparent-user.integration.test.ts
+++ b/src/lib/__tests__/reparent-user.integration.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Guest→account claim (#37): reparentUserData must move EVERY user-owned table
+ * in one atomic batch — the anonymous plugin deletes the anon user right after,
+ * so anything left behind gets cascaded away. One seeded row per table doubles
+ * as the checklist when new user-owned tables land (conversation/image model).
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+import { eq } from "drizzle-orm";
+import { createTestDb } from "./test-db";
+import * as schema from "@/lib/db/schema";
+import { reparentUserData } from "@/lib/reparent-user";
+
+type Db = Awaited<ReturnType<typeof createTestDb>>;
+
+describe("reparentUserData", () => {
+  let db: Db;
+  beforeEach(async () => {
+    db = await createTestDb();
+    await db.insert(schema.user).values([
+      { id: "anon-1", email: "anon@example.com", name: "Guest" },
+      { id: "real-1", email: "real@example.com", name: "Real" },
+    ]);
+  });
+
+  it("re-parents one row per user-owned table", async () => {
+    const [design] = await db
+      .insert(schema.design)
+      .values({ userId: "anon-1" })
+      .returning();
+    const [order] = await db
+      .insert(schema.order)
+      .values({
+        userId: "anon-1",
+        designId: design.id,
+        productId: "bella-canvas-3001",
+        size: "M",
+        color: "Black",
+        totalPrice: 24.12,
+        status: "pending",
+      })
+      .returning();
+    const [cart] = await db
+      .insert(schema.cartItem)
+      .values({
+        userId: "anon-1",
+        designId: design.id,
+        productId: "bella-canvas-3001",
+        size: "M",
+        color: "Black",
+      })
+      .returning();
+    const [store] = await db
+      .insert(schema.store)
+      .values({ ownerId: "anon-1", slug: "guest-shop", name: "Guest Shop" })
+      .returning();
+    const [product] = await db
+      .insert(schema.product)
+      .values({
+        ownerId: "anon-1",
+        designId: design.id,
+        blankId: "bella-canvas-3001",
+      })
+      .returning();
+
+    await reparentUserData(db, "anon-1", "real-1");
+
+    expect(
+      (await db.query.design.findFirst({ where: eq(schema.design.id, design.id) }))
+        ?.userId
+    ).toBe("real-1");
+    expect(
+      (await db.query.order.findFirst({ where: eq(schema.order.id, order.id) }))
+        ?.userId
+    ).toBe("real-1");
+    expect(
+      (await db.query.cartItem.findFirst({ where: eq(schema.cartItem.id, cart.id) }))
+        ?.userId
+    ).toBe("real-1");
+    expect(
+      (await db.query.store.findFirst({ where: eq(schema.store.id, store.id) }))
+        ?.ownerId
+    ).toBe("real-1");
+    expect(
+      (await db.query.product.findFirst({ where: eq(schema.product.id, product.id) }))
+        ?.ownerId
+    ).toBe("real-1");
+
+    // Nothing still points at the anon user.
+    expect(
+      await db.query.design.findMany({ where: eq(schema.design.userId, "anon-1") })
+    ).toHaveLength(0);
+    expect(
+      await db.query.cartItem.findMany({
+        where: eq(schema.cartItem.userId, "anon-1"),
+      })
+    ).toHaveLength(0);
+  });
+
+  it("no-ops when from and to are the same user", async () => {
+    await db.insert(schema.design).values({ userId: "anon-1" });
+    await reparentUserData(db, "anon-1", "anon-1");
+    expect(
+      await db.query.design.findMany({ where: eq(schema.design.userId, "anon-1") })
+    ).toHaveLength(1);
+  });
+
+  it("leaves the other user's rows alone", async () => {
+    await db.insert(schema.design).values({ userId: "real-1" });
+    await db.insert(schema.design).values({ userId: "anon-1" });
+    await reparentUserData(db, "anon-1", "real-1");
+    expect(
+      await db.query.design.findMany({ where: eq(schema.design.userId, "real-1") })
+    ).toHaveLength(2);
+  });
+});

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -2,16 +2,9 @@ import { betterAuth } from "better-auth";
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
 import { nextCookies } from "better-auth/next-js";
 import { anonymous } from "better-auth/plugins/anonymous";
-import { eq } from "drizzle-orm";
 import { db } from "./db";
 import * as schema from "./db/schema";
-import {
-  design as designTable,
-  order as orderTable,
-  cartItem as cartItemTable,
-  store as storeTable,
-  product as productTable,
-} from "./db/schema";
+import { reparentUserData } from "./reparent-user";
 import { sendPasswordResetEmail } from "./email";
 
 // The auth client resolves to same-origin, so requests come from whatever
@@ -58,34 +51,9 @@ export const auth = betterAuth({
     // real account on sign-in/up — it runs BEFORE the plugin deletes the anon
     // user (better-auth 1.5.6 after-hook order), so the FK re-pointing is safe.
     anonymous({
+      // One atomic batch (#37) — see reparentUserData for the why.
       onLinkAccount: async ({ anonymousUser, newUser }) => {
-        const fromId = anonymousUser.user.id;
-        const toId = newUser.user.id;
-        if (fromId === toId) return;
-        // design_image + chat_message follow via design_id. design, order, and
-        // the persistent cart re-parent by userId.
-        await db
-          .update(designTable)
-          .set({ userId: toId })
-          .where(eq(designTable.userId, fromId));
-        await db
-          .update(orderTable)
-          .set({ userId: toId })
-          .where(eq(orderTable.userId, fromId));
-        await db
-          .update(cartItemTable)
-          .set({ userId: toId })
-          .where(eq(cartItemTable.userId, fromId));
-        // Organizer pivot (Phase 1): a guest can build a store + products
-        // before signing up; re-parent both by ownerId on claim.
-        await db
-          .update(storeTable)
-          .set({ ownerId: toId })
-          .where(eq(storeTable.ownerId, fromId));
-        await db
-          .update(productTable)
-          .set({ ownerId: toId })
-          .where(eq(productTable.ownerId, fromId));
+        await reparentUserData(db, anonymousUser.user.id, newUser.user.id);
       },
     }),
     nextCookies(),

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -283,16 +283,24 @@ export const product = sqliteTable("product", {
   updatedAt: integer("updated_at", { mode: "timestamp" }).notNull().$defaultFn(() => new Date()),
 });
 
-export const ledgerEntry = sqliteTable("ledger_entry", {
-  id: text("id").primaryKey().$defaultFn(() => crypto.randomUUID()),
-  orderId: text("order_id").references(() => order.id),
-  type: text("type").notNull(), // sale, stripe_fee, cogs, refund, refund_cogs_reversal
-  amount: real("amount").notNull(), // positive = money in, negative = money out
-  currency: text("currency").notNull().default("USD"),
-  description: text("description").notNull(),
-  metadata: text("metadata", { mode: "json" }).$type<Record<string, unknown>>(),
-  createdAt: integer("created_at", { mode: "timestamp" }).notNull().$defaultFn(() => new Date()),
-});
+export const ledgerEntry = sqliteTable(
+  "ledger_entry",
+  {
+    id: text("id").primaryKey().$defaultFn(() => crypto.randomUUID()),
+    orderId: text("order_id").references(() => order.id),
+    type: text("type").notNull(), // sale, stripe_fee, cogs, refund, refund_cogs_reversal
+    amount: real("amount").notNull(), // positive = money in, negative = money out
+    currency: text("currency").notNull().default("USD"),
+    description: text("description").notNull(),
+    metadata: text("metadata", { mode: "json" }).$type<Record<string, unknown>>(),
+    createdAt: integer("created_at", { mode: "timestamp" }).notNull().$defaultFn(() => new Date()),
+  },
+  // #37 idempotency backstop: every current entry type occurs at most once per
+  // order, so a webhook redelivery that races the live run trips this index and
+  // its whole db.batch rolls back. Rows with NULL order_id (manual entries) are
+  // exempt — SQLite treats NULLs as distinct in unique indexes.
+  (t) => [uniqueIndex("ledger_entry_order_type_unique").on(t.orderId, t.type)]
+);
 
 /**
  * Per-day generation counters for the guest-funnel abuse guard (#26 A3).

--- a/src/lib/ledger.ts
+++ b/src/lib/ledger.ts
@@ -33,15 +33,21 @@ export function summarizeLedger(byType: Record<string, number>) {
   };
 }
 
-export async function recordSale(
+type LedgerRow = typeof ledgerEntry.$inferInsert;
+
+/**
+ * Pure row builders (#37): the values for each once-per-order ledger write,
+ * returned instead of inserted so callers can compose them into a `db.batch`
+ * with the status update they must be atomic with. The record* wrappers below
+ * keep the standalone-insert API for callers with no batching need.
+ */
+export function saleLedgerRows(
   orderId: string,
   amount: number,
-  description: string,
-  db: DbInstance
-) {
+  description: string
+): LedgerRow[] {
   const stripeFee = calculateStripeFee(amount);
-
-  await db.insert(ledgerEntry).values([
+  return [
     {
       orderId,
       type: "sale",
@@ -56,7 +62,43 @@ export async function recordSale(
       description: `Stripe processing fee (2.9% + $0.30)`,
       metadata: { rate: STRIPE_FEE_RATE, fixed: STRIPE_FEE_FIXED },
     },
-  ]);
+  ];
+}
+
+export function cogsLedgerRow(
+  orderId: string,
+  printfulCost: number,
+  description: string
+): LedgerRow {
+  return {
+    orderId,
+    type: "cogs",
+    amount: -printfulCost,
+    description,
+  };
+}
+
+export function refundLedgerRow(
+  orderId: string,
+  originalAmount: number,
+  description: string
+): LedgerRow {
+  return {
+    orderId,
+    type: "refund",
+    amount: -originalAmount,
+    description,
+    metadata: { note: "Order canceled before fulfillment, refund pending" },
+  };
+}
+
+export async function recordSale(
+  orderId: string,
+  amount: number,
+  description: string,
+  db: DbInstance
+) {
+  await db.insert(ledgerEntry).values(saleLedgerRows(orderId, amount, description));
 }
 
 export async function recordCOGS(
@@ -65,12 +107,7 @@ export async function recordCOGS(
   description: string,
   db: DbInstance
 ) {
-  await db.insert(ledgerEntry).values({
-    orderId,
-    type: "cogs",
-    amount: -printfulCost,
-    description,
-  });
+  await db.insert(ledgerEntry).values(cogsLedgerRow(orderId, printfulCost, description));
 }
 
 export async function recordCancellation(
@@ -79,11 +116,15 @@ export async function recordCancellation(
   description: string,
   db: DbInstance
 ) {
-  await db.insert(ledgerEntry).values({
-    orderId,
-    type: "refund",
-    amount: -originalAmount,
-    description,
-    metadata: { note: "Order canceled before fulfillment, refund pending" },
-  });
+  await db.insert(ledgerEntry).values(refundLedgerRow(orderId, originalAmount, description));
+}
+
+/**
+ * True when an error is SQLite/libSQL's unique-constraint rejection — the
+ * signal that a concurrent or redelivered webhook already wrote this order's
+ * ledger rows (the whole batch rolled back; nothing was applied).
+ */
+export function isUniqueViolation(err: unknown): boolean {
+  const message = err instanceof Error ? err.message : String(err);
+  return /UNIQUE constraint failed/i.test(message);
 }

--- a/src/lib/order-fulfillment.ts
+++ b/src/lib/order-fulfillment.ts
@@ -11,11 +11,15 @@
  * fulfillable lines stays `paid` for admin follow-up.
  */
 import { eq } from "drizzle-orm";
-import { order as orderTable, design as designTable } from "@/lib/db/schema";
+import {
+  order as orderTable,
+  design as designTable,
+  ledgerEntry,
+} from "@/lib/db/schema";
 import { resolveOrderLines, type OrderItemRow } from "@/lib/order-lines";
 import { getBlank, getVariantId } from "@/lib/blanks";
 import { assertTransition } from "@/lib/order-state";
-import { recordCOGS } from "@/lib/ledger";
+import { cogsLedgerRow } from "@/lib/ledger";
 import type { createOrder, PrintfulOrderItem } from "@/lib/printful";
 import type { db as appDb } from "@/lib/db";
 import type { generateOrderName } from "@/lib/ai";
@@ -150,6 +154,10 @@ export async function submitOrderFulfillment(
   try {
     const printfulOrder = await deps.createPrintfulOrder({
       items,
+      // Our order id as Printful's external reference (#37): makes the
+      // Printful order traceable to ours, and a duplicate submission of the
+      // same order gets rejected by Printful instead of printing twice.
+      externalId: orderId,
       recipientName: shipping?.name ?? "",
       address1: shipping?.address1 ?? "",
       address2: shipping?.address2 || undefined,
@@ -165,7 +173,11 @@ export async function submitOrderFulfillment(
       ? parseFloat(printfulOrder.costs.total)
       : null;
 
-    await deps.db
+    // Submitted-update, design flips, and the COGS row commit together (#37):
+    // a crash mid-tail can't leave a submitted order with no COGS on the
+    // books (the gap the admin-retry bug hid until PR #42).
+    const designIds = [...new Set(lines.map((l) => l.designId))];
+    const submittedUpdate = deps.db
       .update(orderTable)
       .set({
         status: "submitted",
@@ -174,23 +186,26 @@ export async function submitOrderFulfillment(
         updatedAt: new Date(),
       })
       .where(eq(orderTable.id, orderId));
-
-    // Mark every distinct design in the order as ordered.
-    const designIds = [...new Set(lines.map((l) => l.designId))];
-    for (const designId of designIds) {
-      await deps.db
+    const designUpdates = designIds.map((designId) =>
+      deps.db
         .update(designTable)
         .set({ status: "ordered", updatedAt: new Date() })
-        .where(eq(designTable.id, designId));
-    }
-
+        .where(eq(designTable.id, designId))
+    );
     if (printfulCost && printfulCost > 0) {
-      await recordCOGS(
-        orderId,
-        printfulCost,
-        `Printful fulfillment PF:${printfulOrder.id}${items.length > 1 ? ` (${items.length} items)` : ""}`,
-        deps.db
-      );
+      await deps.db.batch([
+        submittedUpdate,
+        ...designUpdates,
+        deps.db.insert(ledgerEntry).values(
+          cogsLedgerRow(
+            orderId,
+            printfulCost,
+            `Printful fulfillment PF:${printfulOrder.id}${items.length > 1 ? ` (${items.length} items)` : ""}`
+          )
+        ),
+      ]);
+    } else {
+      await deps.db.batch([submittedUpdate, ...designUpdates]);
     }
 
     return { action: "submitted", printfulOrderId: String(printfulOrder.id) };

--- a/src/lib/printful.ts
+++ b/src/lib/printful.ts
@@ -49,6 +49,9 @@ export async function createOrder(params: {
   // Multi-item cart (#26): a full array of line items. When present it takes
   // precedence over the single-item fields below.
   items?: PrintfulOrderItem[];
+  // Our order id, sent as Printful's external_id (#37): traceability plus
+  // Printful-side rejection of a duplicate submission of the same order.
+  externalId?: string;
   size?: string;
   color?: string;
   variantId?: number;
@@ -94,6 +97,7 @@ export async function createOrder(params: {
   const data = await printfulFetch(`/orders${confirm ? "?confirm=true" : ""}`, {
     method: "POST",
     body: JSON.stringify({
+      ...(params.externalId ? { external_id: params.externalId } : {}),
       recipient: {
         name: params.recipientName,
         address1: params.address1,

--- a/src/lib/reparent-user.ts
+++ b/src/lib/reparent-user.ts
@@ -1,0 +1,36 @@
+import { eq } from "drizzle-orm";
+import type { db as appDb } from "@/lib/db";
+import {
+  design as designTable,
+  order as orderTable,
+  cartItem as cartItemTable,
+  store as storeTable,
+  product as productTable,
+} from "@/lib/db/schema";
+
+/**
+ * Re-parent every user-owned row from one user id to another — the guest→
+ * account claim (auth.ts onLinkAccount). One db.batch (#37): the anonymous
+ * plugin deletes the anon user right after this runs, so a crash between
+ * sequential updates used to orphan the not-yet-moved tables (cart, store,
+ * product) for the cleanup to cascade away. Atomic now: all moved or none.
+ *
+ * design_image + chat_message follow via design_id; everything else owns a
+ * user/owner column directly. When the conversation/image migration adds
+ * tables, extend this list — the integration test seeds one row per table as
+ * the checklist.
+ */
+export async function reparentUserData(
+  db: typeof appDb,
+  fromId: string,
+  toId: string
+): Promise<void> {
+  if (fromId === toId) return;
+  await db.batch([
+    db.update(designTable).set({ userId: toId }).where(eq(designTable.userId, fromId)),
+    db.update(orderTable).set({ userId: toId }).where(eq(orderTable.userId, fromId)),
+    db.update(cartItemTable).set({ userId: toId }).where(eq(cartItemTable.userId, fromId)),
+    db.update(storeTable).set({ ownerId: toId }).where(eq(storeTable.ownerId, fromId)),
+    db.update(productTable).set({ ownerId: toId }).where(eq(productTable.ownerId, fromId)),
+  ]);
+}

--- a/src/lib/webhook-handlers.ts
+++ b/src/lib/webhook-handlers.ts
@@ -1,11 +1,12 @@
 import { and, eq } from "drizzle-orm";
 import {
   cartItem as cartItemTable,
+  ledgerEntry,
   order as orderTable,
   orderItem as orderItemTable,
 } from "@/lib/db/schema";
 import { assertTransition } from "@/lib/order-state";
-import { recordSale, recordCancellation } from "@/lib/ledger";
+import { saleLedgerRows, refundLedgerRow, isUniqueViolation } from "@/lib/ledger";
 import {
   submitOrderFulfillment,
   type FulfillmentDeps,
@@ -86,37 +87,49 @@ export async function handleStripeCheckoutCompleted(
     ? session.amountShipping / 100
     : foundOrder.shippingPrice;
 
-  // Mark as paid with shipping details + discount info
-  await deps.db
-    .update(orderTable)
-    .set({
-      status: "paid",
-      classification: "customer",
-      stripeSessionId: session.id,
-      stripePaymentIntentId: session.paymentIntentId,
-      totalPrice: actualTotal,
-      itemPrice,
-      shippingPrice,
-      discountCode: session.discount?.code ?? null,
-      discountAmount: session.discount?.amount ?? null,
-      shippingName: session.shipping?.name ?? "",
-      shippingAddress1: session.shipping?.address1 ?? "",
-      shippingAddress2: session.shipping?.address2 ?? "",
-      shippingCity: session.shipping?.city ?? "",
-      shippingState: session.shipping?.state ?? "",
-      shippingZip: session.shipping?.zip ?? "",
-      shippingCountry: session.shipping?.country ?? "US",
-      updatedAt: new Date(),
-    })
-    .where(eq(orderTable.id, orderId));
-
-  // Record sale + Stripe fee in ledger (using actual amount charged)
-  await recordSale(
-    orderId,
-    actualTotal,
-    `Order ${orderId.slice(0, 8)} — ${foundOrder.color} ${foundOrder.size}${session.discount ? ` (${session.discount.code} -$${session.discount.amount.toFixed(2)})` : ""}`,
-    deps.db
-  );
+  // Atomic claim (#37): the paid-update and the sale/fee ledger rows commit
+  // together, and the claim is conditional on status still being `pending` —
+  // so a redelivery racing the live run (Stripe retries past its timeout while
+  // the slow tail is still working) cannot double-process. The loser's batch
+  // trips the ledger_entry (order_id, type) unique index and rolls back whole:
+  // it neither re-marks the order nor doubles the ledger.
+  try {
+    const [claim] = await deps.db.batch([
+      deps.db
+        .update(orderTable)
+        .set({
+          status: "paid",
+          classification: "customer",
+          stripeSessionId: session.id,
+          stripePaymentIntentId: session.paymentIntentId,
+          totalPrice: actualTotal,
+          itemPrice,
+          shippingPrice,
+          discountCode: session.discount?.code ?? null,
+          discountAmount: session.discount?.amount ?? null,
+          shippingName: session.shipping?.name ?? "",
+          shippingAddress1: session.shipping?.address1 ?? "",
+          shippingAddress2: session.shipping?.address2 ?? "",
+          shippingCity: session.shipping?.city ?? "",
+          shippingState: session.shipping?.state ?? "",
+          shippingZip: session.shipping?.zip ?? "",
+          shippingCountry: session.shipping?.country ?? "US",
+          updatedAt: new Date(),
+        })
+        .where(and(eq(orderTable.id, orderId), eq(orderTable.status, "pending"))),
+      deps.db.insert(ledgerEntry).values(
+        saleLedgerRows(
+          orderId,
+          actualTotal,
+          `Order ${orderId.slice(0, 8)} — ${foundOrder.color} ${foundOrder.size}${session.discount ? ` (${session.discount.code} -$${session.discount.amount.toFixed(2)})` : ""}`
+        )
+      ),
+    ]);
+    if (claim.rowsAffected === 0) return { action: "skipped" };
+  } catch (err) {
+    if (isUniqueViolation(err)) return { action: "skipped" };
+    throw err;
+  }
 
   // Fulfillment: one shared tail for single-item (legacy scalar) and cart
   // (order_item) orders — resolveOrderLines inside submitOrderFulfillment
@@ -163,6 +176,12 @@ export async function handlePrintfulEvent(
   }
 
   if (payload.type === "package_shipped") {
+    // Redelivery (#37): Printful retries until it gets a 2xx, and repeated
+    // 400s can get the webhook disabled. Already at (or past) the target
+    // status → acknowledge and do nothing.
+    if (foundOrder.status === "shipped" || foundOrder.status === "delivered") {
+      return { action: "ignored", orderId: foundOrder.id };
+    }
     assertTransition(foundOrder.status, "shipped");
 
     const shipment = payload.data?.shipment;
@@ -183,24 +202,32 @@ export async function handlePrintfulEvent(
   }
 
   if (payload.type === "order_canceled") {
+    // Redelivery (#37): same 200-on-repeat contract as package_shipped, and
+    // it also prevents a doubled refund ledger row.
+    if (foundOrder.status === "canceled") {
+      return { action: "ignored", orderId: foundOrder.id };
+    }
     assertTransition(foundOrder.status, "canceled");
 
-    await deps.db
-      .update(orderTable)
-      .set({
-        status: "canceled",
-        printfulCost: 0,
-        updatedAt: new Date(),
-      })
-      .where(eq(orderTable.id, foundOrder.id));
-
-    // Record cancellation reversal in ledger
-    await recordCancellation(
-      foundOrder.id,
-      foundOrder.totalPrice,
-      `Order ${foundOrder.id.slice(0, 8)} canceled — Printful ${printfulOrderId}`,
+    // Cancel-update + refund ledger row commit together (#37) — a crash
+    // between them can't leave a canceled order with no refund on the books.
+    await deps.db.batch([
       deps.db
-    );
+        .update(orderTable)
+        .set({
+          status: "canceled",
+          printfulCost: 0,
+          updatedAt: new Date(),
+        })
+        .where(eq(orderTable.id, foundOrder.id)),
+      deps.db.insert(ledgerEntry).values(
+        refundLedgerRow(
+          foundOrder.id,
+          foundOrder.totalPrice,
+          `Order ${foundOrder.id.slice(0, 8)} canceled — Printful ${printfulOrderId}`
+        )
+      ),
+    ]);
 
     return { action: "canceled", orderId: foundOrder.id };
   }


### PR DESCRIPTION
Closes #37 (WP2 from the 2026-07-04 multi-agent review). Every finding addressed:

## Stripe webhook double-fulfillment
- The paid-claim is a conditional update (`WHERE status='pending'`) **batched with the sale/fee ledger inserts**. A redelivery racing the live run trips the new `ledger_entry (order_id, type)` unique index → its whole batch rolls back atomically → `skipped`. One Printful order, one set of ledger rows, no matter how Stripe retries.
- The same batch closes the crash window between paid-update and `recordSale` — they commit together.

## Backstops
- `drizzle/0003`: unique index on `ledger_entry (order_id, type)`. Additive; **prod and preview verified duplicate-free** before generating; applied to dev; CI applies to preview. NULL `order_id` rows (manual entries) exempt. **Prod apply after merge** (inline-token `db:migrate` + backup branch, per migration discipline).
- Printful `createOrder` now sends `external_id = orderId` — traceable, and Printful rejects a duplicate submission of the same order.

## Printful webhook redelivery
- `package_shipped` / `order_canceled` at (or past) target status → 200 `ignored` instead of 400 (repeated 400s can get the webhook disabled).
- Cancel-update + refund ledger row batched.

## Claim + checkout atomicity
- `onLinkAccount`: five sequential re-parent updates → one `db.batch` in new `src/lib/reparent-user.ts`. New integration test seeds one row per user-owned table — the checklist for the conversation/image migration.
- `checkoutCart`: order + order_item inserts batched with a pre-generated id.

## Ledger
- Pure `saleLedgerRows` / `cogsLedgerRow` / `refundLedgerRow` builders; `record*` wrappers unchanged for existing callers. `isUniqueViolation` helper.

## Tests (452 pass; lint/build green)
Race-loser rollback (claim + ledger roll back together on real libSQL), `external_id` pass-through, promo×cart, back-placement-inside-cart, cart-Printful-failure, Printful redelivery ×2, reparent checklist. Local e2e green (one known parallel-load flake in guest-funnel desktop, passes isolated + in CI; store-compose exercises the batched claim live).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HrvM3mNXB9y16166EgXsv7