### PR TITLE
fix(design): atomic generation-number reservation kills R2 overwrite + counter races (#40, WP2)

### DIFF
--- a/src/app/design/__tests__/generation-races.integration.test.ts
+++ b/src/app/design/__tests__/generation-races.integration.test.ts
@@ -1,0 +1,286 @@
+/**
+ * Generation-race regressions (#40, WP2) at the server-action level. Proves the
+ * R2 key is derived from the atomically reserved generation number in both the
+ * Generate and Compare paths, that two concurrent generates land on distinct
+ * keys (no overwrite), that the success-path writes commit as one batch, that a
+ * post-upload failure cleans up the orphaned R2 object, and that a failed
+ * generation refunds the consumed quota unit.
+ *
+ * The DB is real in-memory libSQL (the #28 pattern); the generator adapters,
+ * R2 client, AI, auth, and `fetch` are mocked so nothing hits a live API.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi, type Mock } from "vitest";
+import { createTestDb } from "@/lib/__tests__/test-db";
+import * as schema from "@/lib/db/schema";
+import { eq } from "drizzle-orm";
+
+type Db = Awaited<ReturnType<typeof createTestDb>>;
+let testDb: Db;
+
+vi.mock("@/lib/db", () => ({
+  get db() {
+    return testDb;
+  },
+}));
+
+vi.mock("next/headers", () => ({ headers: vi.fn(async () => new Headers()) }));
+vi.mock("next/server", () => ({ after: () => {} }));
+vi.mock("@/app/preview/actions", () => ({
+  prefetchProductMockups: vi.fn(async () => {}),
+}));
+
+vi.mock("@/lib/auth", () => ({
+  auth: {
+    api: {
+      getSession: vi.fn(async () => ({
+        user: { id: "u1", isAnonymous: false },
+      })),
+    },
+  },
+  isAnonymousUser: () => false,
+}));
+
+vi.mock("@/lib/ai", () => ({
+  assessReadiness: vi.fn(async () => ({ ready: true, question: "", options: [] })),
+  constructFluxPrompt: vi.fn(async () => ({
+    message: "Here it is",
+    fluxPrompt: "a happy cat",
+    negativePrompt: null,
+    referenceImage: null,
+  })),
+  chatAboutDesign: vi.fn(async () => ({
+    message: "",
+    readyToGenerate: true,
+    options: [],
+  })),
+}));
+
+vi.mock("@/lib/r2", () => ({
+  // Encode the reserved generation number into the returned URL so the tests
+  // can assert the key was derived from the reservation, not a stale read.
+  uploadDesignImage: vi.fn(
+    async (designId: string, gen: number) => `https://r2/${designId}/${gen}.png`
+  ),
+  deleteDesignImageObject: vi.fn(async () => {}),
+}));
+
+vi.mock("@/lib/generators/registry", () => {
+  const ideogram = {
+    id: "ideogram",
+    label: "Ideogram",
+    costPerImage: 0.03,
+    adaptPrompt: (p: string) => p,
+    generate: vi.fn(async () => "https://src/ideogram.png"),
+  };
+  const recraft = {
+    id: "recraft",
+    label: "Recraft",
+    costPerImage: 0.04,
+    adaptPrompt: (p: string) => p,
+    generate: vi.fn(async () => "https://src/recraft.png"),
+  };
+  return {
+    DEFAULT_GENERATOR_ID: "ideogram",
+    GENERATORS: { ideogram, recraft },
+    getGenerator: (id: string | null | undefined) =>
+      id === "recraft" ? recraft : ideogram,
+  };
+});
+
+const { generateDesign, compareGenerators } = await import(
+  "@/app/design/actions"
+);
+const r2 = await import("@/lib/r2");
+const registry = await import("@/lib/generators/registry");
+
+const uploadMock = r2.uploadDesignImage as Mock;
+const deleteMock = r2.deleteDesignImageObject as Mock;
+const ideogramGen = registry.GENERATORS.ideogram.generate as Mock;
+const recraftGen = registry.GENERATORS.recraft.generate as Mock;
+
+async function seedDesign(generationCount = 0): Promise<string> {
+  await testDb.insert(schema.user).values({ id: "u1", email: "a@b.c", name: "A" });
+  const [design] = await testDb
+    .insert(schema.design)
+    .values({ userId: "u1", generationCount })
+    .returning();
+  return design.id;
+}
+
+async function seedSourceImage(designId: string, url: string): Promise<string> {
+  const [row] = await testDb
+    .insert(schema.designImage)
+    .values({ designId, aspectRatio: "1:1", imageUrl: url })
+    .returning();
+  return row.id;
+}
+
+async function sourceImages(designId: string) {
+  return testDb
+    .select()
+    .from(schema.designImage)
+    .where(eq(schema.designImage.designId, designId));
+}
+
+async function chatMessages(designId: string) {
+  return testDb
+    .select()
+    .from(schema.chatMessage)
+    .where(eq(schema.chatMessage.designId, designId));
+}
+
+async function getDesignRow(designId: string) {
+  const [row] = await testDb
+    .select()
+    .from(schema.design)
+    .where(eq(schema.design.id, designId));
+  return row;
+}
+
+beforeEach(async () => {
+  testDb = await createTestDb();
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async () => ({
+      arrayBuffer: async () => new Uint8Array([1, 2, 3]).buffer,
+    }))
+  );
+  uploadMock.mockClear();
+  deleteMock.mockClear();
+  ideogramGen.mockReset().mockResolvedValue("https://src/ideogram.png");
+  recraftGen.mockReset().mockResolvedValue("https://src/recraft.png");
+  delete process.env.GUEST_FUNNEL_ENABLED;
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("generateDesign — R2 key derivation", () => {
+  it("derives the key from the reserved number and batches the writes", async () => {
+    const designId = await seedDesign(5);
+    const seedImg = await seedSourceImage(designId, "https://r2/seed.png");
+
+    const res = await generateDesign(designId, "make a cat");
+
+    // Key = reserved number (6), not a re-read of the pre-generation count.
+    expect(uploadMock).toHaveBeenCalledTimes(1);
+    expect(uploadMock).toHaveBeenCalledWith(designId, 6, expect.anything());
+    expect(res.generationNumber).toBe(6);
+    expect(res.imageUrl).toBe(`https://r2/${designId}/6.png`);
+
+    const design = await getDesignRow(designId);
+    expect(design.generationCount).toBe(6);
+    expect(design.generationCost).toBeCloseTo(0.03);
+    expect(design.primaryImageId).toBe(res.imageId);
+
+    const imgs = await sourceImages(designId);
+    const generated = imgs.find((i) => i.id === res.imageId)!;
+    expect(generated.imageUrl).toBe(`https://r2/${designId}/6.png`);
+    // Provenance threaded to the pre-generation latest image, not re-read.
+    expect(generated.parentImageId).toBe(seedImg);
+
+    const msgs = await chatMessages(designId);
+    expect(msgs.map((m) => m.role).sort()).toEqual(["assistant", "user"]);
+    const assistant = msgs.find((m) => m.role === "assistant")!;
+    expect(assistant.imageId).toBe(res.imageId);
+    expect(msgs.find((m) => m.role === "user")!.content).toBe("make a cat");
+  });
+
+  it("hands two concurrent generates distinct keys (no overwrite)", async () => {
+    const designId = await seedDesign(0);
+
+    const [a, b] = await Promise.all([
+      generateDesign(designId, "one"),
+      generateDesign(designId, "two"),
+    ]);
+
+    const usedNumbers = uploadMock.mock.calls.map((c) => c[1]).sort();
+    expect(usedNumbers).toEqual([1, 2]);
+    expect(new Set([a.imageUrl, b.imageUrl]).size).toBe(2);
+
+    const design = await getDesignRow(designId);
+    expect(design.generationCount).toBe(2);
+
+    const imgs = await sourceImages(designId);
+    const urls = imgs.map((i) => i.imageUrl).sort();
+    expect(urls).toEqual([
+      `https://r2/${designId}/1.png`,
+      `https://r2/${designId}/2.png`,
+    ]);
+  });
+
+  it("deletes the orphaned R2 object when the DB batch fails", async () => {
+    const designId = await seedDesign(0);
+    vi.spyOn(testDb, "batch").mockRejectedValueOnce(new Error("boom"));
+
+    await expect(generateDesign(designId, "boom")).rejects.toThrow();
+
+    expect(uploadMock).toHaveBeenCalledWith(designId, 1, expect.anything());
+    expect(deleteMock).toHaveBeenCalledWith(designId, 1);
+    // No row was committed.
+    expect(await sourceImages(designId)).toHaveLength(0);
+  });
+
+  it("refunds the consumed quota unit when generation throws", async () => {
+    process.env.GUEST_FUNNEL_ENABLED = "true";
+    const designId = await seedDesign(0);
+    ideogramGen.mockRejectedValue(new Error("model down"));
+
+    await expect(generateDesign(designId, "cat")).rejects.toThrow(
+      "Image generation failed"
+    );
+
+    // consume bumped user:u1 → 1, the failure refunded it back to 0.
+    const [usage] = await testDb
+      .select()
+      .from(schema.generationUsage)
+      .where(eq(schema.generationUsage.bucket, "user:u1"));
+    expect(usage.count).toBe(0);
+    // Reservation happens after the render, so a pre-upload failure left no gap.
+    expect(uploadMock).not.toHaveBeenCalled();
+    expect((await getDesignRow(designId)).generationCount).toBe(0);
+  });
+});
+
+describe("compareGenerators — R2 key derivation", () => {
+  it("gives each adapter a distinct reserved number and batches the rows", async () => {
+    const designId = await seedDesign(5);
+
+    const res = await compareGenerators(designId, "a cat");
+
+    const usedNumbers = uploadMock.mock.calls.map((c) => c[1]).sort();
+    expect(usedNumbers).toEqual([6, 7]);
+    expect(res.images).toHaveLength(2);
+
+    const design = await getDesignRow(designId);
+    expect(design.generationCount).toBe(7);
+    expect(design.generationCost).toBeCloseTo(0.07); // 0.03 + 0.04
+
+    const imgs = await sourceImages(designId);
+    expect(imgs.map((i) => i.imageUrl).sort()).toEqual([
+      `https://r2/${designId}/6.png`,
+      `https://r2/${designId}/7.png`,
+    ]);
+    expect(imgs.map((i) => i.generator).sort()).toEqual(["ideogram", "recraft"]);
+
+    const msgs = await chatMessages(designId);
+    expect(msgs.filter((m) => m.role === "assistant")).toHaveLength(1);
+    expect(msgs.find((m) => m.role === "user")!.content).toBe("a cat");
+  });
+
+  it("advances the counter past every reserved slot even when one adapter fails", async () => {
+    const designId = await seedDesign(0);
+    recraftGen.mockRejectedValue(new Error("recraft down"));
+
+    const res = await compareGenerators(designId, "a cat");
+
+    // One image succeeded, but both slots were reserved — the counter must
+    // clear all of them so a later generation can't reuse the failed slot's key.
+    expect(res.images).toHaveLength(1);
+    expect((await getDesignRow(designId)).generationCount).toBe(2);
+    const imgs = await sourceImages(designId);
+    expect(imgs).toHaveLength(1);
+    expect(imgs[0].imageUrl).toBe(`https://r2/${designId}/1.png`);
+  });
+});

--- a/src/app/design/actions.ts
+++ b/src/app/design/actions.ts
@@ -3,19 +3,24 @@
 import { headers } from "next/headers";
 import { after } from "next/server";
 import { auth, isAnonymousUser } from "@/lib/auth";
-import { consumeGenerationQuota } from "@/lib/generation-quota";
+import {
+  consumeGenerationQuota,
+  refundGenerationQuota,
+} from "@/lib/generation-quota";
 import { db } from "@/lib/db";
 import {
   design as designTable,
   designImage as designImageTable,
+  chatMessage as chatMessageTable,
   order as orderTable,
 } from "@/lib/db/schema";
-import { eq } from "drizzle-orm";
+import { eq, sql } from "drizzle-orm";
 import { chatAboutDesign, constructFluxPrompt, assessReadiness } from "@/lib/ai";
-import { uploadDesignImage } from "@/lib/r2";
+import { uploadDesignImage, deleteDesignImageObject } from "@/lib/r2";
 import { getGenerator, GENERATORS, DEFAULT_GENERATOR_ID } from "@/lib/generators/registry";
 import {
   insertDesignImage,
+  reserveGenerationNumbers,
   findDesignImageByUrl,
   getDesignSourceImages,
   getDesignPlacementRenders,
@@ -128,13 +133,14 @@ export async function generateDesign(
   if (!session) throw new Error("Unauthorized");
 
   const found = await getOrCreateDesign(designId, session.user.id);
+  const ip = clientIp(hdrs);
 
   // Abuse guard (#26 A3): count this generation against the daily caps before
   // any paid model call. Over the cap → nudge to sign in, no API spend.
   const quota = await consumeGenerationQuota({
     userId: session.user.id,
     isAnonymous: isAnonymousUser(session.user),
-    ip: clientIp(hdrs),
+    ip,
   });
   if (!quota.allowed) {
     return {
@@ -146,6 +152,28 @@ export async function generateDesign(
     };
   }
 
+  // Quota is consumed above; if the generation then throws, refund the unit so
+  // a failed render doesn't cost the user a design (guests get only 8/day).
+  // Clarification early-returns below aren't failures — they leave quota spent.
+  try {
+    return await runGenerate({ designId, found, userMessage });
+  } catch (err) {
+    await refundGenerationQuota({ userId: session.user.id, ip }).catch((e) =>
+      console.error("refundGenerationQuota failed:", e)
+    );
+    throw err;
+  }
+}
+
+async function runGenerate({
+  designId,
+  found,
+  userMessage,
+}: {
+  designId: string;
+  found: typeof designTable.$inferSelect;
+  userMessage?: string;
+}) {
   const messages = await getDesignMessages(designId);
   const images = await getDesignImagesForAIContext(designId);
 
@@ -223,52 +251,78 @@ export async function generateDesign(
     throw new Error("Image generation failed");
   }
 
-  // Download and upload to R2
-  const newGeneration = found.generationCount + 1;
+  // Atomically reserve this generation's number so a concurrent generate can't
+  // land on the same R2 key and overwrite our image (reserved once the render
+  // succeeded, so a failed generate rarely leaves a gap).
+  const [newGeneration] = await reserveGenerationNumbers(designId, 1);
   const response = await fetch(imageUrl);
   const buffer = Buffer.from(await response.arrayBuffer());
   const r2Url = await uploadDesignImage(designId, newGeneration, buffer);
 
-  // Phase 2: record this generation as a first-class design_image row.
-  // Aspect is "1:1" here — chat-driven generations are always square;
-  // product-targeted regenerations happen in preview/actions.ts.
-  const newImageId = await insertDesignImage({
-    designId,
-    imageUrl: r2Url,
-    aspectRatio: "1:1",
-    prompt: aiResponse.fluxPrompt,
-    generationCost: generator.costPerImage,
-    generator: generator.id,
-  });
+  try {
+    const newImageId = crypto.randomUUID();
+    // Anchor provenance on the latest image the user's request was built from,
+    // not a "latest by createdAt" re-read that a racing generate could shift.
+    const parentImageId = images[images.length - 1]?.id ?? null;
 
-  if (userMessage) {
-    await insertChatMessage({ designId, role: "user", content: userMessage });
+    // Commit the four writes atomically (db.batch) so a mid-sequence crash can't
+    // leave a design_image with no assistant message, or an orphaned user turn.
+    // Aspect is "1:1" — chat-driven generations are always square; product
+    // regenerations happen in preview/actions.ts. generationCost is an atomic
+    // increment so a concurrent generate's cost isn't clobbered.
+    await db.batch([
+      db.insert(designImageTable).values({
+        id: newImageId,
+        designId,
+        parentImageId,
+        aspectRatio: "1:1",
+        productId: null,
+        placementId: null,
+        imageUrl: r2Url,
+        prompt: aiResponse.fluxPrompt,
+        generationCost: generator.costPerImage,
+        generator: generator.id,
+        isApproved: false,
+      }),
+      ...(userMessage
+        ? [
+            db.insert(chatMessageTable).values({
+              designId,
+              role: "user" as const,
+              content: userMessage,
+            }),
+          ]
+        : []),
+      db.insert(chatMessageTable).values({
+        designId,
+        role: "assistant" as const,
+        content: aiResponse.message,
+        imageId: newImageId,
+      }),
+      db
+        .update(designTable)
+        .set({
+          primaryImageId: newImageId,
+          generationCost: sql`${designTable.generationCost} + ${generator.costPerImage}`,
+          mockupUrls: null,
+          updatedAt: new Date(),
+        })
+        .where(eq(designTable.id, designId)),
+    ]);
+
+    return {
+      message: aiResponse.message,
+      imageUrl: r2Url,
+      imageId: newImageId,
+      generationNumber: newGeneration,
+      readyToGenerate: true,
+    };
+  } catch (err) {
+    // The DB writes failed after the R2 upload; drop the now-orphaned object so
+    // the reserved key doesn't strand a file nothing references. Best-effort.
+    await deleteDesignImageObject(designId, newGeneration).catch(() => {});
+    throw err;
   }
-  await insertChatMessage({
-    designId,
-    role: "assistant",
-    content: aiResponse.message,
-    imageId: newImageId,
-  });
-
-  await db
-    .update(designTable)
-    .set({
-      primaryImageId: newImageId,
-      generationCount: newGeneration,
-      generationCost: found.generationCost + generator.costPerImage,
-      mockupUrls: null,
-      updatedAt: new Date(),
-    })
-    .where(eq(designTable.id, designId));
-
-  return {
-    message: aiResponse.message,
-    imageUrl: r2Url,
-    imageId: newImageId,
-    generationNumber: newGeneration,
-    readyToGenerate: true,
-  };
 }
 
 export async function uploadReferenceImage(
@@ -471,18 +525,37 @@ export async function compareGenerators(designId: string, userMessage?: string) 
   if (!session) throw new Error("Unauthorized");
 
   const found = await getOrCreateDesign(designId, session.user.id);
+  const ip = clientIp(hdrs);
 
   // Abuse guard (#26 A3): Compare runs two paid model calls, so it's the
   // costliest dead-click — count it against the daily caps before any work.
   const quota = await consumeGenerationQuota({
     userId: session.user.id,
     isAnonymous: isAnonymousUser(session.user),
-    ip: clientIp(hdrs),
+    ip,
   });
   if (!quota.allowed) {
     return { message: generationLimitMessage(quota.reason), images: [], readyToGenerate: true };
   }
 
+  // Refund the consumed unit if the whole compare fails (see generateDesign).
+  try {
+    return await runCompare({ designId, userMessage });
+  } catch (err) {
+    await refundGenerationQuota({ userId: session.user.id, ip }).catch((e) =>
+      console.error("refundGenerationQuota failed:", e)
+    );
+    throw err;
+  }
+}
+
+async function runCompare({
+  designId,
+  userMessage,
+}: {
+  designId: string;
+  userMessage?: string;
+}) {
   const messages = await getDesignMessages(designId);
   const images = await getDesignImagesForAIContext(designId);
   const messagesForPrompt: ChatMessage[] = userMessage
@@ -515,8 +588,18 @@ export async function compareGenerators(designId: string, userMessage?: string) 
       ? images.find((img) => img.number === aiResponse.referenceImage)?.url
       : undefined;
 
+  const gens = Object.values(GENERATORS);
+  // Reserve one number per adapter in a single atomic increment, so parallel
+  // uploads (here and across concurrent Compares/Generates) never collide on
+  // the R2 key designs/{id}/{n}.png. Failed adapters leave their number unused.
+  const reserved = await reserveGenerationNumbers(designId, gens.length);
+  // All compared images share the pre-compare latest source as their parent —
+  // anchoring on a fixed pick beats a "latest by createdAt" re-read that the
+  // parallel inserts would race.
+  const parentImageId = images[images.length - 1]?.id ?? null;
+
   const results = await Promise.all(
-    Object.values(GENERATORS).map(async (g, i) => {
+    gens.map(async (g, i) => {
       try {
         const url = await g.generate(g.adaptPrompt(aiResponse.fluxPrompt), {
           aspect: "1:1",
@@ -525,19 +608,15 @@ export async function compareGenerators(designId: string, userMessage?: string) 
         });
         const response = await fetch(url);
         const buffer = Buffer.from(await response.arrayBuffer());
-        // Distinct generation number per adapter so parallel uploads don't
-        // collide on the R2 key (designs/{id}/{generation}.png).
-        const generation = found.generationCount + 1 + i;
-        const r2Url = await uploadDesignImage(designId, generation, buffer);
-        const imageId = await insertDesignImage({
-          designId,
+        const r2Url = await uploadDesignImage(designId, reserved[i], buffer);
+        // Pre-generate the id and defer the DB insert to the batch below, so all
+        // rows commit atomically with the chat message + design update.
+        return {
+          imageId: crypto.randomUUID(),
           imageUrl: r2Url,
-          aspectRatio: "1:1",
-          prompt: aiResponse.fluxPrompt,
-          generationCost: g.costPerImage,
           generator: g.id,
-        });
-        return { imageId, imageUrl: r2Url, generator: g.id, cost: g.costPerImage };
+          cost: g.costPerImage,
+        };
       } catch (err) {
         console.error(`compareGenerators ${g.id} failed:`, err);
         return null;
@@ -551,31 +630,55 @@ export async function compareGenerators(designId: string, userMessage?: string) 
   // Summarize honestly: name the styles that didn't come back rather than
   // silently undercounting (#19 — "Compared 1 generators"). results is
   // index-aligned with the generators we ran.
-  const gens = Object.values(GENERATORS);
   const succeeded = gens.filter((_, i) => results[i] !== null).map((g) => g.label);
   const failed = gens.filter((_, i) => results[i] === null).map((g) => g.label);
   const summary = compareSummary(succeeded, failed);
-  if (userMessage) {
-    await insertChatMessage({ designId, role: "user", content: userMessage });
-  }
-  await insertChatMessage({
-    designId,
-    role: "assistant",
-    content: summary,
-  });
 
-  // Advance the counter past every slot we *reserved* (one per attempted
-  // adapter), not just the successes — each parallel branch used
-  // generationCount+1+i as its R2 key, so a future generation must start
-  // beyond all of them or it would overwrite a surviving compare image.
-  await db
-    .update(designTable)
-    .set({
-      generationCount: found.generationCount + Object.values(GENERATORS).length,
-      generationCost: found.generationCost + ok.reduce((sum, r) => sum + r.cost, 0),
-      updatedAt: new Date(),
-    })
-    .where(eq(designTable.id, designId));
+  // Commit every image row + the summary message + the cost increment together.
+  // generationCount is already reserved above (atomic), so it's not written here;
+  // generationCost is an atomic increment over the successful adapters' cost.
+  const totalCost = ok.reduce((sum, r) => sum + r.cost, 0);
+  // db.batch is atomic, so element order is only for readability (no FK edges
+  // between these rows). Lead with the design update — a fixed first element
+  // keeps this a non-empty tuple for the batch type.
+  await db.batch([
+    db
+      .update(designTable)
+      .set({
+        generationCost: sql`${designTable.generationCost} + ${totalCost}`,
+        updatedAt: new Date(),
+      })
+      .where(eq(designTable.id, designId)),
+    ...ok.map((r) =>
+      db.insert(designImageTable).values({
+        id: r.imageId,
+        designId,
+        parentImageId,
+        aspectRatio: "1:1",
+        productId: null,
+        placementId: null,
+        imageUrl: r.imageUrl,
+        prompt: aiResponse.fluxPrompt,
+        generationCost: r.cost,
+        generator: r.generator,
+        isApproved: false,
+      })
+    ),
+    ...(userMessage
+      ? [
+          db.insert(chatMessageTable).values({
+            designId,
+            role: "user" as const,
+            content: userMessage,
+          }),
+        ]
+      : []),
+    db.insert(chatMessageTable).values({
+      designId,
+      role: "assistant" as const,
+      content: summary,
+    }),
+  ]);
 
   return { message: summary, images: ok, readyToGenerate: true };
 }

--- a/src/lib/__tests__/generation-quota.integration.test.ts
+++ b/src/lib/__tests__/generation-quota.integration.test.ts
@@ -1,0 +1,165 @@
+/**
+ * DB-path coverage for the generation quota (#40 item c). The pure decision
+ * (quotaDecision) and day bucketing are unit-tested in generation-quota.test.ts;
+ * this exercises the real upsert increment, the identity+IP double-bump, the
+ * anon-vs-signed-in caps, the flag short-circuit, and the WP2 refund helper —
+ * all against a real in-memory libSQL (the #28 pattern).
+ *
+ * consumeGenerationQuota / refundGenerationQuota accept an explicit `db`, so no
+ * module mocking is needed here.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { createTestDb } from "./test-db";
+import * as schema from "@/lib/db/schema";
+import { eq, and } from "drizzle-orm";
+import {
+  consumeGenerationQuota,
+  refundGenerationQuota,
+  GUEST_GEN_DAILY_CAP,
+} from "@/lib/generation-quota";
+
+type Db = Awaited<ReturnType<typeof createTestDb>>;
+let testDb: Db;
+
+const NOW = new Date("2026-07-18T12:00:00Z");
+const DAY = "2026-07-18";
+
+async function countFor(db: Db, bucket: string): Promise<number | null> {
+  const [row] = await db
+    .select({ c: schema.generationUsage.count })
+    .from(schema.generationUsage)
+    .where(
+      and(
+        eq(schema.generationUsage.bucket, bucket),
+        eq(schema.generationUsage.day, DAY)
+      )
+    );
+  return row?.c ?? null;
+}
+
+describe("consumeGenerationQuota — DB path", () => {
+  beforeEach(async () => {
+    testDb = await createTestDb();
+    process.env.GUEST_FUNNEL_ENABLED = "true";
+  });
+  afterEach(() => {
+    delete process.env.GUEST_FUNNEL_ENABLED;
+  });
+
+  it("no-ops (always allowed, writes nothing) when the funnel flag is off", async () => {
+    delete process.env.GUEST_FUNNEL_ENABLED;
+    const res = await consumeGenerationQuota({
+      userId: "u1",
+      isAnonymous: true,
+      ip: "1.2.3.4",
+      now: NOW,
+      db: testDb,
+    });
+    expect(res).toEqual({ allowed: true });
+    expect(await countFor(testDb, "user:u1")).toBeNull();
+    expect(await countFor(testDb, "ip:1.2.3.4")).toBeNull();
+  });
+
+  it("upsert-increments the identity and IP buckets on each call", async () => {
+    await consumeGenerationQuota({
+      userId: "u1",
+      isAnonymous: false,
+      ip: "1.2.3.4",
+      now: NOW,
+      db: testDb,
+    });
+    await consumeGenerationQuota({
+      userId: "u1",
+      isAnonymous: false,
+      ip: "1.2.3.4",
+      now: NOW,
+      db: testDb,
+    });
+    expect(await countFor(testDb, "user:u1")).toBe(2);
+    expect(await countFor(testDb, "ip:1.2.3.4")).toBe(2);
+  });
+
+  it("only bumps identity when no IP is available", async () => {
+    await consumeGenerationQuota({
+      userId: "u1",
+      isAnonymous: false,
+      ip: null,
+      now: NOW,
+      db: testDb,
+    });
+    expect(await countFor(testDb, "user:u1")).toBe(1);
+  });
+
+  it("blocks a guest past the anon cap but a signed-in user sails through it", async () => {
+    // Push a guest one over the cap; the call that crosses is blocked.
+    let last;
+    for (let i = 0; i < GUEST_GEN_DAILY_CAP + 1; i++) {
+      last = await consumeGenerationQuota({
+        userId: "guest",
+        isAnonymous: true,
+        ip: null,
+        now: NOW,
+        db: testDb,
+      });
+    }
+    expect(last).toEqual({ allowed: false, reason: "identity" });
+
+    // A signed-in user at the same count is still under the larger cap.
+    let signedIn;
+    for (let i = 0; i < GUEST_GEN_DAILY_CAP + 1; i++) {
+      signedIn = await consumeGenerationQuota({
+        userId: "real",
+        isAnonymous: false,
+        ip: null,
+        now: NOW,
+        db: testDb,
+      });
+    }
+    expect(signedIn).toEqual({ allowed: true });
+  });
+});
+
+describe("refundGenerationQuota — DB path (#40 WP2)", () => {
+  beforeEach(async () => {
+    testDb = await createTestDb();
+    process.env.GUEST_FUNNEL_ENABLED = "true";
+  });
+  afterEach(() => {
+    delete process.env.GUEST_FUNNEL_ENABLED;
+  });
+
+  it("decrements the identity and IP buckets a failed generation consumed", async () => {
+    for (let i = 0; i < 3; i++) {
+      await consumeGenerationQuota({
+        userId: "u1",
+        isAnonymous: true,
+        ip: "1.2.3.4",
+        now: NOW,
+        db: testDb,
+      });
+    }
+    await refundGenerationQuota({ userId: "u1", ip: "1.2.3.4", now: NOW, db: testDb });
+    expect(await countFor(testDb, "user:u1")).toBe(2);
+    expect(await countFor(testDb, "ip:1.2.3.4")).toBe(2);
+  });
+
+  it("floors at 0 and never goes negative", async () => {
+    await consumeGenerationQuota({
+      userId: "u1",
+      isAnonymous: true,
+      ip: null,
+      now: NOW,
+      db: testDb,
+    });
+    await refundGenerationQuota({ userId: "u1", ip: null, now: NOW, db: testDb });
+    await refundGenerationQuota({ userId: "u1", ip: null, now: NOW, db: testDb });
+    expect(await countFor(testDb, "user:u1")).toBe(0);
+  });
+
+  it("no-ops when the funnel flag is off", async () => {
+    delete process.env.GUEST_FUNNEL_ENABLED;
+    // Nothing to refund and no throw — a signed-in path never wants side effects.
+    await refundGenerationQuota({ userId: "u1", ip: "1.2.3.4", now: NOW, db: testDb });
+    expect(await countFor(testDb, "user:u1")).toBeNull();
+  });
+});

--- a/src/lib/__tests__/reserve-generation-numbers.integration.test.ts
+++ b/src/lib/__tests__/reserve-generation-numbers.integration.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Atomic generation-number reservation (#40, WP2). The R2 key for a generated
+ * image is designs/{id}/{n}.png where n comes from design.generation_count.
+ * The old read-then-write let two concurrent generates both read N and both
+ * write N+1 — the second R2 put overwrote the first image while both rows
+ * pointed at it. reserveGenerationNumbers replaces that with an atomic
+ * UPDATE ... RETURNING so each caller gets a disjoint range. Real in-memory
+ * libSQL (the #28 pattern).
+ */
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { createTestDb } from "./test-db";
+import * as schema from "@/lib/db/schema";
+import { eq } from "drizzle-orm";
+
+type Db = Awaited<ReturnType<typeof createTestDb>>;
+let testDb: Db;
+
+vi.mock("@/lib/db", () => ({
+  get db() {
+    return testDb;
+  },
+}));
+
+const { reserveGenerationNumbers } = await import("@/lib/design-images");
+
+async function seedDesign(db: Db, generationCount = 0): Promise<string> {
+  await db.insert(schema.user).values({ id: "u1", email: "a@b.c", name: "A" });
+  const [design] = await db
+    .insert(schema.design)
+    .values({ userId: "u1", generationCount })
+    .returning();
+  return design.id;
+}
+
+describe("reserveGenerationNumbers", () => {
+  beforeEach(async () => {
+    testDb = await createTestDb();
+  });
+
+  it("returns the next number and advances the counter", async () => {
+    const designId = await seedDesign(testDb, 5);
+    expect(await reserveGenerationNumbers(designId, 1)).toEqual([6]);
+
+    const [row] = await testDb
+      .select({ n: schema.design.generationCount })
+      .from(schema.design)
+      .where(eq(schema.design.id, designId));
+    expect(row.n).toBe(6);
+  });
+
+  it("reserves a contiguous block for a multi-image compare", async () => {
+    const designId = await seedDesign(testDb, 0);
+    expect(await reserveGenerationNumbers(designId, 2)).toEqual([1, 2]);
+    expect(await reserveGenerationNumbers(designId, 3)).toEqual([3, 4, 5]);
+  });
+
+  it("hands parallel reservations disjoint numbers (no collision)", async () => {
+    const designId = await seedDesign(testDb, 0);
+
+    const batches = await Promise.all([
+      reserveGenerationNumbers(designId, 1),
+      reserveGenerationNumbers(designId, 1),
+      reserveGenerationNumbers(designId, 1),
+      reserveGenerationNumbers(designId, 2),
+    ]);
+
+    const all = batches.flat().sort((a, b) => a - b);
+    // 5 numbers reserved total, every one distinct and contiguous from 1.
+    expect(all).toEqual([1, 2, 3, 4, 5]);
+    expect(new Set(all).size).toBe(all.length);
+  });
+
+  it("throws for an unknown design", async () => {
+    await expect(reserveGenerationNumbers("nope", 1)).rejects.toThrow(
+      "Design not found"
+    );
+  });
+});

--- a/src/lib/design-images.ts
+++ b/src/lib/design-images.ts
@@ -5,8 +5,34 @@ import {
   chatMessage as chatMessageTable,
   type ChatMessage,
 } from "@/lib/db/schema";
-import { eq, and, asc, desc, inArray, isNull, isNotNull } from "drizzle-orm";
+import { eq, and, asc, desc, inArray, isNull, isNotNull, sql } from "drizzle-orm";
 import { getBlank, type AspectRatio } from "@/lib/blanks";
+
+/**
+ * Atomically reserve `count` generation numbers for a design in a single
+ * `UPDATE ... RETURNING`, returning the reserved numbers ascending. Two
+ * concurrent generations get disjoint ranges, so the R2 keys they derive
+ * (designs/{id}/{n}.png) never collide — the read-modify-write this replaces
+ * let both read N and both write N+1, permanently overwriting one image.
+ *
+ * A generation that fails after reserving leaves its number unused: gaps in
+ * the sequence are expected and harmless (the number only seeds an R2 key, it
+ * is not a dense index).
+ */
+export async function reserveGenerationNumbers(
+  designId: string,
+  count: number
+): Promise<number[]> {
+  const [row] = await db
+    .update(designTable)
+    .set({ generationCount: sql`${designTable.generationCount} + ${count}` })
+    .where(eq(designTable.id, designId))
+    .returning({ generationCount: designTable.generationCount });
+  if (!row) throw new Error("Design not found");
+  const end = row.generationCount;
+  const start = end - count + 1;
+  return Array.from({ length: count }, (_, i) => start + i);
+}
 
 export type DesignImage = {
   id: string;

--- a/src/lib/generation-quota.ts
+++ b/src/lib/generation-quota.ts
@@ -1,4 +1,4 @@
-import { sql } from "drizzle-orm";
+import { sql, and, eq } from "drizzle-orm";
 import type { db as appDb } from "./db";
 import { generationUsage } from "./db/schema";
 import { guestFunnelEnabled } from "./flags";
@@ -83,4 +83,33 @@ export async function consumeGenerationQuota(opts: {
     identityCap,
     ipCap: IP_GEN_DAILY_CAP,
   });
+}
+
+/** Decrement one (bucket, day) counter by 1, floored at 0. */
+async function unbump(bucket: string, day: string, db: AppDb): Promise<void> {
+  await db
+    .update(generationUsage)
+    .set({ count: sql`max(${generationUsage.count} - 1, 0)` })
+    .where(and(eq(generationUsage.bucket, bucket), eq(generationUsage.day, day)));
+}
+
+/**
+ * Give back the quota unit a generation consumed when that generation then
+ * failed, so a user isn't charged a design for an image they never got.
+ * Mirrors consumeGenerationQuota's identity + IP buckets and floors at 0.
+ * No-op when the funnel flag is off (caps aren't enforced there anyway).
+ * Caller should treat this as best-effort — refund failure must not mask the
+ * original generation error.
+ */
+export async function refundGenerationQuota(opts: {
+  userId: string;
+  ip: string | null;
+  now?: Date;
+  db?: AppDb;
+}): Promise<void> {
+  if (!guestFunnelEnabled()) return;
+  const db = opts.db ?? (await import("./db")).db;
+  const day = dayKeyUTC(opts.now ?? new Date());
+  await unbump(`user:${opts.userId}`, day, db);
+  if (opts.ip) await unbump(`ip:${opts.ip}`, day, db);
 }

--- a/src/lib/r2.ts
+++ b/src/lib/r2.ts
@@ -3,6 +3,7 @@ import {
   PutObjectCommand,
   GetObjectCommand,
   CopyObjectCommand,
+  DeleteObjectCommand,
 } from "@aws-sdk/client-s3";
 
 const r2 = new S3Client({
@@ -89,6 +90,23 @@ export async function copyDesignImageByUrl(
   );
 
   return `${publicBase}/${destKey}`;
+}
+
+/**
+ * Delete a generation's R2 object by (design, generation number). Best-effort
+ * orphan cleanup: called when a step after the upload fails, so a half-written
+ * generation doesn't leave a stranded object under a reserved key.
+ */
+export async function deleteDesignImageObject(
+  designId: string,
+  generationNumber: number
+): Promise<void> {
+  await r2.send(
+    new DeleteObjectCommand({
+      Bucket: bucket,
+      Key: `designs/${designId}/${generationNumber}.png`,
+    })
+  );
 }
 
 export async function getDesignImage(


### PR DESCRIPTION
Closes #40

Concurrent Generate/Compare read `design.generation_count` once and wrote it back non-atomically, so two parallel renders both derived the R2 key `designs/{id}/{N+1}.png` — the second `PutObject` permanently overwrote the first image while both `design_image` rows pointed at it, and the counter undercounted `generation_count`/`generation_cost`. WP2 fixes the race and adds the quota DB-path coverage #40 item (c) was missing.

## Per-fix summary

1. **Atomic generation-number reservation.** New `reserveGenerationNumbers(designId, n)` in the design DB layer (`src/lib/design-images.ts`) does `UPDATE design SET generation_count = generation_count + n ... RETURNING` and returns the reserved numbers. `generateDesign` reserves 1; `compareGenerators` reserves one per adapter in a single increment. R2 keys derive from the reserved numbers, so concurrent callers get disjoint keys. `generation_cost` is now an atomic `sql\`generation_cost + cost\`` increment. Failed generations may leave a gap in the number sequence — expected and harmless (the number only seeds an R2 key, it isn't a dense index).

2. **Batched success-path writes.** The 4+ sequential awaits (design_image insert, user + assistant chat_message inserts, design update) now commit as one `db.batch`, so a mid-sequence crash can't leave a design_image with no assistant message or an orphaned user turn. Same for `compareGenerators`' tail (all image rows + summary message + cost increment).

3. **Quota refund on failure.** Quota is consumed before the model call; if the generation throws, `refundGenerationQuota` decrements the identity + IP buckets (floored at 0) so a user isn't charged a design for an image they never got. Blocked-by-quota and clarification returns are unchanged (no refund — they aren't failures). `consumeGenerationQuota` is untouched (its `onConflictDoUpdate` increment was already atomic).

4. **Quota DB-path integration tests** — the real gap in #40(c): `consumeGenerationQuota` against the real-DB harness (upsert increment, identity+IP double-bump, anon vs signed-in caps, flag short-circuit) plus the new refund helper.

5. **Optional extras (both cheap, both done):** best-effort R2 object delete when the post-upload DB batch fails (orphan cleanup, `generateDesign` only — see note); and the `parentImageId` "latest by createdAt" race fixed by threading the pre-generation latest source image explicitly in both paths.

> Note: R2 orphan cleanup is wired for `generateDesign` (single upload). Skipped for `compareGenerators` — tracking per-adapter uploaded keys to clean a partial multi-upload bloats the diff for a low-value edge (compare failures already return the successful subset), so it was left out per the WP scope.

## Tests (all green: 478 pass, lint 0 errors, build ok)

- `reserve-generation-numbers.integration.test.ts` — reservation advances the counter, reserves contiguous blocks, and hands parallel reservations disjoint numbers (real libSQL).
- `generation-races.integration.test.ts` — generate/compare derive R2 keys from reserved numbers; two concurrent generates land on distinct keys (no overwrite); success writes batch; DB-batch failure triggers R2 orphan delete; failed generation refunds quota; compare advances the counter past every reserved slot when one adapter fails (mock adapters + R2, real DB).
- `generation-quota.integration.test.ts` — DB-path quota suite + refund helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)