### PR TITLE
feat(fulfillment): daily cron retry for stuck orders + naming off payment path (#39)

### DIFF
--- a/src/app/api/cron/retry-fulfillment/route.ts
+++ b/src/app/api/cron/retry-fulfillment/route.ts
@@ -1,0 +1,37 @@
+import { NextRequest, NextResponse } from "next/server";
+import { db } from "@/lib/db";
+import { createOrder } from "@/lib/printful";
+import { generateOrderName } from "@/lib/ai";
+import { retryStuckFulfillments } from "@/lib/retry-fulfillment";
+import { getDesignDisplayImageUrl, getDesignImageById } from "@/lib/design-images";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 60;
+
+// Durability sweep (#39). Vercel Cron hits this daily; the core lives in
+// retry-fulfillment.ts. See that file for the paid-but-unsubmitted rationale
+// and guardrails.
+export async function GET(request: NextRequest) {
+  // Vercel Cron injects `Authorization: Bearer ${CRON_SECRET}` on scheduled
+  // calls. Require it so the endpoint isn't publicly triggerable; treat a
+  // missing secret as misconfiguration rather than an open door.
+  const secret = process.env.CRON_SECRET;
+  if (!secret) {
+    console.error("retry-fulfillment: CRON_SECRET not set");
+    return NextResponse.json({ error: "Not configured" }, { status: 500 });
+  }
+  if (request.headers.get("authorization") !== `Bearer ${secret}`) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const result = await retryStuckFulfillments({
+    db,
+    createPrintfulOrder: createOrder,
+    generateOrderName,
+    resolveDesignImageUrl: getDesignDisplayImageUrl,
+    resolveImageUrlById: async (imageId) =>
+      (await getDesignImageById(imageId))?.imageUrl ?? null,
+  });
+
+  return NextResponse.json(result);
+}

--- a/src/lib/__tests__/retry-fulfillment.integration.test.ts
+++ b/src/lib/__tests__/retry-fulfillment.integration.test.ts
@@ -1,0 +1,228 @@
+/**
+ * Durability sweep (#39) + order-naming-off-the-payment-path, on the real
+ * in-memory libSQL harness. Covers which paid-but-unsubmitted orders the cron
+ * picks up (floor/ceil/limit), that a Printful failure leaves the order paid
+ * without aborting the sweep, and that naming now runs AFTER submission and
+ * fails soft (a broken naming call never blocks the shirt).
+ */
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { eq } from "drizzle-orm";
+import { createTestDb } from "./test-db";
+import * as schema from "@/lib/db/schema";
+import { submitOrderFulfillment, type FulfillmentDeps } from "@/lib/order-fulfillment";
+import { retryStuckFulfillments } from "@/lib/retry-fulfillment";
+
+type Db = Awaited<ReturnType<typeof createTestDb>>;
+
+const HOUR = 60 * 60 * 1000;
+
+function makeDeps(db: Db, overrides: Partial<FulfillmentDeps> = {}): FulfillmentDeps {
+  return {
+    db,
+    createPrintfulOrder: vi
+      .fn()
+      .mockResolvedValue({ id: 9999, costs: { total: "12.50" } }),
+    generateOrderName: vi.fn().mockResolvedValue("Named Order"),
+    resolveDesignImageUrl: vi.fn().mockResolvedValue("https://img.example/x.png"),
+    ...overrides,
+  } as unknown as FulfillmentDeps;
+}
+
+/** Seed a paid, unsubmitted order with a controllable updatedAt age. */
+async function seedStuck(
+  db: Db,
+  { ageMs = HOUR, overrides = {} }: { ageMs?: number; overrides?: Partial<typeof schema.order.$inferInsert> } = {}
+) {
+  const userId = `u-${Math.round(ageMs)}-${Object.keys(overrides).length}-${Math.random().toString(36).slice(2)}`;
+  await db.insert(schema.user).values({ id: userId, email: `${userId}@example.com`, name: "U" });
+  const [design] = await db.insert(schema.design).values({ userId }).returning();
+  const updatedAt = new Date(Date.now() - ageMs);
+  const [order] = await db
+    .insert(schema.order)
+    .values({
+      userId,
+      designId: design.id,
+      productId: "bella-canvas-3001",
+      size: "M",
+      color: "Black",
+      totalPrice: 24.12,
+      itemPrice: 19.43,
+      shippingPrice: 4.69,
+      status: "paid",
+      shippingName: "Jane Doe",
+      shippingAddress1: "1 Main St",
+      shippingCity: "Town",
+      shippingState: "CA",
+      shippingZip: "90001",
+      shippingCountry: "US",
+      updatedAt,
+      ...overrides,
+    })
+    .returning();
+  return { userId, design, order };
+}
+
+describe("retryStuckFulfillments (#39)", () => {
+  let db: Db;
+  beforeEach(async () => {
+    db = await createTestDb();
+  });
+
+  it("retries a stuck paid order and submits it to Printful", async () => {
+    const { order } = await seedStuck(db);
+    const deps = makeDeps(db);
+
+    const res = await retryStuckFulfillments(deps);
+
+    expect(res.scanned).toBe(1);
+    expect(res.results).toEqual([{ orderId: order.id, action: "submitted" }]);
+    expect(deps.createPrintfulOrder).toHaveBeenCalledWith(
+      expect.objectContaining({ externalId: order.id })
+    );
+
+    const updated = await db.query.order.findFirst({
+      where: eq(schema.order.id, order.id),
+    });
+    expect(updated?.status).toBe("submitted");
+    expect(updated?.printfulOrderId).toBe("9999");
+  });
+
+  it("skips orders inside the 10-min floor (too fresh — may be an in-flight webhook)", async () => {
+    await seedStuck(db, { ageMs: 2 * 60 * 1000 });
+    const deps = makeDeps(db);
+
+    const res = await retryStuckFulfillments(deps);
+
+    expect(res.scanned).toBe(0);
+    expect(deps.createPrintfulOrder).not.toHaveBeenCalled();
+  });
+
+  it("skips orders past the 24h ceiling (left for admin)", async () => {
+    await seedStuck(db, { ageMs: 25 * HOUR });
+    const deps = makeDeps(db);
+
+    const res = await retryStuckFulfillments(deps);
+
+    expect(res.scanned).toBe(0);
+    expect(deps.createPrintfulOrder).not.toHaveBeenCalled();
+  });
+
+  it("ignores orders that already submitted (have a printfulOrderId)", async () => {
+    await seedStuck(db, { overrides: { status: "submitted", printfulOrderId: "already" } });
+    const deps = makeDeps(db);
+
+    const res = await retryStuckFulfillments(deps);
+
+    expect(res.scanned).toBe(0);
+  });
+
+  it("a Printful failure leaves the order paid and does not abort the sweep", async () => {
+    const { order: failOrder } = await seedStuck(db);
+    const { order: okOrder } = await seedStuck(db, { ageMs: 2 * HOUR });
+    // Key the mock on externalId (= our order id), so the outcome is
+    // deterministic regardless of the sweep's processing order.
+    const createPrintfulOrder = vi
+      .fn()
+      .mockImplementation(async ({ externalId }: { externalId: string }) => {
+        if (externalId === failOrder.id) throw new Error("Printful 500");
+        return { id: 4321, costs: { total: "12.50" } };
+      });
+    const deps = makeDeps(db, { createPrintfulOrder });
+
+    const res = await retryStuckFulfillments(deps);
+
+    expect(res.scanned).toBe(2);
+    const byId = Object.fromEntries(res.results.map((r) => [r.orderId, r.action]));
+    expect(byId[okOrder.id]).toBe("submitted"); // sibling still processed
+    expect(byId[failOrder.id]).toBe("paid_printful_failed");
+
+    const stillPaid = await db.query.order.findFirst({
+      where: eq(schema.order.id, failOrder.id),
+    });
+    expect(stillPaid?.status).toBe("paid");
+    expect(stillPaid?.printfulOrderId).toBeNull();
+  });
+
+  it("honors the batch limit", async () => {
+    for (let i = 0; i < 3; i++) await seedStuck(db, { ageMs: (i + 1) * HOUR });
+    const deps = makeDeps(db);
+
+    const res = await retryStuckFulfillments(deps, { limit: 2 });
+
+    expect(res.scanned).toBe(2);
+  });
+});
+
+describe("order naming off the payment path (#39)", () => {
+  let db: Db;
+  beforeEach(async () => {
+    db = await createTestDb();
+  });
+
+  async function fulfill(order: typeof schema.order.$inferSelect, deps: FulfillmentDeps) {
+    return submitOrderFulfillment(
+      order,
+      [],
+      {
+        name: "Jane Doe",
+        address1: "1 Main St",
+        address2: "",
+        city: "Town",
+        state: "CA",
+        zip: "90001",
+        country: "US",
+      },
+      deps
+    );
+  }
+
+  it("submits even when order naming throws (naming is post-submission, fails soft)", async () => {
+    const { order } = await seedStuck(db);
+    const createPrintfulOrder = vi
+      .fn()
+      .mockResolvedValue({ id: 9999, costs: { total: "12.50" } });
+    const deps = makeDeps(db, {
+      createPrintfulOrder,
+      generateOrderName: vi.fn().mockRejectedValue(new Error("Anthropic down")),
+    });
+
+    const res = await fulfill(order, deps);
+
+    expect(res.action).toBe("submitted");
+    // The shirt went to Printful despite the naming failure.
+    expect(createPrintfulOrder).toHaveBeenCalled();
+    const updated = await db.query.order.findFirst({
+      where: eq(schema.order.id, order.id),
+    });
+    expect(updated?.status).toBe("submitted");
+    expect(updated?.printfulOrderId).toBe("9999");
+    expect(updated?.displayName).toBeNull();
+  });
+
+  it("names the order after a successful submission", async () => {
+    const { order } = await seedStuck(db);
+    const deps = makeDeps(db);
+
+    const res = await fulfill(order, deps);
+
+    expect(res.action).toBe("submitted");
+    const updated = await db.query.order.findFirst({
+      where: eq(schema.order.id, order.id),
+    });
+    expect(updated?.displayName).toBe("Named Order");
+  });
+
+  it("does not re-name an order that already has a name (admin/cron retry)", async () => {
+    const { order } = await seedStuck(db, { overrides: { displayName: "Existing Name" } });
+    const generateOrderName = vi.fn().mockResolvedValue("New Name");
+    const deps = makeDeps(db, { generateOrderName });
+
+    await fulfill(order, deps);
+
+    expect(generateOrderName).not.toHaveBeenCalled();
+    const updated = await db.query.order.findFirst({
+      where: eq(schema.order.id, order.id),
+    });
+    expect(updated?.displayName).toBe("Existing Name");
+  });
+});

--- a/src/lib/order-fulfillment.ts
+++ b/src/lib/order-fulfillment.ts
@@ -20,9 +20,16 @@ import { resolveOrderLines, type OrderItemRow } from "@/lib/order-lines";
 import { getBlank, getVariantId } from "@/lib/blanks";
 import { assertTransition } from "@/lib/order-state";
 import { cogsLedgerRow } from "@/lib/ledger";
+import { withTimeout } from "@/lib/timeout";
 import type { createOrder, PrintfulOrderItem } from "@/lib/printful";
 import type { db as appDb } from "@/lib/db";
 import type { generateOrderName } from "@/lib/ai";
+
+// Cap on the post-submission order-naming Anthropic call. Long enough for a
+// normal vision response, short enough that a hung call can't push the webhook
+// response past Stripe's ~10s delivery timeout (the order is already submitted
+// to Printful by the time this runs).
+const ORDER_NAME_TIMEOUT_MS = 8_000;
 
 export type FulfillmentDeps = {
   db: typeof appDb;
@@ -139,18 +146,6 @@ export async function submitOrderFulfillment(
     return { action: "paid" };
   }
 
-  // Name the order once, from the first print file. Skipped when the order
-  // already has a name (e.g. an admin retry after a Printful failure).
-  if (firstFrontUrl && !order.displayName) {
-    const displayName = await deps.generateOrderName(firstFrontUrl);
-    if (displayName) {
-      await deps.db
-        .update(orderTable)
-        .set({ displayName, updatedAt: new Date() })
-        .where(eq(orderTable.id, orderId));
-    }
-  }
-
   try {
     const printfulOrder = await deps.createPrintfulOrder({
       items,
@@ -206,6 +201,29 @@ export async function submitOrderFulfillment(
       ]);
     } else {
       await deps.db.batch([submittedUpdate, ...designUpdates]);
+    }
+
+    // Name the order AFTER Printful submission — the shirt never waits on the
+    // LLM (#39). Bounded so a hung Anthropic call can't stall the webhook
+    // response past Stripe's timeout. Skipped when already named (admin retry).
+    // displayName is written before returning so the confirmation email, sent
+    // by the caller after this resolves, still carries the name. Fails soft.
+    if (firstFrontUrl && !order.displayName) {
+      try {
+        const displayName = await withTimeout(
+          "generateOrderName",
+          ORDER_NAME_TIMEOUT_MS,
+          () => deps.generateOrderName(firstFrontUrl!)
+        );
+        if (displayName) {
+          await deps.db
+            .update(orderTable)
+            .set({ displayName, updatedAt: new Date() })
+            .where(eq(orderTable.id, orderId));
+        }
+      } catch (err) {
+        console.error(`Order ${orderId}: order naming failed (non-fatal):`, err);
+      }
     }
 
     return { action: "submitted", printfulOrderId: String(printfulOrder.id) };

--- a/src/lib/replicate.ts
+++ b/src/lib/replicate.ts
@@ -1,5 +1,6 @@
 import Replicate from "replicate";
 import type { AspectRatio } from "./blanks";
+import { withTimeout } from "./timeout";
 
 const replicate = new Replicate();
 
@@ -10,30 +11,6 @@ const replicate = new Replicate();
 // spins with no error surfaced (issue #15). This ceiling converts that
 // silent hang into a rejection the UI can show.
 const REPLICATE_RUN_TIMEOUT_MS = 120_000;
-
-/**
- * Reject if `run` hasn't settled within `ms`. Note: this does not cancel
- * the underlying Replicate prediction (Promise.race can't), it just stops
- * the caller from waiting indefinitely so an error state can render.
- */
-async function withTimeout<T>(
-  label: string,
-  ms: number,
-  run: () => Promise<T>
-): Promise<T> {
-  let timer: ReturnType<typeof setTimeout> | undefined;
-  const timeout = new Promise<never>((_, reject) => {
-    timer = setTimeout(
-      () => reject(new Error(`${label} timed out after ${ms}ms`)),
-      ms
-    );
-  });
-  try {
-    return await Promise.race([run(), timeout]);
-  } finally {
-    if (timer) clearTimeout(timer);
-  }
-}
 
 /**
  * Run a Replicate call with one retry on 429 (Replicate throttles to

--- a/src/lib/retry-fulfillment.ts
+++ b/src/lib/retry-fulfillment.ts
@@ -1,0 +1,85 @@
+/**
+ * Durability sweep core (#39). Finds paid orders whose Printful submission
+ * never landed (status `paid`, no printfulOrderId) and re-runs the shared
+ * fulfillment tail. Called on a schedule by /api/cron/retry-fulfillment; kept
+ * as a deps-injected lib function (like handleStripeCheckoutCompleted) so it's
+ * testable against the real in-memory DB without the route's auth/env.
+ *
+ * A paid-but-unsubmitted order stalls because the Stripe webhook returned 200
+ * (so Stripe won't redeliver) after Printful was down. Guardrails:
+ *   - floor: skip orders paid in the last `floorMs` (default 10 min) so the
+ *     sweep never races an in-flight webhook or Stripe's own delivery retries.
+ *   - ceil: skip orders older than `ceilMs` (default 24h) — a permanently
+ *     unfulfillable order (missing image/variant) would be retried forever
+ *     otherwise; those are left for the admin manual retry.
+ *   - limit: bound per-run work to stay inside the function's maxDuration.
+ * Double-submit safety (this sweep vs. a concurrent admin retry) rides on
+ * #37's Printful external_id dedupe inside submitOrderFulfillment.
+ */
+import { and, asc, eq, gt, isNull, lt } from "drizzle-orm";
+import { order as orderTable, orderItem as orderItemTable } from "@/lib/db/schema";
+import {
+  submitOrderFulfillment,
+  type FulfillmentDeps,
+  type FulfillmentResult,
+} from "@/lib/order-fulfillment";
+
+export const RETRY_FLOOR_MS = 10 * 60 * 1000;
+export const RETRY_CEIL_MS = 24 * 60 * 60 * 1000;
+export const RETRY_BATCH_LIMIT = 5;
+
+export type RetryFulfillmentResult = {
+  scanned: number;
+  results: { orderId: string; action: FulfillmentResult["action"] | "error" }[];
+};
+
+export async function retryStuckFulfillments(
+  deps: FulfillmentDeps,
+  opts: { now?: number; floorMs?: number; ceilMs?: number; limit?: number } = {}
+): Promise<RetryFulfillmentResult> {
+  const now = opts.now ?? Date.now();
+  const floor = new Date(now - (opts.floorMs ?? RETRY_FLOOR_MS));
+  const ceil = new Date(now - (opts.ceilMs ?? RETRY_CEIL_MS));
+
+  const stuck = await deps.db.query.order.findMany({
+    where: and(
+      eq(orderTable.status, "paid"),
+      isNull(orderTable.printfulOrderId),
+      lt(orderTable.updatedAt, floor),
+      gt(orderTable.updatedAt, ceil)
+    ),
+    orderBy: asc(orderTable.createdAt),
+    limit: opts.limit ?? RETRY_BATCH_LIMIT,
+  });
+
+  const results: RetryFulfillmentResult["results"] = [];
+  for (const foundOrder of stuck) {
+    const items = await deps.db.query.orderItem.findMany({
+      where: eq(orderItemTable.orderId, foundOrder.id),
+    });
+    try {
+      const result = await submitOrderFulfillment(
+        foundOrder,
+        items,
+        {
+          name: foundOrder.shippingName ?? "",
+          address1: foundOrder.shippingAddress1 ?? "",
+          address2: foundOrder.shippingAddress2 ?? "",
+          city: foundOrder.shippingCity ?? "",
+          state: foundOrder.shippingState ?? "",
+          zip: foundOrder.shippingZip ?? "",
+          country: foundOrder.shippingCountry ?? "US",
+        },
+        deps
+      );
+      console.log(`retry-fulfillment: order ${foundOrder.id} → ${result.action}`);
+      results.push({ orderId: foundOrder.id, action: result.action });
+    } catch (err) {
+      // One order's failure shouldn't abort the sweep.
+      console.error(`retry-fulfillment: order ${foundOrder.id} threw:`, err);
+      results.push({ orderId: foundOrder.id, action: "error" });
+    }
+  }
+
+  return { scanned: stuck.length, results };
+}

--- a/src/lib/timeout.ts
+++ b/src/lib/timeout.ts
@@ -1,0 +1,23 @@
+/**
+ * Reject if `run` hasn't settled within `ms`. Note: this does not cancel the
+ * underlying work (Promise.race can't) — it just stops the caller from waiting
+ * indefinitely so an error state can render or a bounded fallback can run.
+ */
+export async function withTimeout<T>(
+  label: string,
+  ms: number,
+  run: () => Promise<T>
+): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(
+      () => reject(new Error(`${label} timed out after ${ms}ms`)),
+      ms
+    );
+  });
+  try {
+    return await Promise.race([run(), timeout]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "crons": [
+    {
+      "path": "/api/cron/retry-fulfillment",
+      "schedule": "0 8 * * *"
+    }
+  ]
+}


### PR DESCRIPTION
Closes #39 (WP3).

## Problem
A paid order whose Printful submission failed (e.g. Printful down during the Stripe webhook) is left at `paid` with no `printfulOrderId`, and nothing retries it — the webhook returned 200 so Stripe never redelivers. Separately, `generateOrderName` (an Anthropic call) was awaited *before* Printful submission, so the shirt waited on an LLM.

## Fix
**Durability cron**
- `vercel.json` — daily cron `0 8 * * *` (Hobby-safe) → `/api/cron/retry-fulfillment`.
- `src/lib/retry-fulfillment.ts` — deps-injected core (testable on the real in-memory libSQL). Selects `status=paid AND printfulOrderId IS NULL AND updatedAt ∈ [now−24h, now−10min]`, limit 5, re-runs the shared `submitOrderFulfillment`.
  - **10-min floor** avoids racing an in-flight webhook or Stripe's own delivery retries.
  - **24h ceiling** stops infinite retries of permanently-unfulfillable orders — those go to the admin manual retry.
- Route is a thin GET gated on `Authorization: Bearer ${CRON_SECRET}` (Vercel auto-injects this on scheduled calls; missing secret → 500 by design).
- **Double-submit safety** (cron vs. admin retry) rides on #37's Printful `external_id` dedupe — a duplicate is rejected and the loser returns `paid_printful_failed`, no double COGS.

**Order naming off the payment path**
- `generateOrderName` moved *after* Printful submission in `submitOrderFulfillment`, wrapped in an 8s `withTimeout` + its own try/catch. The shirt never waits on the LLM; a hung call can't push the webhook past Stripe's timeout. `displayName` still written before return, so the confirmation email keeps the name. Fails soft.
- `withTimeout` extracted to `src/lib/timeout.ts` (shared with `replicate.ts`).

## Tests
New `retry-fulfillment.integration.test.ts` (9 cases) on the real-DB harness: floor/ceil/limit selection, ignores already-submitted orders, Printful failure doesn't abort the sweep, naming fails soft post-submission. Full suite 470 passing, lint 0 errors, build compiles the cron route.

## Deploy notes
- `CRON_SECRET` already set in Vercel **Production** (stored in 1Password `dev-secrets/prntd CRON_SECRET`).
- Vercel crons run **only on production deployments** and start firing once this merges and deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)