### PR TITLE
chore(test): seed factories, node env for lib tests, order_item orderBy, e2e testids, cart pricing tests (#41, WP3)

### DIFF
--- a/e2e/cart.spec.ts
+++ b/e2e/cart.spec.ts
@@ -51,12 +51,16 @@ test("guest cart: two items, bundled shipping, sign-in gate at checkout", async 
 
     // First item.
     await addToCartFromOrderPage(page, seeded[0]);
-    await expect(page.locator("ul > li")).toHaveCount(1, { timeout: 30_000 });
+    await expect(page.getByTestId("cart-line-item")).toHaveCount(1, {
+      timeout: 30_000,
+    });
     const oneItemShipping = await shippingAmount(page);
 
     // Second item — bundled shipping must not scale with item count.
     await addToCartFromOrderPage(page, seeded[1]);
-    await expect(page.locator("ul > li")).toHaveCount(2, { timeout: 30_000 });
+    await expect(page.getByTestId("cart-line-item")).toHaveCount(2, {
+      timeout: 30_000,
+    });
     const twoItemShipping = await shippingAmount(page);
     expect(twoItemShipping).toBe(oneItemShipping);
 

--- a/e2e/store-compose.spec.ts
+++ b/e2e/store-compose.spec.ts
@@ -44,7 +44,7 @@ test("organizer compose: create shop, add + edit product, edit shop, list + publ
 
     // The new store's card. Scope every later interaction to it so leftover
     // stores from a prior failed run can't shadow the buttons.
-    const card = page.locator("div.rounded-lg").filter({ hasText: shopName });
+    const card = page.getByTestId("store-card").filter({ hasText: shopName });
     await expect(card).toBeVisible({ timeout: 15_000 });
     await expect(card.getByText(/^0 products$/)).toBeVisible();
 
@@ -73,17 +73,17 @@ test("organizer compose: create shop, add + edit product, edit shop, list + publ
     // Save → back to the dashboard, product count rises.
     await page.getByRole("button", { name: "Add to shop" }).click();
     await page.waitForURL(/\/dashboard$/);
-    const savedCard = page.locator("div.rounded-lg").filter({ hasText: shopName });
+    const savedCard = page.getByTestId("store-card").filter({ hasText: shopName });
     await expect(savedCard.getByText(/^1 product$/)).toBeVisible({ timeout: 15_000 });
 
     // Edit the shop: rename it and confirm the slug (shared-link path) is fixed.
     const slug = (await savedCard.getByText(/^\//).first().innerText()).trim();
     await savedCard.getByRole("button", { name: "Edit shop" }).click();
-    const panel = page.locator("div.rounded-lg").filter({ hasText: "Accent color" });
+    const panel = page.getByTestId("store-edit-panel");
     const newName = `${shopName} Edited`;
     await panel.getByRole("textbox").first().fill(newName); // first textbox = name input
     await panel.getByRole("button", { name: "Save" }).click();
-    const renamed = page.locator("div.rounded-lg").filter({ hasText: newName });
+    const renamed = page.getByTestId("store-card").filter({ hasText: newName });
     await expect(renamed).toBeVisible({ timeout: 15_000 });
     await expect(renamed.getByText(slug, { exact: true })).toBeVisible(); // slug unchanged
 
@@ -97,7 +97,7 @@ test("organizer compose: create shop, add + edit product, edit shop, list + publ
     await page.locator('input[type="number"]').fill("30");
     await page.getByRole("button", { name: "Save changes" }).click();
     await page.waitForURL(/\/dashboard$/);
-    const finalCard = page.locator("div.rounded-lg").filter({ hasText: newName });
+    const finalCard = page.getByTestId("store-card").filter({ hasText: newName });
     await expect(finalCard.getByText("$30.00")).toBeVisible({ timeout: 15_000 });
 
     // List the product + publish the shop. Each toggle is optimistic + fires a

--- a/src/app/cart/page.tsx
+++ b/src/app/cart/page.tsx
@@ -76,7 +76,11 @@ export default function CartPage() {
           <>
             <ul className="divide-y divide-border border-y border-border">
               {cart.items.map((item) => (
-                <li key={item.id} className="flex items-center gap-4 py-4">
+                <li
+                  key={item.id}
+                  data-testid="cart-line-item"
+                  className="flex items-center gap-4 py-4"
+                >
                   <div className="w-16 h-16 shrink-0 rounded-md bg-checkerboard overflow-hidden">
                     {item.imageUrl && (
                       // eslint-disable-next-line @next/next/no-img-element

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -198,7 +198,7 @@ function StoreCard({
   }
 
   return (
-    <div className="border border-border rounded-lg p-4">
+    <div className="border border-border rounded-lg p-4" data-testid="store-card">
       <div className="flex items-start justify-between gap-2">
         <div className="min-w-0">
           <div className="flex items-center gap-2">
@@ -331,7 +331,10 @@ function StoreEditPanel({
   }
 
   return (
-    <div className="border border-border rounded-lg p-4 space-y-3">
+    <div
+      className="border border-border rounded-lg p-4 space-y-3"
+      data-testid="store-edit-panel"
+    >
       <div>
         <label className="block text-sm font-medium mb-1">Shop name</label>
         <Input

--- a/src/app/order/confirm/actions.ts
+++ b/src/app/order/confirm/actions.ts
@@ -5,7 +5,7 @@ import {
   order as orderTable,
   orderItem as orderItemTable,
 } from "@/lib/db/schema";
-import { eq } from "drizzle-orm";
+import { asc, eq } from "drizzle-orm";
 import { resolveOrderLines } from "@/lib/order-lines";
 
 export async function getOrderBySession(stripeSessionId: string) {
@@ -30,7 +30,8 @@ export async function getOrderBySession(stripeSessionId: string) {
       printfulCost: orderItemTable.printfulCost,
     })
     .from(orderItemTable)
-    .where(eq(orderItemTable.orderId, found.id));
+    .where(eq(orderItemTable.orderId, found.id))
+    .orderBy(asc(orderItemTable.createdAt));
 
   const lines = resolveOrderLines(found, items).map((l) => ({
     blankId: l.blankId,

--- a/src/app/orders/actions.ts
+++ b/src/app/orders/actions.ts
@@ -10,7 +10,7 @@ import {
   designImage as designImageTable,
   user as userTable,
 } from "@/lib/db/schema";
-import { eq, desc, inArray } from "drizzle-orm";
+import { eq, asc, desc, inArray } from "drizzle-orm";
 import { resolveDesignDisplayImageUrls } from "@/lib/design-images";
 import { resolveOrderLines } from "@/lib/order-lines";
 import { designerAttribution } from "@/lib/order-attribution";
@@ -59,6 +59,7 @@ export async function getUserOrders() {
         })
         .from(orderItemTable)
         .where(inArray(orderItemTable.orderId, orderIds))
+        .orderBy(asc(orderItemTable.createdAt))
     : [];
   const itemsByOrder = new Map<string, typeof itemRows>();
   for (const it of itemRows) {

--- a/src/lib/__tests__/ai.test.ts
+++ b/src/lib/__tests__/ai.test.ts
@@ -72,10 +72,13 @@ describe("chatAboutDesign", () => {
     await chatAboutDesign("third", history, []);
 
     const call = mockCreate.mock.calls[0][0];
-    // All three user messages should be merged into alternating roles
-    // "first" + "second" merged, then "third" as the new user message
-    const userMessages = call.messages.filter((m: any) => m.role === "user");
-    expect(userMessages.length).toBeGreaterThanOrEqual(1);
+    // "first", "second" (history) and "third" (the new turn) are all user
+    // role with nothing in between, so buildMessages must collapse them into
+    // a single alternating-role message — Anthropic rejects consecutive
+    // same-role messages.
+    expect(call.messages).toHaveLength(1);
+    expect(call.messages[0].role).toBe("user");
+    expect(call.messages[0].content).toBe("first\n\nsecond\n\nthird");
   });
 
   it("parses message and readyToGenerate from valid JSON", async () => {

--- a/src/lib/__tests__/checkout.test.ts
+++ b/src/lib/__tests__/checkout.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { buildCheckoutSessionParams } from "../checkout";
+import { buildCheckoutSessionParams, buildCartCheckoutSessionParams } from "../checkout";
 
 const base = {
   orderId: "order-1",
@@ -83,5 +83,82 @@ describe("buildCheckoutSessionParams", () => {
     expect(p.mode).toBe("payment");
     expect(p.allow_promotion_codes).toBe(true);
     expect(p.shipping_address_collection!.allowed_countries).toEqual(["US"]);
+  });
+});
+
+const cartBase = {
+  orderId: "order-1",
+  designId: "design-1",
+  lineItems: [
+    {
+      name: "Unisex Tee",
+      description: "Black / L",
+      imageUrl: "https://cdn.example.com/a.png",
+      unitPrice: 19.43,
+      quantity: 1,
+    },
+    {
+      name: "Women's Tee",
+      description: "White / S",
+      imageUrl: null,
+      unitPrice: 19.43,
+      quantity: 2,
+    },
+  ],
+  shippingPrice: 4.69,
+  cancelUrl: "https://prntd.org/cart",
+  appUrl: "https://prntd.org",
+};
+
+describe("buildCartCheckoutSessionParams", () => {
+  it("builds one Stripe line item per cart line, priced in cents with its own quantity", () => {
+    const p = buildCartCheckoutSessionParams(cartBase);
+    expect(p.line_items).toHaveLength(2);
+    const [first, second] = p.line_items!;
+    expect(first.price_data!.unit_amount).toBe(1943);
+    expect(first.quantity).toBe(1);
+    expect(second.price_data!.unit_amount).toBe(1943);
+    expect(second.quantity).toBe(2);
+  });
+
+  it("charges shipping once as a single shipping_option, never per line item (bundled-shipping contract)", () => {
+    const p = buildCartCheckoutSessionParams(cartBase);
+    expect(p.shipping_options).toHaveLength(1);
+    const rate = p.shipping_options![0].shipping_rate_data!;
+    expect(rate.type).toBe("fixed_amount");
+    expect(rate.fixed_amount!.amount).toBe(469);
+    expect(rate.display_name).toBe("Standard shipping");
+  });
+
+  it("labels each line 'PRNTD <name>' with its own description and image", () => {
+    const p = buildCartCheckoutSessionParams(cartBase);
+    const [first, second] = p.line_items!;
+    expect(first.price_data!.product_data!.name).toBe("PRNTD Unisex Tee");
+    expect(first.price_data!.product_data!.description).toBe("Black / L");
+    expect(first.price_data!.product_data!.images).toEqual([
+      "https://cdn.example.com/a.png",
+    ]);
+    expect(second.price_data!.product_data!.name).toBe("PRNTD Women's Tee");
+    expect(second.price_data!.product_data!.images).toEqual([]);
+  });
+
+  it("carries orderId and a representative designId in metadata", () => {
+    const p = buildCartCheckoutSessionParams(cartBase);
+    expect(p.metadata).toEqual({ orderId: "order-1", designId: "design-1" });
+  });
+
+  it("is a one-time payment that allows promo codes on every line item and collects US shipping", () => {
+    const p = buildCartCheckoutSessionParams(cartBase);
+    expect(p.mode).toBe("payment");
+    expect(p.allow_promotion_codes).toBe(true);
+    expect(p.shipping_address_collection!.allowed_countries).toEqual(["US"]);
+  });
+
+  it("builds the success_url from appUrl with the session-id placeholder and uses the given cancel_url", () => {
+    const p = buildCartCheckoutSessionParams(cartBase);
+    expect(p.success_url).toBe(
+      "https://prntd.org/order/confirm?session_id={CHECKOUT_SESSION_ID}"
+    );
+    expect(p.cancel_url).toBe("https://prntd.org/cart");
   });
 });

--- a/src/lib/__tests__/factories.ts
+++ b/src/lib/__tests__/factories.ts
@@ -1,0 +1,21 @@
+/**
+ * Shared seed helpers for real-DB integration tests (createTestDb). Kept
+ * minimal — only what's duplicated verbatim across test files. Don't force
+ * every integration test onto these; add a factory only when a second file
+ * needs the exact same shape.
+ */
+import type { db as appDb } from "@/lib/db";
+import * as schema from "@/lib/db/schema";
+
+type Db = typeof appDb;
+
+/** Insert a user row with a deterministic email/name derived from `id`. */
+export async function makeUser(db: Db, id: string) {
+  await db.insert(schema.user).values({ id, email: `${id}@example.com`, name: id });
+}
+
+/** Insert a bare design owned by `userId` and return the row. */
+export async function makeDesign(db: Db, userId: string) {
+  const [d] = await db.insert(schema.design).values({ userId }).returning();
+  return d;
+}

--- a/src/lib/__tests__/pricing.test.ts
+++ b/src/lib/__tests__/pricing.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   computePrice,
   computeOrderTotal,
+  computeCartTotal,
   estimateShipping,
   minRetailPrice,
   FLAT_SHIPPING_USD,
@@ -123,6 +124,44 @@ describe("computePrice", () => {
         expect(Math.round(total * 100) / 100).toBe(total);
       }
     }
+  });
+});
+
+describe("computeCartTotal", () => {
+  it("sums N line-item prices with one order-level shipping charge", () => {
+    const b = computeCartTotal([19.43, 19.43, 21.43], FLAT_SHIPPING_USD);
+    expect(b.item).toBe(19.43 + 19.43 + 21.43);
+    expect(b.shipping).toBe(FLAT_SHIPPING_USD);
+    expect(b.total).toBe(
+      Math.round((19.43 + 19.43 + 21.43 + FLAT_SHIPPING_USD) * 100) / 100
+    );
+  });
+
+  it("charges shipping once regardless of item count (bundled-shipping contract)", () => {
+    const one = computeCartTotal([19.43], FLAT_SHIPPING_USD);
+    const three = computeCartTotal([19.43, 19.43, 19.43], FLAT_SHIPPING_USD);
+    expect(one.shipping).toBe(FLAT_SHIPPING_USD);
+    expect(three.shipping).toBe(FLAT_SHIPPING_USD);
+  });
+
+  it("passes through a live (non-flat) shipping quote unchanged", () => {
+    const b = computeCartTotal([19.43, 19.43], 8.5);
+    expect(b.shipping).toBe(8.5);
+    expect(b.total).toBe(Math.round((19.43 + 19.43 + 8.5) * 100) / 100);
+  });
+
+  it("charges no shipping for an empty cart, even if a shipping quote is passed", () => {
+    const b = computeCartTotal([], FLAT_SHIPPING_USD);
+    expect(b.item).toBe(0);
+    expect(b.shipping).toBe(0);
+    expect(b.total).toBe(0);
+  });
+
+  it("rounds the item subtotal to exact cent precision", () => {
+    // Three prices whose float sum can carry sub-cent error.
+    const b = computeCartTotal([19.43, 19.43, 19.43], FLAT_SHIPPING_USD);
+    expect(Math.round(b.item * 100) / 100).toBe(b.item);
+    expect(Math.round(b.total * 100) / 100).toBe(b.total);
   });
 });
 

--- a/src/lib/__tests__/store-service.integration.test.ts
+++ b/src/lib/__tests__/store-service.integration.test.ts
@@ -6,7 +6,7 @@
  */
 import { describe, it, expect, beforeEach } from "vitest";
 import { createTestDb } from "./test-db";
-import * as schema from "@/lib/db/schema";
+import { makeUser, makeDesign } from "./factories";
 import {
   createStore,
   getMyStores,
@@ -23,21 +23,13 @@ import {
 type Db = Awaited<ReturnType<typeof createTestDb>>;
 let db: Db;
 
-async function makeUser(id: string) {
-  await db.insert(schema.user).values({ id, email: `${id}@example.com`, name: id });
-}
-async function makeDesign(userId: string) {
-  const [d] = await db.insert(schema.design).values({ userId }).returning();
-  return d;
-}
-
 beforeEach(async () => {
   db = await createTestDb();
 });
 
 describe("createStore", () => {
   it("creates a draft store with a slug derived from the name", async () => {
-    await makeUser("org-1");
+    await makeUser(db, "org-1");
     const s = await createStore(db, "org-1", { name: "Manine's Club!" });
     expect(s.status).toBe("draft");
     expect(s.slug).toBe("manines-club");
@@ -45,8 +37,8 @@ describe("createStore", () => {
   });
 
   it("suffixes the slug on collision", async () => {
-    await makeUser("org-1");
-    await makeUser("org-2");
+    await makeUser(db, "org-1");
+    await makeUser(db, "org-2");
     const a = await createStore(db, "org-1", { name: "Club" });
     const b = await createStore(db, "org-2", { name: "Club" });
     expect(a.slug).toBe("club");
@@ -54,12 +46,12 @@ describe("createStore", () => {
   });
 
   it("rejects a blank name", async () => {
-    await makeUser("org-1");
+    await makeUser(db, "org-1");
     await expect(createStore(db, "org-1", { name: "   " })).rejects.toThrow(/name/i);
   });
 
   it("lists an organizer's stores oldest-first", async () => {
-    await makeUser("org-1");
+    await makeUser(db, "org-1");
     await createStore(db, "org-1", { name: "First" });
     await createStore(db, "org-1", { name: "Second" });
     const mine = await getMyStores(db, "org-1");
@@ -69,7 +61,7 @@ describe("createStore", () => {
 
 describe("updateStore", () => {
   it("applies a partial update and keeps the slug stable on rename", async () => {
-    await makeUser("org-1");
+    await makeUser(db, "org-1");
     const s = await createStore(db, "org-1", { name: "Club" });
     const updated = await updateStore(db, "org-1", s.id, {
       name: "The Club",
@@ -83,8 +75,8 @@ describe("updateStore", () => {
   });
 
   it("refuses a non-owner", async () => {
-    await makeUser("org-1");
-    await makeUser("org-2");
+    await makeUser(db, "org-1");
+    await makeUser(db, "org-2");
     const s = await createStore(db, "org-1", { name: "Club" });
     await expect(updateStore(db, "org-2", s.id, { name: "Hijack" })).rejects.toThrow(/unauthorized/i);
   });
@@ -92,8 +84,8 @@ describe("updateStore", () => {
 
 describe("createProduct", () => {
   it("creates a draft product from an owned design", async () => {
-    await makeUser("org-1");
-    const design = await makeDesign("org-1");
+    await makeUser(db, "org-1");
+    const design = await makeDesign(db, "org-1");
     const store = await createStore(db, "org-1", { name: "Club" });
     const p = await createProduct(db, "org-1", {
       designId: design.id,
@@ -107,17 +99,17 @@ describe("createProduct", () => {
   });
 
   it("rejects a design the organizer doesn't own", async () => {
-    await makeUser("org-1");
-    await makeUser("org-2");
-    const design = await makeDesign("org-2");
+    await makeUser(db, "org-1");
+    await makeUser(db, "org-2");
+    const design = await makeDesign(db, "org-2");
     await expect(
       createProduct(db, "org-1", { designId: design.id, blankId: "bella-canvas-3001" })
     ).rejects.toThrow(/unauthorized/i);
   });
 
   it("allows a loose product with no store", async () => {
-    await makeUser("org-1");
-    const design = await makeDesign("org-1");
+    await makeUser(db, "org-1");
+    const design = await makeDesign(db, "org-1");
     const p = await createProduct(db, "org-1", {
       designId: design.id,
       blankId: "bella-canvas-3001",
@@ -128,11 +120,11 @@ describe("createProduct", () => {
 
 describe("ordering", () => {
   async function seedThree() {
-    await makeUser("org-1");
+    await makeUser(db, "org-1");
     const store = await createStore(db, "org-1", { name: "Club" });
     const ids: string[] = [];
     for (let i = 0; i < 3; i++) {
-      const d = await makeDesign("org-1");
+      const d = await makeDesign(db, "org-1");
       const p = await createProduct(db, "org-1", {
         designId: d.id,
         blankId: "bella-canvas-3001",
@@ -158,11 +150,11 @@ describe("ordering", () => {
   });
 
   it("addProductToStore shelves a loose product at the end", async () => {
-    await makeUser("org-1");
+    await makeUser(db, "org-1");
     const store = await createStore(db, "org-1", { name: "Club" });
-    const d1 = await makeDesign("org-1");
+    const d1 = await makeDesign(db, "org-1");
     await createProduct(db, "org-1", { designId: d1.id, blankId: "bella-canvas-3001", storeId: store.id });
-    const d2 = await makeDesign("org-1");
+    const d2 = await makeDesign(db, "org-1");
     const loose = await createProduct(db, "org-1", { designId: d2.id, blankId: "bella-canvas-3001" });
 
     const shelved = await addProductToStore(db, "org-1", loose.id, store.id);
@@ -179,8 +171,8 @@ describe("getStoreById", () => {
 
 describe("updateProduct", () => {
   async function makeProduct(owner: string) {
-    await makeUser(owner);
-    const d = await makeDesign(owner);
+    await makeUser(db, owner);
+    const d = await makeDesign(db, owner);
     return createProduct(db, owner, { designId: d.id, blankId: "bella-canvas-3001" });
   }
 
@@ -205,7 +197,7 @@ describe("updateProduct", () => {
 
   it("refuses a non-owner", async () => {
     const p = await makeProduct("org-1");
-    await makeUser("org-2");
+    await makeUser(db, "org-2");
     await expect(
       updateProduct(db, "org-2", p.id, { price: 99 })
     ).rejects.toThrow(/unauthorized/i);

--- a/src/lib/__tests__/store.integration.test.ts
+++ b/src/lib/__tests__/store.integration.test.ts
@@ -6,20 +6,12 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { eq } from "drizzle-orm";
 import { createTestDb } from "./test-db";
+import { makeUser, makeDesign } from "./factories";
 import * as schema from "@/lib/db/schema";
 
 type Db = Awaited<ReturnType<typeof createTestDb>>;
 
 let db: Db;
-
-async function makeUser(id: string) {
-  await db.insert(schema.user).values({ id, email: `${id}@example.com`, name: id });
-}
-
-async function makeDesign(userId: string) {
-  const [d] = await db.insert(schema.design).values({ userId }).returning();
-  return d;
-}
 
 beforeEach(async () => {
   db = await createTestDb();
@@ -27,7 +19,7 @@ beforeEach(async () => {
 
 describe("store table", () => {
   it("creates a store with status defaulting to draft", async () => {
-    await makeUser("org-1");
+    await makeUser(db, "org-1");
     const [s] = await db
       .insert(schema.store)
       .values({ ownerId: "org-1", slug: "manines-club", name: "Manine's Club" })
@@ -37,8 +29,8 @@ describe("store table", () => {
   });
 
   it("enforces unique slugs across owners", async () => {
-    await makeUser("org-1");
-    await makeUser("org-2");
+    await makeUser(db, "org-1");
+    await makeUser(db, "org-2");
     await db.insert(schema.store).values({ ownerId: "org-1", slug: "dup", name: "A" });
     await expect(
       db.insert(schema.store).values({ ownerId: "org-2", slug: "dup", name: "B" })
@@ -46,7 +38,7 @@ describe("store table", () => {
   });
 
   it("allows many stores per organizer (no ownerId uniqueness)", async () => {
-    await makeUser("org-1");
+    await makeUser(db, "org-1");
     await db.insert(schema.store).values({ ownerId: "org-1", slug: "club", name: "Club" });
     await db.insert(schema.store).values({ ownerId: "org-1", slug: "band", name: "Band" });
     const rows = await db.select().from(schema.store).where(eq(schema.store.ownerId, "org-1"));
@@ -56,8 +48,8 @@ describe("store table", () => {
 
 describe("product table", () => {
   it("persists placements JSON and links design + store", async () => {
-    await makeUser("org-1");
-    const design = await makeDesign("org-1");
+    await makeUser(db, "org-1");
+    const design = await makeDesign(db, "org-1");
     const [store] = await db
       .insert(schema.store)
       .values({ ownerId: "org-1", slug: "club", name: "Club" })
@@ -77,8 +69,8 @@ describe("product table", () => {
   });
 
   it("allows a loose product (no store) before it's shelved", async () => {
-    await makeUser("org-1");
-    const design = await makeDesign("org-1");
+    await makeUser(db, "org-1");
+    const design = await makeDesign(db, "org-1");
     const [p] = await db
       .insert(schema.product)
       .values({ ownerId: "org-1", designId: design.id, blankId: "bella-canvas-3001" })
@@ -87,7 +79,7 @@ describe("product table", () => {
   });
 
   it("rejects a product whose design FK doesn't exist", async () => {
-    await makeUser("org-1");
+    await makeUser(db, "org-1");
     await expect(
       db
         .insert(schema.product)
@@ -98,9 +90,9 @@ describe("product table", () => {
 
 describe("guest → account claim re-parents store + product", () => {
   it("moves both to the real account by ownerId (what onLinkAccount runs)", async () => {
-    await makeUser("guest");
-    await makeUser("real");
-    const design = await makeDesign("guest");
+    await makeUser(db, "guest");
+    await makeUser(db, "real");
+    const design = await makeDesign(db, "guest");
     await db.insert(schema.store).values({ ownerId: "guest", slug: "club", name: "Club" });
     await db
       .insert(schema.product)

--- a/src/lib/feedback/__tests__/capture.test.ts
+++ b/src/lib/feedback/__tests__/capture.test.ts
@@ -1,3 +1,6 @@
+// @vitest-environment jsdom
+// This lib file is a DOM walker, unlike the rest of src/lib/** (node env) —
+// override back to jsdom.
 import { describe, it, expect, beforeEach } from "vitest";
 import { buildPageCapture, OUTLINE_MAX_CHARS } from "../capture";
 

--- a/src/lib/order-emails.ts
+++ b/src/lib/order-emails.ts
@@ -154,6 +154,7 @@ export function createDefaultOrderEmailDeps(
       // columns for legacy single-item orders.
       const items = await db.query.orderItem.findMany({
         where: eq(orderItemTable.orderId, orderId),
+        orderBy: (fields, { asc }) => [asc(fields.createdAt)],
       });
       const orderLines = resolveOrderLines(
         {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,6 +6,10 @@ export default defineConfig({
   plugins: [react()],
   test: {
     environment: "jsdom",
+    // src/lib/** is pure logic + real-DB integration tests — no DOM needed,
+    // and node is faster/lighter than jsdom for these. Component tests
+    // (src/components/**, src/app/**) keep the jsdom default.
+    environmentMatchGlobs: [["src/lib/**", "node"]],
     setupFiles: "./vitest.setup.ts",
     include: ["src/**/*.test.{ts,tsx}"],
     coverage: {


### PR DESCRIPTION
Closes #41

Per-item summary:

1. **Shared seed factories** — `src/lib/__tests__/factories.ts` (`makeUser`, `makeDesign`). Migrated the two files with verbatim-duplicated inline helpers: `store.integration.test.ts` and `store-service.integration.test.ts`. Left other integration tests (order-fulfillment, retry-fulfillment, placement-render, order-email-loader, get-user-orders) alone — their seed shapes vary enough that forcing them onto shared factories wasn't a clean win, and order-fulfillment/retry-fulfillment are owned by a parallel workstream.
2. **Node environment for lib tests** — `vitest.config.ts` uses `environmentMatchGlobs: [["src/lib/**", "node"]]` (still supported in the installed vitest 3.2.4, though deprecated in favor of `projects`; kept the smaller change since a full `projects` split wasn't asked for). One exception: `src/lib/feedback/__tests__/capture.test.ts` is a real DOM walker, so it opts back into jsdom via a per-file `// @vitest-environment jsdom` docblock. All 461 pre-existing tests still pass (472 now, with the new cart-pricing + ai.test.ts assertions).
3. **Deterministic order_item ordering** — added `.orderBy(asc(orderItemTable.createdAt))` to the three call sites that had none and relied on implicit insertion order: `getUserOrders` (orders/actions.ts), `getOrderBySession` (order/confirm/actions.ts), and `loadOrderForEmail`'s `db.query.orderItem.findMany` (order-emails.ts). Left `admin/actions.ts` and the fulfillment/webhook files alone (admin pages + parallel-owned files, per scope).
4. **e2e data-testids** — added `data-testid="store-card"` / `"store-edit-panel"` to the dashboard store card/edit-panel divs, and `data-testid="cart-line-item"` to the cart's `<li>`. Updated `e2e/store-compose.spec.ts` and `e2e/cart.spec.ts` to select by testid instead of `div.rounded-lg` / `ul > li`. `npx playwright test --list` confirms both specs still parse (16 tests, 4 files).
5. **Cart pricing unit tests** — new tests lock `computeCartTotal`'s actual contract (sums line prices, shipping charged once regardless of item count, empty cart zeroes out, cent-precision rounding) and `buildCartCheckoutSessionParams`'s Stripe session shape (N line items with per-line quantity/price, one bundled `shipping_options` entry, metadata, URLs).
6. **Fixed vacuous assertion** — `ai.test.ts`'s "merges consecutive same-role messages" now asserts the actual merged output (`call.messages` has length 1, role `user`, content `"first\n\nsecond\n\nthird"`) instead of `userMessages.length >= 1`.

e2e verification happens in CI (this worktree has no `.env.local`, so Playwright can't run locally against a live preview) — the `store-compose` and `cart` specs will exercise the new testids against the Vercel preview once CI runs.

Verified locally: lint 0 errors (pre-existing warnings only), `npm test` 472/472 passing, `npm run build` green (with CI's fake-env-var set, matching `.github/workflows/ci.yml`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)