### PR TITLE
fix(money): admin-clicked refunds, COGS reversal on cancel, stranded-submission recovery (WP1)

### DIFF
--- a/src/app/admin/actions.ts
+++ b/src/app/admin/actions.ts
@@ -14,7 +14,7 @@ import {
 import { eq, desc, isNull, isNotNull, sum, count, and } from "drizzle-orm";
 import { alias } from "drizzle-orm/sqlite-core";
 import { revalidatePath } from "next/cache";
-import { createOrder } from "@/lib/printful";
+import { createOrder, getOrderByExternalId } from "@/lib/printful";
 import { generateOrderName } from "@/lib/ai";
 import { assertTransition } from "@/lib/order-state";
 import { summarizeLedger } from "@/lib/ledger";
@@ -25,6 +25,7 @@ import { submitOrderFulfillment } from "@/lib/order-fulfillment";
 import { toStripeSessionData } from "@/lib/stripe-session";
 import { resolveOrderLines } from "@/lib/order-lines";
 import { recoverPendingOrderCore } from "@/lib/recover-pending-order";
+import { refundOrderCore, type RefundOrderResult } from "@/lib/refund-order";
 import { sendPostOrderEmails, createDefaultOrderEmailDeps } from "@/lib/order-emails";
 import { sendOrderConfirmation, sendOwnerOrderAlert } from "@/lib/email";
 import {
@@ -124,6 +125,7 @@ export async function retryPrintfulSubmission(orderId: string) {
     {
       db,
       createPrintfulOrder: createOrder,
+      getPrintfulOrderByExternalId: getOrderByExternalId,
       generateOrderName,
       resolveDesignImageUrl: getDesignDisplayImageUrl,
       resolveImageUrlById: async (imageId) =>
@@ -185,6 +187,7 @@ export async function recoverPendingOrder(
         handleStripeCheckoutCompleted(sessionData, {
           db,
           createPrintfulOrder: createOrder,
+          getPrintfulOrderByExternalId: getOrderByExternalId,
           generateOrderName,
           resolveDesignImageUrl: getDesignDisplayImageUrl,
           resolveImageUrlById: async (imageId) =>
@@ -204,6 +207,38 @@ export async function recoverPendingOrder(
     console.error(`recoverPendingOrder(${orderId}) failed:`, err);
     return { ok: false, reason };
   }
+}
+
+/**
+ * Refund a canceled order's customer (finding #1). Admin-clicked only — a
+ * Printful cancel never auto-refunds. Idempotent: a second click is a no-op
+ * (see refundOrderCore). Returns a result object rather than throwing so the UI
+ * can show why a refund was skipped (already refunded, not canceled, $0, etc.).
+ */
+export async function refundOrder(orderId: string): Promise<RefundOrderResult> {
+  const session = await auth.api.getSession({ headers: await headers() });
+  if (!session || session.user.email !== ADMIN_EMAIL) {
+    throw new Error("Unauthorized");
+  }
+
+  const result = await refundOrderCore(orderId, {
+    db,
+    retrievePaymentIntentId: async (stripeSessionId) => {
+      const s = await stripe.checkout.sessions.retrieve(stripeSessionId);
+      return typeof s.payment_intent === "string"
+        ? s.payment_intent
+        : s.payment_intent?.id ?? null;
+    },
+    createRefund: async (paymentIntentId, idempotencyKey) => {
+      await stripe.refunds.create(
+        { payment_intent: paymentIntentId },
+        { idempotencyKey }
+      );
+    },
+  });
+
+  if (result.ok) revalidatePath(`/admin/orders/${orderId}`);
+  return result;
 }
 
 export async function archiveOrder(orderId: string) {

--- a/src/app/admin/orders/[id]/page.tsx
+++ b/src/app/admin/orders/[id]/page.tsx
@@ -8,6 +8,7 @@ import {
   getOrderDetail,
   retryPrintfulSubmission,
   recoverPendingOrder,
+  refundOrder,
   archiveOrder,
   unarchiveOrder,
   setOrderClassification,
@@ -38,6 +39,7 @@ export default function OrderDetailPage() {
   const [loading, setLoading] = useState(true);
   const [retrying, setRetrying] = useState(false);
   const [recovering, setRecovering] = useState(false);
+  const [refunding, setRefunding] = useState(false);
 
   async function fetchOrder() {
     const o = await getOrderDetail(params.id);
@@ -82,6 +84,30 @@ export default function OrderDetailPage() {
       alert(`Recover failed: ${message}`);
     } finally {
       setRecovering(false);
+    }
+  }
+
+  async function handleRefund() {
+    if (
+      !window.confirm(
+        "Refund this customer via Stripe? This issues a real refund and cannot be undone."
+      )
+    )
+      return;
+    setRefunding(true);
+    try {
+      const result = await refundOrder(params.id);
+      if (result.ok) {
+        alert(result.refunded ? "Refund issued." : "Already refunded — no action taken.");
+        await fetchOrder();
+      } else {
+        alert(`Cannot refund: ${result.reason}`);
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      alert(`Refund failed: ${message}`);
+    } finally {
+      setRefunding(false);
     }
   }
 
@@ -143,6 +169,7 @@ export default function OrderDetailPage() {
 
   const profit =
     order.printfulCost != null ? order.totalPrice - order.printfulCost : null;
+  const hasRefund = order.ledger.some((e) => e.type === "refund");
 
   return (
     <div className="max-w-4xl mx-auto py-8 px-4">
@@ -332,6 +359,17 @@ export default function OrderDetailPage() {
                 {retrying ? "Retrying..." : "Retry Printful"}
               </Button>
             )}
+            {order.status === "canceled" &&
+              order.totalPrice > 0 &&
+              (hasRefund ? (
+                <span className="text-xs text-text-muted self-center">
+                  Refunded ${order.totalPrice.toFixed(2)}
+                </span>
+              ) : (
+                <Button size="sm" onClick={handleRefund} disabled={refunding}>
+                  {refunding ? "Refunding..." : `Refund $${order.totalPrice.toFixed(2)}`}
+                </Button>
+              ))}
             {order.trackingUrl && (
               <a href={order.trackingUrl} target="_blank" rel="noopener noreferrer">
                 <Button size="sm" variant="secondary">

--- a/src/app/admin/orders/[id]/page.tsx
+++ b/src/app/admin/orders/[id]/page.tsx
@@ -361,6 +361,7 @@ export default function OrderDetailPage() {
             )}
             {order.status === "canceled" &&
               order.totalPrice > 0 &&
+              order.classification !== "test" &&
               (hasRefund ? (
                 <span className="text-xs text-text-muted self-center">
                   Refunded ${order.totalPrice.toFixed(2)}

--- a/src/app/api/cron/retry-fulfillment/route.ts
+++ b/src/app/api/cron/retry-fulfillment/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/lib/db";
-import { createOrder } from "@/lib/printful";
+import { createOrder, getOrderByExternalId } from "@/lib/printful";
 import { generateOrderName } from "@/lib/ai";
 import { retryStuckFulfillments } from "@/lib/retry-fulfillment";
 import { getDesignDisplayImageUrl, getDesignImageById } from "@/lib/design-images";
@@ -27,6 +27,7 @@ export async function GET(request: NextRequest) {
   const result = await retryStuckFulfillments({
     db,
     createPrintfulOrder: createOrder,
+    getPrintfulOrderByExternalId: getOrderByExternalId,
     generateOrderName,
     resolveDesignImageUrl: getDesignDisplayImageUrl,
     resolveImageUrlById: async (imageId) =>

--- a/src/app/api/webhooks/stripe/route.ts
+++ b/src/app/api/webhooks/stripe/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { stripe } from "@/lib/stripe";
 import { db } from "@/lib/db";
-import { createOrder } from "@/lib/printful";
+import { createOrder, getOrderByExternalId } from "@/lib/printful";
 import { generateOrderName } from "@/lib/ai";
 import {
   handleStripeCheckoutCompleted,
@@ -56,6 +56,7 @@ export async function POST(request: NextRequest) {
       const result = await handleStripeCheckoutCompleted(sessionData, {
         db,
         createPrintfulOrder: createOrder,
+        getPrintfulOrderByExternalId: getOrderByExternalId,
         generateOrderName,
         resolveDesignImageUrl: getDesignDisplayImageUrl,
         resolveImageUrlById: async (imageId) =>

--- a/src/lib/__tests__/ledger.test.ts
+++ b/src/lib/__tests__/ledger.test.ts
@@ -104,9 +104,23 @@ describe("summarizeLedger", () => {
 
   it("excludes a tax pass-through from gross profit (1C)", () => {
     // Tax collected is a liability we remit, not profit. Adding a `tax` type
-    // must not move grossProfit.
+    // must not move grossProfit. (This is the deliberate carve-out: an UNKNOWN
+    // type stays out of profit — but refund_cogs_reversal is NOT unknown, it's a
+    // COGS correction and is folded in, see the next test.)
     const base = { sale: 20, stripe_fee: -0.88, cogs: -10 };
     const withTax = summarizeLedger({ ...base, tax: 1.65 });
     expect(withTax.grossProfit).toBe(summarizeLedger(base).grossProfit);
+  });
+
+  it("folds refund_cogs_reversal into gross profit and net COGS (cancel correction)", () => {
+    // A submitted-then-canceled order: COGS booked, then reversed. Profit and
+    // reported COGS must land exactly where a never-fulfilled order would —
+    // otherwise the reversed COGS is silently double-counted against profit.
+    const withCogs = { sale: 20, stripe_fee: -0.88, cogs: -10 };
+    const reversed = summarizeLedger({ ...withCogs, refund_cogs_reversal: 10 });
+    const noCogs = summarizeLedger({ sale: 20, stripe_fee: -0.88 });
+
+    expect(reversed.grossProfit).toBeCloseTo(noCogs.grossProfit, 5);
+    expect(reversed.cogs).toBe(0); // net COGS is zero after the reversal
   });
 });

--- a/src/lib/__tests__/money-path.integration.test.ts
+++ b/src/lib/__tests__/money-path.integration.test.ts
@@ -417,6 +417,79 @@ describe("money path — checkout.session.completed", () => {
     expect(remaining[0].designId).toBe(d3.id);
   });
 
+  it("returns submitted even when clearing the cart throws (finding #3b: cart cleanup is non-fatal)", async () => {
+    // A one-line cart order so the post-payment cart-clear loop actually runs.
+    const userId = "clear-throw-user";
+    await db
+      .insert(schema.user)
+      .values({ id: userId, email: "clear@example.com", name: "C" });
+    const [d1] = await db.insert(schema.design).values({ userId }).returning();
+    const [order] = await db
+      .insert(schema.order)
+      .values({
+        userId,
+        designId: d1.id,
+        productId: "bella-canvas-3001",
+        size: "M",
+        color: "Black",
+        itemPrice: 19.43,
+        shippingPrice: 4.69,
+        totalPrice: 24.12,
+        status: "pending",
+      })
+      .returning();
+    await db.insert(schema.orderItem).values({
+      orderId: order.id,
+      designId: d1.id,
+      productId: "bella-canvas-3001",
+      size: "M",
+      color: "Black",
+      placements: { front: "img-1" },
+      quantity: 1,
+      itemPrice: 19.43,
+    });
+    await db.insert(schema.cartItem).values({
+      userId,
+      designId: d1.id,
+      productId: "bella-canvas-3001",
+      size: "M",
+      color: "Black",
+    });
+
+    // Make only db.delete blow up (the cart-clear); every other op passes
+    // through to the real db so the paid-claim + fulfillment still run.
+    const throwingDb = new Proxy(db, {
+      get(target, prop, receiver) {
+        if (prop === "delete") {
+          return () => {
+            throw new Error("cart delete boom");
+          };
+        }
+        const value = Reflect.get(target, prop, receiver);
+        return typeof value === "function" ? value.bind(target) : value;
+      },
+    }) as unknown as Db;
+
+    const result = await handleStripeCheckoutCompleted(
+      makeSession(order.id, d1.id),
+      makeDeps(throwingDb, {
+        createPrintfulOrder: vi
+          .fn()
+          .mockResolvedValue({ id: 5555, costs: { total: "12.50" } }),
+        resolveImageUrlById: vi
+          .fn()
+          .mockImplementation(async (id: string) => `https://img.example/${id}.png`),
+      })
+    );
+
+    // Fulfillment succeeded despite the cart-clear failure — no 400 to Stripe.
+    expect(result.action).toBe("submitted");
+    const updated = await db.query.order.findFirst({
+      where: eq(schema.order.id, order.id),
+    });
+    expect(updated?.status).toBe("submitted");
+  });
+
   it("Printful failure leaves the order paid with no COGS and design not ordered", async () => {
     const { order, design } = await seed(db);
     const deps = makeDeps(db, {
@@ -652,10 +725,20 @@ describe("money path — Printful lifecycle events", () => {
     expect(updated?.trackingUrl).toBe("https://track/1Z999");
   });
 
-  it("order_canceled records a refund reversal for the full total", async () => {
+  it("cancel after submitted reverses COGS and never books a phantom refund", async () => {
+    // A submitted order has COGS on the books; Printful canceling it reverses
+    // that cost. The customer refund is a separate admin action, so NO `refund`
+    // row is written here (finding #1).
     const { order } = await seed(db, {
       status: "submitted",
       printfulOrderId: "9999",
+      printfulCost: 12.5,
+    });
+    await db.insert(schema.ledgerEntry).values({
+      orderId: order.id,
+      type: "cogs",
+      amount: -12.5,
+      description: "Printful fulfillment PF:9999",
     });
 
     const result = await handlePrintfulEvent(
@@ -671,9 +754,32 @@ describe("money path — Printful lifecycle events", () => {
     expect(updated?.printfulCost).toBe(0);
 
     const entries = await ledgerFor(db, order.id);
-    expect(entries).toHaveLength(1);
-    expect(entries[0].type).toBe("refund");
-    expect(entries[0].amount).toBe(-24.12);
+    const byType = Object.fromEntries(entries.map((e) => [e.type, e.amount]));
+    // COGS reversed (+12.50 offsets the -12.50 row), no refund booked.
+    expect(byType.refund_cogs_reversal).toBe(12.5);
+    expect(byType.refund).toBeUndefined();
+    expect(entries.filter((e) => e.type === "refund")).toHaveLength(0);
+  });
+
+  it("cancel with no COGS on the books writes neither reversal nor refund", async () => {
+    const { order } = await seed(db, {
+      status: "submitted",
+      printfulOrderId: "9999",
+    });
+
+    const result = await handlePrintfulEvent(
+      { type: "order_canceled", data: { order: { id: 9999 } } },
+      { db }
+    );
+
+    expect(result.action).toBe("canceled");
+    const updated = await db.query.order.findFirst({
+      where: eq(schema.order.id, order.id),
+    });
+    expect(updated?.status).toBe("canceled");
+
+    const entries = await ledgerFor(db, order.id);
+    expect(entries).toHaveLength(0);
   });
 });
 
@@ -913,10 +1019,17 @@ describe("Printful webhook — redelivery (#37)", () => {
     expect(result.orderId).toBe(order.id);
   });
 
-  it("order_canceled redelivery keeps exactly one refund row", async () => {
+  it("order_canceled redelivery keeps exactly one COGS-reversal row", async () => {
     const { order } = await seed(db, {
       status: "submitted",
       printfulOrderId: "pf-2",
+      printfulCost: 12.5,
+    });
+    await db.insert(schema.ledgerEntry).values({
+      orderId: order.id,
+      type: "cogs",
+      amount: -12.5,
+      description: "Printful fulfillment PF:pf-2",
     });
     const payload = { type: "order_canceled", data: { order: { id: "pf-2" } } };
 
@@ -927,6 +1040,6 @@ describe("Printful webhook — redelivery (#37)", () => {
     expect(second.action).toBe("ignored");
 
     const entries = await ledgerFor(db, order.id);
-    expect(entries.filter((e) => e.type === "refund")).toHaveLength(1);
+    expect(entries.filter((e) => e.type === "refund_cogs_reversal")).toHaveLength(1);
   });
 });

--- a/src/lib/__tests__/money-path.integration.test.ts
+++ b/src/lib/__tests__/money-path.integration.test.ts
@@ -9,7 +9,7 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 import { eq } from "drizzle-orm";
 import { createTestDb } from "./test-db";
 import * as schema from "@/lib/db/schema";
-import { calculateStripeFee } from "@/lib/ledger";
+import { calculateStripeFee, summarizeLedger } from "@/lib/ledger";
 import {
   handleStripeCheckoutCompleted,
   handlePrintfulEvent,
@@ -734,12 +734,13 @@ describe("money path — Printful lifecycle events", () => {
       printfulOrderId: "9999",
       printfulCost: 12.5,
     });
-    await db.insert(schema.ledgerEntry).values({
-      orderId: order.id,
-      type: "cogs",
-      amount: -12.5,
-      description: "Printful fulfillment PF:9999",
-    });
+    // A real submitted order's full ledger: sale + fee + cogs.
+    const fee = calculateStripeFee(24.12);
+    await db.insert(schema.ledgerEntry).values([
+      { orderId: order.id, type: "sale", amount: 24.12, description: "sale" },
+      { orderId: order.id, type: "stripe_fee", amount: -fee, description: "fee" },
+      { orderId: order.id, type: "cogs", amount: -12.5, description: "Printful fulfillment PF:9999" },
+    ]);
 
     const result = await handlePrintfulEvent(
       { type: "order_canceled", data: { order: { id: 9999 } } },
@@ -759,6 +760,13 @@ describe("money path — Printful lifecycle events", () => {
     expect(byType.refund_cogs_reversal).toBe(12.5);
     expect(byType.refund).toBeUndefined();
     expect(entries.filter((e) => e.type === "refund")).toHaveLength(0);
+
+    // Summary-level: the reversal must actually move the books. Gross profit
+    // after the cancel equals the never-fulfilled outcome (sale + fee, no COGS)
+    // — this FAILS if summarizeLedger drops refund_cogs_reversal.
+    const summary = summarizeLedger(byType);
+    expect(summary.grossProfit).toBeCloseTo(24.12 - fee, 5);
+    expect(summary.cogs).toBe(0);
   });
 
   it("cancel with no COGS on the books writes neither reversal nor refund", async () => {

--- a/src/lib/__tests__/order-fulfillment.integration.test.ts
+++ b/src/lib/__tests__/order-fulfillment.integration.test.ts
@@ -245,17 +245,15 @@ describe("submitOrderFulfillment (admin-retry shape)", () => {
     expect(call.items).toHaveLength(1);
   });
 
-  it("recovers a stranded submission: duplicate external_id → fetch existing → submitted + COGS", async () => {
+  it("recovers a stranded submission by probing external_id, regardless of the rejection wording", async () => {
     // Finding #2: a prior attempt created the Printful order but crashed before
-    // persisting its id, so this resubmit is rejected as a duplicate. The getter
-    // returns the order Printful already has; we persist it instead of leaving
-    // the printed order stuck `paid` forever.
+    // persisting its id, so this resubmit fails. Recovery probes by external_id
+    // rather than matching the error text — so even a generically-worded /
+    // transient failure recovers as long as Printful actually has the order.
     const { order } = await seedPaidOrder(db);
     const createPrintfulOrder = vi
       .fn()
-      .mockRejectedValue(
-        new Error("Printful API error: 400 External ID (x) is already used by another order")
-      );
+      .mockRejectedValue(new Error("Printful API error: 500 Internal Server Error"));
     const getPrintfulOrderByExternalId = vi
       .fn()
       .mockResolvedValue({ id: 4242, costs: { total: "13.75" } });
@@ -285,7 +283,7 @@ describe("submitOrderFulfillment (admin-retry shape)", () => {
     expect(entries[0].amount).toBe(-13.75);
   });
 
-  it("duplicate external_id but no existing order found → paid_printful_failed", async () => {
+  it("submit fails and the probe finds no existing order → paid_printful_failed", async () => {
     const { order } = await seedPaidOrder(db);
     const result = await submitOrderFulfillment(
       order,
@@ -294,7 +292,7 @@ describe("submitOrderFulfillment (admin-retry shape)", () => {
       makeDeps(db, {
         createPrintfulOrder: vi
           .fn()
-          .mockRejectedValue(new Error("400 External ID already used")),
+          .mockRejectedValue(new Error("Printful API error: 503")),
         getPrintfulOrderByExternalId: vi.fn().mockResolvedValue(null),
       })
     );

--- a/src/lib/__tests__/order-fulfillment.integration.test.ts
+++ b/src/lib/__tests__/order-fulfillment.integration.test.ts
@@ -245,6 +245,93 @@ describe("submitOrderFulfillment (admin-retry shape)", () => {
     expect(call.items).toHaveLength(1);
   });
 
+  it("recovers a stranded submission: duplicate external_id → fetch existing → submitted + COGS", async () => {
+    // Finding #2: a prior attempt created the Printful order but crashed before
+    // persisting its id, so this resubmit is rejected as a duplicate. The getter
+    // returns the order Printful already has; we persist it instead of leaving
+    // the printed order stuck `paid` forever.
+    const { order } = await seedPaidOrder(db);
+    const createPrintfulOrder = vi
+      .fn()
+      .mockRejectedValue(
+        new Error("Printful API error: 400 External ID (x) is already used by another order")
+      );
+    const getPrintfulOrderByExternalId = vi
+      .fn()
+      .mockResolvedValue({ id: 4242, costs: { total: "13.75" } });
+
+    const result = await submitOrderFulfillment(
+      order,
+      [],
+      SHIPPING,
+      makeDeps(db, { createPrintfulOrder, getPrintfulOrderByExternalId })
+    );
+
+    expect(result.action).toBe("submitted");
+    expect(getPrintfulOrderByExternalId).toHaveBeenCalledWith(order.id);
+
+    const updated = await db.query.order.findFirst({
+      where: eq(schema.order.id, order.id),
+    });
+    expect(updated?.status).toBe("submitted");
+    expect(updated?.printfulOrderId).toBe("4242");
+    expect(updated?.printfulCost).toBe(13.75);
+
+    const entries = await db.query.ledgerEntry.findMany({
+      where: eq(schema.ledgerEntry.orderId, order.id),
+    });
+    expect(entries).toHaveLength(1);
+    expect(entries[0].type).toBe("cogs");
+    expect(entries[0].amount).toBe(-13.75);
+  });
+
+  it("duplicate external_id but no existing order found → paid_printful_failed", async () => {
+    const { order } = await seedPaidOrder(db);
+    const result = await submitOrderFulfillment(
+      order,
+      [],
+      SHIPPING,
+      makeDeps(db, {
+        createPrintfulOrder: vi
+          .fn()
+          .mockRejectedValue(new Error("400 External ID already used")),
+        getPrintfulOrderByExternalId: vi.fn().mockResolvedValue(null),
+      })
+    );
+
+    expect(result.action).toBe("paid_printful_failed");
+    const updated = await db.query.order.findFirst({
+      where: eq(schema.order.id, order.id),
+    });
+    expect(updated?.status).toBe("paid");
+  });
+
+  it("returns paid_printful_failed when image resolution throws (finding #3a: reads inside the try)", async () => {
+    const { order } = await seedPaidOrder(db);
+    const createPrintfulOrder = vi.fn();
+    const result = await submitOrderFulfillment(
+      order,
+      [],
+      SHIPPING,
+      makeDeps(db, {
+        createPrintfulOrder,
+        // A transient R2/DB read error while resolving the print image must not
+        // throw unhandled (that 400s the Stripe webhook) — it yields a
+        // cron-retryable paid_printful_failed instead.
+        resolveDesignImageUrl: vi
+          .fn()
+          .mockRejectedValue(new Error("R2 read timeout")),
+      })
+    );
+
+    expect(result.action).toBe("paid_printful_failed");
+    expect(createPrintfulOrder).not.toHaveBeenCalled();
+    const updated = await db.query.order.findFirst({
+      where: eq(schema.order.id, order.id),
+    });
+    expect(updated?.status).toBe("paid");
+  });
+
   it("returns paid_printful_failed with no COGS when Printful errors", async () => {
     const { order } = await seedPaidOrder(db);
     const result = await submitOrderFulfillment(

--- a/src/lib/__tests__/refund-order.integration.test.ts
+++ b/src/lib/__tests__/refund-order.integration.test.ts
@@ -88,6 +88,44 @@ describe("refundOrderCore", () => {
     expect(entries.filter((e) => e.type === "refund")).toHaveLength(1);
   });
 
+  it("books the ledger row when Stripe reports the charge is already refunded (crash-replay past the idempotency TTL)", async () => {
+    // A prior click refunded at Stripe but died before booking the ledger row;
+    // the stable idempotency key has since expired, so Stripe now rejects the
+    // replay with charge_already_refunded. The action must treat that as success
+    // and book the missing row — not throw forever.
+    const { order } = await seedCanceledOrder(db);
+    const alreadyRefunded = Object.assign(new Error("Charge already refunded."), {
+      code: "charge_already_refunded",
+    });
+    const deps = makeDeps(db, {
+      createRefund: vi.fn().mockRejectedValue(alreadyRefunded),
+    });
+
+    const result = await refundOrderCore(order.id, deps);
+
+    expect(result).toEqual({ ok: true, refunded: true });
+    const entries = await db.query.ledgerEntry.findMany({
+      where: eq(schema.ledgerEntry.orderId, order.id),
+    });
+    expect(entries.filter((e) => e.type === "refund")).toHaveLength(1);
+    expect(entries[0].amount).toBe(-24.12);
+  });
+
+  it("rethrows a non-benign Stripe error and books nothing", async () => {
+    const { order } = await seedCanceledOrder(db);
+    const deps = makeDeps(db, {
+      createRefund: vi
+        .fn()
+        .mockRejectedValue(Object.assign(new Error("boom"), { code: "card_declined" })),
+    });
+
+    await expect(refundOrderCore(order.id, deps)).rejects.toThrow("boom");
+    const entries = await db.query.ledgerEntry.findMany({
+      where: eq(schema.ledgerEntry.orderId, order.id),
+    });
+    expect(entries).toHaveLength(0);
+  });
+
   it("refuses a non-canceled order without touching Stripe", async () => {
     const { order } = await seedCanceledOrder(db, { status: "submitted" });
     const deps = makeDeps(db);

--- a/src/lib/__tests__/refund-order.integration.test.ts
+++ b/src/lib/__tests__/refund-order.integration.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Admin refund core (finding #1) against a real in-memory DB. Only Stripe is
+ * mocked (payment-intent lookup + refund); the ledger + order rows are real, so
+ * the idempotency guard (existing `refund` row / unique index) is exercised.
+ */
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { eq } from "drizzle-orm";
+import { createTestDb } from "./test-db";
+import * as schema from "@/lib/db/schema";
+import { refundOrderCore, type RefundOrderDeps } from "@/lib/refund-order";
+
+type Db = Awaited<ReturnType<typeof createTestDb>>;
+
+async function seedCanceledOrder(
+  db: Db,
+  overrides: Partial<typeof schema.order.$inferInsert> = {}
+) {
+  const userId = "user-1";
+  await db
+    .insert(schema.user)
+    .values({ id: userId, email: "buyer@example.com", name: "Buyer" });
+  const [design] = await db.insert(schema.design).values({ userId }).returning();
+  const [order] = await db
+    .insert(schema.order)
+    .values({
+      userId,
+      designId: design.id,
+      productId: "bella-canvas-3001",
+      size: "M",
+      color: "Black",
+      totalPrice: 24.12,
+      status: "canceled",
+      stripeSessionId: "cs_test_1",
+      ...overrides,
+    })
+    .returning();
+  return { order };
+}
+
+function makeDeps(db: Db, overrides: Partial<RefundOrderDeps> = {}): RefundOrderDeps {
+  return {
+    db,
+    retrievePaymentIntentId: vi.fn().mockResolvedValue("pi_123"),
+    createRefund: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  } as unknown as RefundOrderDeps;
+}
+
+describe("refundOrderCore", () => {
+  let db: Db;
+  beforeEach(async () => {
+    db = await createTestDb();
+  });
+
+  it("issues a Stripe refund and books one refund ledger row", async () => {
+    const { order } = await seedCanceledOrder(db);
+    const deps = makeDeps(db);
+
+    const result = await refundOrderCore(order.id, deps);
+
+    expect(result).toEqual({ ok: true, refunded: true });
+    expect(deps.createRefund).toHaveBeenCalledTimes(1);
+    expect(deps.createRefund).toHaveBeenCalledWith("pi_123", `refund-${order.id}`);
+
+    const entries = await db.query.ledgerEntry.findMany({
+      where: eq(schema.ledgerEntry.orderId, order.id),
+    });
+    expect(entries).toHaveLength(1);
+    expect(entries[0].type).toBe("refund");
+    expect(entries[0].amount).toBe(-24.12);
+  });
+
+  it("is idempotent: a second refund is a no-op — no second Stripe refund, no duplicate row", async () => {
+    const { order } = await seedCanceledOrder(db);
+    const deps = makeDeps(db);
+
+    const first = await refundOrderCore(order.id, deps);
+    expect(first).toEqual({ ok: true, refunded: true });
+
+    const second = await refundOrderCore(order.id, deps);
+    expect(second).toEqual({ ok: true, refunded: false });
+
+    // Stripe called exactly once across both invocations.
+    expect(deps.createRefund).toHaveBeenCalledTimes(1);
+    const entries = await db.query.ledgerEntry.findMany({
+      where: eq(schema.ledgerEntry.orderId, order.id),
+    });
+    expect(entries.filter((e) => e.type === "refund")).toHaveLength(1);
+  });
+
+  it("refuses a non-canceled order without touching Stripe", async () => {
+    const { order } = await seedCanceledOrder(db, { status: "submitted" });
+    const deps = makeDeps(db);
+
+    const result = await refundOrderCore(order.id, deps);
+
+    expect(result.ok).toBe(false);
+    expect(deps.createRefund).not.toHaveBeenCalled();
+  });
+
+  it("refuses when the order has no Stripe session", async () => {
+    const { order } = await seedCanceledOrder(db, { stripeSessionId: null });
+    const deps = makeDeps(db);
+
+    const result = await refundOrderCore(order.id, deps);
+
+    expect(result).toEqual({ ok: false, reason: "No Stripe session on this order" });
+    expect(deps.createRefund).not.toHaveBeenCalled();
+  });
+
+  it("refuses when the session has no payment intent", async () => {
+    const { order } = await seedCanceledOrder(db);
+    const deps = makeDeps(db, {
+      retrievePaymentIntentId: vi.fn().mockResolvedValue(null),
+    });
+
+    const result = await refundOrderCore(order.id, deps);
+
+    expect(result.ok).toBe(false);
+    expect(deps.createRefund).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/ledger.ts
+++ b/src/lib/ledger.ts
@@ -88,7 +88,26 @@ export function refundLedgerRow(
     type: "refund",
     amount: -originalAmount,
     description,
-    metadata: { note: "Order canceled before fulfillment, refund pending" },
+    metadata: { note: "Customer refund issued via Stripe" },
+  };
+}
+
+/**
+ * Reverse a booked COGS entry when Printful cancels an order — their cost is no
+ * longer incurred. `cogsAmount` is the (negative) amount on the `cogs` row being
+ * reversed; negating it yields the positive offset. This is a fact independent
+ * of whether the customer is refunded (that's the admin-clicked `refund` row).
+ */
+export function refundCogsReversalRow(
+  orderId: string,
+  cogsAmount: number,
+  description: string
+): LedgerRow {
+  return {
+    orderId,
+    type: "refund_cogs_reversal",
+    amount: -cogsAmount,
+    description,
   };
 }
 

--- a/src/lib/ledger.ts
+++ b/src/lib/ledger.ts
@@ -13,23 +13,27 @@ type DbInstance = Pick<typeof db, "insert" | "query">;
  * Pure, so it's tested without an admin session (getFinancialSummary wraps
  * it after auth + the grouped query).
  *
- * `grossProfit` sums only sale + refund + stripe_fee + cogs. A `tax`
- * pass-through (1C — only if collection is ever turned on) is a liability we
- * remit, not revenue, so it must stay OUT of profit. It's excluded by
- * omission today; the test locks that so a later refactor can't fold a new
- * type into the total by accident.
+ * `grossProfit` sums sale + refund + stripe_fee + cogs + refund_cogs_reversal.
+ * `refund_cogs_reversal` is a COGS *correction* — booked when Printful cancels a
+ * submitted order, so their cost is no longer incurred — and MUST net against
+ * COGS, or a canceled-with-COGS order permanently understates profit by the full
+ * COGS. A `tax` pass-through (1C — only if collection is ever turned on) is a
+ * different case: a liability we remit, not revenue, so it stays OUT of profit.
+ * The tests lock both: reversal in, tax out.
  */
 export function summarizeLedger(byType: Record<string, number>) {
   const sales = byType["sale"] ?? 0;
   const stripeFees = byType["stripe_fee"] ?? 0;
   const cogs = byType["cogs"] ?? 0;
+  const cogsReversal = byType["refund_cogs_reversal"] ?? 0;
   const refunds = byType["refund"] ?? 0;
+  const netCogs = cogs + cogsReversal; // reversal (+) offsets the cogs row (−)
   const revenue = sales + refunds;
   return {
     revenue,
     stripeFees,
-    cogs: Math.abs(cogs),
-    grossProfit: revenue + stripeFees + cogs,
+    cogs: Math.abs(netCogs),
+    grossProfit: revenue + stripeFees + netCogs,
   };
 }
 

--- a/src/lib/order-fulfillment.ts
+++ b/src/lib/order-fulfillment.ts
@@ -21,7 +21,6 @@ import { getBlank, getVariantId } from "@/lib/blanks";
 import { assertTransition } from "@/lib/order-state";
 import { cogsLedgerRow } from "@/lib/ledger";
 import { withTimeout } from "@/lib/timeout";
-import { isDuplicateExternalIdError } from "@/lib/printful";
 import type { createOrder, PrintfulOrderItem } from "@/lib/printful";
 import type { db as appDb } from "@/lib/db";
 import type { generateOrderName } from "@/lib/ai";
@@ -182,33 +181,34 @@ export async function submitOrderFulfillment(
         countryCode: shipping?.country ?? "US",
         zip: shipping?.zip ?? "",
       });
-    } catch (err) {
-      // Recovery (finding #2): a prior attempt created the Printful order but
-      // crashed before persisting its id, so this resubmit is rejected as a
-      // duplicate external_id. Fetch the order Printful already has and persist
-      // it below — otherwise every retry hits the same dedupe forever and the
-      // printed order is stranded `paid` (COGS unbooked, no shipping match).
-      if (isDuplicateExternalIdError(err) && deps.getPrintfulOrderByExternalId) {
-        console.warn(
-          `Order ${orderId}: Printful rejected duplicate external_id — recovering existing order`
-        );
-        const existing = await deps
-          .getPrintfulOrderByExternalId(orderId)
-          .catch((fetchErr) => {
+    } catch (createErr) {
+      // Recovery probe (finding #2): a prior attempt may have created the
+      // Printful order but crashed before persisting its id — the resubmit then
+      // fails (duplicate external_id, or any transient error). Probe by
+      // external_id rather than pattern-matching the rejection text: if Printful
+      // already has the order, adopt it and persist it below; otherwise the
+      // printed order is stranded `paid` forever (COGS unbooked, no shipping
+      // match). Phrasing-independent, so a Printful message change can't defeat
+      // it, and it also covers a network error that dropped the create response.
+      // Probe finds nothing (404 → null) or itself fails → rethrow the original
+      // error → paid_printful_failed, cron-retryable.
+      const recovered = deps.getPrintfulOrderByExternalId
+        ? await deps.getPrintfulOrderByExternalId(orderId).catch((probeErr) => {
             console.error(
-              `Order ${orderId}: could not fetch existing Printful order:`,
-              fetchErr
+              `Order ${orderId}: recovery probe (getOrderByExternalId) failed:`,
+              probeErr
             );
             return null;
-          });
-        if (!existing) return { action: "paid_printful_failed" };
-        printfulOrder = existing;
-      } else {
-        throw err;
-      }
+          })
+        : null;
+      if (!recovered) throw createErr;
+      console.warn(
+        `Order ${orderId}: adopting the existing Printful order after a submit failure (recovered by external_id)`
+      );
+      printfulOrder = recovered;
     }
     // Narrows for the type checker — either branch above set printfulOrder or
-    // already returned/threw.
+    // already threw.
     if (!printfulOrder) return { action: "paid_printful_failed" };
 
     assertTransition("paid", "submitted");
@@ -249,6 +249,15 @@ export async function submitOrderFulfillment(
         ),
       ]);
     } else {
+      // printfulCost === null means the Printful response carried no costs.total
+      // — expected for dry-run (0.00 → 0, not null), but on the recovery path a
+      // fetched order can lack costs, so the order goes `submitted` with COGS
+      // unbooked. Log loudly so it's visible for a manual COGS entry.
+      if (printfulCost == null) {
+        console.error(
+          `Order ${orderId}: submitted with NO COGS — Printful response had no costs.total (likely a recovery fetch that omitted costs). Book COGS manually.`
+        );
+      }
       await deps.db.batch([submittedUpdate, ...designUpdates]);
     }
   } catch (err) {

--- a/src/lib/order-fulfillment.ts
+++ b/src/lib/order-fulfillment.ts
@@ -21,9 +21,15 @@ import { getBlank, getVariantId } from "@/lib/blanks";
 import { assertTransition } from "@/lib/order-state";
 import { cogsLedgerRow } from "@/lib/ledger";
 import { withTimeout } from "@/lib/timeout";
+import { isDuplicateExternalIdError } from "@/lib/printful";
 import type { createOrder, PrintfulOrderItem } from "@/lib/printful";
 import type { db as appDb } from "@/lib/db";
 import type { generateOrderName } from "@/lib/ai";
+
+// The subset of a Printful order response fulfillment persists — its id and the
+// invoice total that becomes COGS. Matches both createOrder and the
+// external-id getter's return shapes.
+type PrintfulOrderResult = { id: string | number; costs?: { total?: string } | null };
 
 // Cap on the post-submission order-naming Anthropic call. Long enough for a
 // normal vision response, short enough that a hung call can't push the webhook
@@ -43,6 +49,13 @@ export type FulfillmentDeps = {
   // after purchase. Optional: when absent, lines fall back to
   // `resolveDesignImageUrl(designId)`.
   resolveImageUrlById?: (imageId: string) => Promise<string | null>;
+  // Fetch the Printful order Printful already has for OUR order id, when a
+  // resubmit is rejected as a duplicate external_id (finding #2). Optional:
+  // when absent, a duplicate rejection just yields paid_printful_failed (the
+  // pre-recovery behavior). Real call sites inject printful.getOrderByExternalId.
+  getPrintfulOrderByExternalId?: (
+    externalId: string
+  ) => Promise<PrintfulOrderResult | null>;
 };
 
 export type ShippingAddress = {
@@ -93,74 +106,110 @@ export async function submitOrderFulfillment(
     orderItems
   );
 
-  // One Printful line item per fulfillable line. Front prefers the image
-  // pinned on the line (placements.front) and falls back to the design's
-  // current display image; non-front placements resolve only via their pinned
-  // image id — a missing one is logged and dropped, never fatal.
-  const items: PrintfulOrderItem[] = [];
+  // Item-building (image resolution), submission, and persistence all sit under
+  // one try that returns paid_printful_failed on any throw (finding #3a): the
+  // reads used to run before the try, so a transient R2/DB read error threw
+  // unhandled and 400'd the Stripe webhook (→ redelivery skips, cron-only
+  // recovery). paid_printful_failed leaves the order `paid` for the daily cron
+  // to retry. Naming runs after, outside the failure path — it's soft either way.
+  let printfulOrder: PrintfulOrderResult | null = null;
   let firstFrontUrl: string | null = null;
-  for (const line of lines) {
-    const frontImageId = line.placements.front ?? null;
-    const frontUrl =
-      (frontImageId && deps.resolveImageUrlById
-        ? await deps.resolveImageUrlById(frontImageId)
-        : null) ?? (await deps.resolveDesignImageUrl(line.designId));
-    if (!frontUrl) {
-      console.error(
-        `Order ${orderId}: line (design ${line.designId}) has no front image — dropping`
-      );
-      continue;
-    }
-    firstFrontUrl ??= frontUrl;
-
-    const files: { placement: string; url: string }[] = [
-      { placement: "front", url: frontUrl },
-    ];
-    for (const [placement, imageId] of Object.entries(line.placements)) {
-      if (placement === "front") continue;
-      const url = deps.resolveImageUrlById
-        ? await deps.resolveImageUrlById(imageId)
-        : null;
-      if (url) files.push({ placement, url });
-      else
-        console.error(
-          `Order ${orderId}: placement "${placement}" image ${imageId} unresolved — submitting without it`
-        );
-    }
-
-    const product = getBlank(line.blankId);
-    const variantId = product
-      ? getVariantId(product, line.color, line.size)
-      : null;
-    if (!variantId) {
-      console.error(
-        `Order ${orderId}: no variant for ${line.color} ${line.size} on ${product?.name ?? line.blankId} — dropping line`
-      );
-      continue;
-    }
-    items.push({ variantId, quantity: line.quantity, files });
-  }
-
-  if (items.length === 0) {
-    console.error(`Order ${orderId}: no fulfillable lines`);
-    return { action: "paid" };
-  }
-
   try {
-    const printfulOrder = await deps.createPrintfulOrder({
-      items,
-      // Our order id as Printful's external reference (#37): makes the
-      // Printful order traceable to ours, and a duplicate submission of the
-      // same order gets rejected by Printful instead of printing twice.
-      externalId: orderId,
-      recipientName: shipping?.name ?? "",
-      address1: shipping?.address1 ?? "",
-      address2: shipping?.address2 || undefined,
-      city: shipping?.city ?? "",
-      stateCode: shipping?.state ?? "",
-      countryCode: shipping?.country ?? "US",
-      zip: shipping?.zip ?? "",
-    });
+    // One Printful line item per fulfillable line. Front prefers the image
+    // pinned on the line (placements.front) and falls back to the design's
+    // current display image; non-front placements resolve only via their pinned
+    // image id — a missing one is logged and dropped, never fatal.
+    const items: PrintfulOrderItem[] = [];
+    for (const line of lines) {
+      const frontImageId = line.placements.front ?? null;
+      const frontUrl =
+        (frontImageId && deps.resolveImageUrlById
+          ? await deps.resolveImageUrlById(frontImageId)
+          : null) ?? (await deps.resolveDesignImageUrl(line.designId));
+      if (!frontUrl) {
+        console.error(
+          `Order ${orderId}: line (design ${line.designId}) has no front image — dropping`
+        );
+        continue;
+      }
+      firstFrontUrl ??= frontUrl;
+
+      const files: { placement: string; url: string }[] = [
+        { placement: "front", url: frontUrl },
+      ];
+      for (const [placement, imageId] of Object.entries(line.placements)) {
+        if (placement === "front") continue;
+        const url = deps.resolveImageUrlById
+          ? await deps.resolveImageUrlById(imageId)
+          : null;
+        if (url) files.push({ placement, url });
+        else
+          console.error(
+            `Order ${orderId}: placement "${placement}" image ${imageId} unresolved — submitting without it`
+          );
+      }
+
+      const product = getBlank(line.blankId);
+      const variantId = product
+        ? getVariantId(product, line.color, line.size)
+        : null;
+      if (!variantId) {
+        console.error(
+          `Order ${orderId}: no variant for ${line.color} ${line.size} on ${product?.name ?? line.blankId} — dropping line`
+        );
+        continue;
+      }
+      items.push({ variantId, quantity: line.quantity, files });
+    }
+
+    if (items.length === 0) {
+      console.error(`Order ${orderId}: no fulfillable lines`);
+      return { action: "paid" };
+    }
+
+    try {
+      printfulOrder = await deps.createPrintfulOrder({
+        items,
+        // Our order id as Printful's external reference (#37): makes the
+        // Printful order traceable to ours, and a duplicate submission of the
+        // same order gets rejected by Printful instead of printing twice.
+        externalId: orderId,
+        recipientName: shipping?.name ?? "",
+        address1: shipping?.address1 ?? "",
+        address2: shipping?.address2 || undefined,
+        city: shipping?.city ?? "",
+        stateCode: shipping?.state ?? "",
+        countryCode: shipping?.country ?? "US",
+        zip: shipping?.zip ?? "",
+      });
+    } catch (err) {
+      // Recovery (finding #2): a prior attempt created the Printful order but
+      // crashed before persisting its id, so this resubmit is rejected as a
+      // duplicate external_id. Fetch the order Printful already has and persist
+      // it below — otherwise every retry hits the same dedupe forever and the
+      // printed order is stranded `paid` (COGS unbooked, no shipping match).
+      if (isDuplicateExternalIdError(err) && deps.getPrintfulOrderByExternalId) {
+        console.warn(
+          `Order ${orderId}: Printful rejected duplicate external_id — recovering existing order`
+        );
+        const existing = await deps
+          .getPrintfulOrderByExternalId(orderId)
+          .catch((fetchErr) => {
+            console.error(
+              `Order ${orderId}: could not fetch existing Printful order:`,
+              fetchErr
+            );
+            return null;
+          });
+        if (!existing) return { action: "paid_printful_failed" };
+        printfulOrder = existing;
+      } else {
+        throw err;
+      }
+    }
+    // Narrows for the type checker — either branch above set printfulOrder or
+    // already returned/threw.
+    if (!printfulOrder) return { action: "paid_printful_failed" };
 
     assertTransition("paid", "submitted");
 
@@ -202,33 +251,39 @@ export async function submitOrderFulfillment(
     } else {
       await deps.db.batch([submittedUpdate, ...designUpdates]);
     }
-
-    // Name the order AFTER Printful submission — the shirt never waits on the
-    // LLM (#39). Bounded so a hung Anthropic call can't stall the webhook
-    // response past Stripe's timeout. Skipped when already named (admin retry).
-    // displayName is written before returning so the confirmation email, sent
-    // by the caller after this resolves, still carries the name. Fails soft.
-    if (firstFrontUrl && !order.displayName) {
-      try {
-        const displayName = await withTimeout(
-          "generateOrderName",
-          ORDER_NAME_TIMEOUT_MS,
-          () => deps.generateOrderName(firstFrontUrl!)
-        );
-        if (displayName) {
-          await deps.db
-            .update(orderTable)
-            .set({ displayName, updatedAt: new Date() })
-            .where(eq(orderTable.id, orderId));
-        }
-      } catch (err) {
-        console.error(`Order ${orderId}: order naming failed (non-fatal):`, err);
-      }
-    }
-
-    return { action: "submitted", printfulOrderId: String(printfulOrder.id) };
   } catch (err) {
-    console.error(`Order ${orderId}: Printful submission failed:`, err);
+    console.error(`Order ${orderId}: Printful fulfillment failed:`, err);
     return { action: "paid_printful_failed" };
   }
+
+  // Unreachable in practice — every non-submit path above already returned —
+  // but this narrows printfulOrder for the type checker and is a cheap backstop.
+  if (!printfulOrder) return { action: "paid_printful_failed" };
+
+  // Name the order AFTER Printful submission — the shirt never waits on the
+  // LLM (#39). Bounded so a hung Anthropic call can't stall the webhook
+  // response past Stripe's timeout. Skipped when already named (admin retry).
+  // displayName is written before returning so the confirmation email, sent by
+  // the caller after this resolves, still carries the name. Fails soft — and it
+  // sits outside the fulfillment try so a naming hiccup can't undo a submission
+  // that already persisted.
+  if (firstFrontUrl && !order.displayName) {
+    try {
+      const displayName = await withTimeout(
+        "generateOrderName",
+        ORDER_NAME_TIMEOUT_MS,
+        () => deps.generateOrderName(firstFrontUrl!)
+      );
+      if (displayName) {
+        await deps.db
+          .update(orderTable)
+          .set({ displayName, updatedAt: new Date() })
+          .where(eq(orderTable.id, orderId));
+      }
+    } catch (err) {
+      console.error(`Order ${orderId}: order naming failed (non-fatal):`, err);
+    }
+  }
+
+  return { action: "submitted", printfulOrderId: String(printfulOrder.id) };
 }

--- a/src/lib/printful.ts
+++ b/src/lib/printful.ts
@@ -126,6 +126,38 @@ export async function getOrderStatus(orderId: string) {
   return data.result;
 }
 
+/**
+ * Fetch an order by OUR id (sent as external_id on createOrder). Printful's
+ * `@`-prefix on the id path selects by external_id instead of Printful's own
+ * numeric id. Used to recover a stranded submission: a prior fulfillment
+ * attempt created the Printful order but crashed before we persisted its id, so
+ * the resubmit is rejected as a duplicate — we fetch the order Printful already
+ * has and persist it. Returns null on 404 (no such order).
+ */
+export async function getOrderByExternalId(externalId: string) {
+  try {
+    const data = await printfulFetch(`/orders/@${encodeURIComponent(externalId)}`);
+    return data.result as { id: string | number; costs?: { total?: string } | null };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    if (/\b404\b/.test(message)) return null;
+    throw err;
+  }
+}
+
+/**
+ * True when a createOrder rejection is Printful's "external_id already used"
+ * error — the duplicate-submission guard tripping because a prior attempt
+ * already created this order. The caller recovers via getOrderByExternalId
+ * instead of stranding a printed order as `paid` forever (finding #2).
+ */
+export function isDuplicateExternalIdError(err: unknown): boolean {
+  const message = err instanceof Error ? err.message : String(err);
+  return (
+    /external[ _]?id/i.test(message) && /already (used|exist)/i.test(message)
+  );
+}
+
 export type EstimatedCosts = {
   subtotal: number;
   shipping: number;

--- a/src/lib/printful.ts
+++ b/src/lib/printful.ts
@@ -145,19 +145,6 @@ export async function getOrderByExternalId(externalId: string) {
   }
 }
 
-/**
- * True when a createOrder rejection is Printful's "external_id already used"
- * error — the duplicate-submission guard tripping because a prior attempt
- * already created this order. The caller recovers via getOrderByExternalId
- * instead of stranding a printed order as `paid` forever (finding #2).
- */
-export function isDuplicateExternalIdError(err: unknown): boolean {
-  const message = err instanceof Error ? err.message : String(err);
-  return (
-    /external[ _]?id/i.test(message) && /already (used|exist)/i.test(message)
-  );
-}
-
 export type EstimatedCosts = {
   subtotal: number;
   shipping: number;

--- a/src/lib/refund-order.ts
+++ b/src/lib/refund-order.ts
@@ -1,0 +1,81 @@
+/**
+ * Admin-clicked customer refund (money-safety WP1, finding #1). A Printful
+ * cancel does NOT refund the customer automatically — the cancel webhook only
+ * reverses COGS. Refunding real money is a deliberate admin action, so it lives
+ * here as a deps-injected core (Stripe + revalidate wrapped by the server
+ * action in admin/actions.ts) and is tested against the real in-memory DB.
+ *
+ * Idempotent: a booked `refund` ledger row is the "already refunded" flag —
+ * checked up front so a second click is a no-op, never a second Stripe refund.
+ * The Stripe call is also idempotency-keyed on the order id as a backstop for a
+ * concurrent double-click, and the ledger insert relies on the
+ * ledger_entry(order_id, type) unique index.
+ */
+import { and, eq } from "drizzle-orm";
+import { order as orderTable, ledgerEntry } from "@/lib/db/schema";
+import { refundLedgerRow, isUniqueViolation } from "@/lib/ledger";
+import type { db as appDb } from "@/lib/db";
+
+export type RefundOrderDeps = {
+  db: typeof appDb;
+  /** Resolve the checkout session id to its payment_intent id (null if none). */
+  retrievePaymentIntentId: (stripeSessionId: string) => Promise<string | null>;
+  /** Issue the Stripe refund. `idempotencyKey` guards a concurrent double-click. */
+  createRefund: (paymentIntentId: string, idempotencyKey: string) => Promise<void>;
+};
+
+export type RefundOrderResult =
+  // refunded=false → nothing to do (already refunded); true → a refund was issued.
+  | { ok: true; refunded: boolean }
+  | { ok: false; reason: string };
+
+export async function refundOrderCore(
+  orderId: string,
+  deps: RefundOrderDeps
+): Promise<RefundOrderResult> {
+  const found = await deps.db.query.order.findFirst({
+    where: eq(orderTable.id, orderId),
+  });
+  if (!found) return { ok: false, reason: "Order not found" };
+
+  // Already refunded? The ledger row is the source of truth — a second click
+  // must not issue a second Stripe refund.
+  const existing = await deps.db.query.ledgerEntry.findFirst({
+    where: and(eq(ledgerEntry.orderId, orderId), eq(ledgerEntry.type, "refund")),
+  });
+  if (existing) return { ok: true, refunded: false };
+
+  if (found.status !== "canceled") {
+    return { ok: false, reason: "Only canceled orders can be refunded" };
+  }
+  if (found.totalPrice <= 0) {
+    return { ok: false, reason: "Nothing to refund (order total is $0)" };
+  }
+  if (!found.stripeSessionId) {
+    return { ok: false, reason: "No Stripe session on this order" };
+  }
+
+  const paymentIntentId = await deps.retrievePaymentIntentId(found.stripeSessionId);
+  if (!paymentIntentId) {
+    return { ok: false, reason: "No payment intent on the Stripe session" };
+  }
+
+  await deps.createRefund(paymentIntentId, `refund-${orderId}`);
+
+  try {
+    await deps.db.insert(ledgerEntry).values(
+      refundLedgerRow(
+        orderId,
+        found.totalPrice,
+        `Order ${orderId.slice(0, 8)} refunded via Stripe`
+      )
+    );
+  } catch (err) {
+    // A concurrent click booked the row first; the Stripe refund is
+    // idempotency-keyed so no double refund happened. Treat as a no-op success.
+    if (isUniqueViolation(err)) return { ok: true, refunded: false };
+    throw err;
+  }
+
+  return { ok: true, refunded: true };
+}

--- a/src/lib/refund-order.ts
+++ b/src/lib/refund-order.ts
@@ -29,6 +29,24 @@ export type RefundOrderResult =
   | { ok: true; refunded: boolean }
   | { ok: false; reason: string };
 
+/**
+ * Stripe raises StripeInvalidRequestError with code `charge_already_refunded`
+ * when the underlying charge is already fully refunded. That is the benign
+ * crash-replay case: a prior click's refunds.create succeeded but the process
+ * died before booking the ledger row, and the stable idempotency key has since
+ * aged past Stripe's TTL (so the replay is treated as fresh and rejected).
+ * Treating it as success lets us book the missing ledger row instead of
+ * throwing forever.
+ */
+export function isChargeAlreadyRefunded(err: unknown): boolean {
+  return (
+    typeof err === "object" &&
+    err !== null &&
+    "code" in err &&
+    (err as { code?: unknown }).code === "charge_already_refunded"
+  );
+}
+
 export async function refundOrderCore(
   orderId: string,
   deps: RefundOrderDeps
@@ -60,7 +78,16 @@ export async function refundOrderCore(
     return { ok: false, reason: "No payment intent on the Stripe session" };
   }
 
-  await deps.createRefund(paymentIntentId, `refund-${orderId}`);
+  try {
+    await deps.createRefund(paymentIntentId, `refund-${orderId}`);
+  } catch (err) {
+    if (!isChargeAlreadyRefunded(err)) throw err;
+    // Refund already happened at Stripe (crash after refund, before ledger,
+    // past the idempotency-key TTL). Fall through to book the missing row.
+    console.warn(
+      `Order ${orderId}: Stripe reports the charge is already refunded — booking the ledger row for the prior refund`
+    );
+  }
 
   try {
     await deps.db.insert(ledgerEntry).values(

--- a/src/lib/webhook-handlers.ts
+++ b/src/lib/webhook-handlers.ts
@@ -6,7 +6,11 @@ import {
   orderItem as orderItemTable,
 } from "@/lib/db/schema";
 import { assertTransition } from "@/lib/order-state";
-import { saleLedgerRows, refundLedgerRow, isUniqueViolation } from "@/lib/ledger";
+import {
+  saleLedgerRows,
+  refundCogsReversalRow,
+  isUniqueViolation,
+} from "@/lib/ledger";
 import {
   submitOrderFulfillment,
   type FulfillmentDeps,
@@ -143,16 +147,25 @@ export async function handleStripeCheckoutCompleted(
   // purchased lines here, matched per line so a single-item /order purchase
   // (no order_item rows today) or anything added to the cart mid-checkout is
   // untouched. Runs even if fulfillment fails below: the customer paid.
-  for (const item of orderItems) {
-    await deps.db.delete(cartItemTable).where(
-      and(
-        eq(cartItemTable.userId, foundOrder.userId),
-        eq(cartItemTable.designId, item.designId),
-        eq(cartItemTable.productId, item.productId),
-        eq(cartItemTable.size, item.size),
-        eq(cartItemTable.color, item.color)
-      )
-    );
+  //
+  // Wrapped so a cart-cleanup failure never fails the webhook (finding #3b):
+  // the paid-claim already committed, so a throw here would 400 → Stripe
+  // redelivers → skipped (status≠pending) → fulfillment stranded until the
+  // daily cron. A leftover cart row is cosmetic; log and press on to fulfill.
+  try {
+    for (const item of orderItems) {
+      await deps.db.delete(cartItemTable).where(
+        and(
+          eq(cartItemTable.userId, foundOrder.userId),
+          eq(cartItemTable.designId, item.designId),
+          eq(cartItemTable.productId, item.productId),
+          eq(cartItemTable.size, item.size),
+          eq(cartItemTable.color, item.color)
+        )
+      );
+    }
+  } catch (err) {
+    console.error(`Order ${orderId}: cart cleanup failed (non-fatal):`, err);
   }
 
   return submitOrderFulfillment(foundOrder, orderItems, session.shipping, deps);
@@ -203,31 +216,44 @@ export async function handlePrintfulEvent(
 
   if (payload.type === "order_canceled") {
     // Redelivery (#37): same 200-on-repeat contract as package_shipped, and
-    // it also prevents a doubled refund ledger row.
+    // it also prevents a doubled COGS-reversal ledger row.
     if (foundOrder.status === "canceled") {
       return { action: "ignored", orderId: foundOrder.id };
     }
     assertTransition(foundOrder.status, "canceled");
 
-    // Cancel-update + refund ledger row commit together (#37) — a crash
-    // between them can't leave a canceled order with no refund on the books.
-    await deps.db.batch([
-      deps.db
-        .update(orderTable)
-        .set({
-          status: "canceled",
-          printfulCost: 0,
-          updatedAt: new Date(),
-        })
-        .where(eq(orderTable.id, foundOrder.id)),
-      deps.db.insert(ledgerEntry).values(
-        refundLedgerRow(
-          foundOrder.id,
-          foundOrder.totalPrice,
-          `Order ${foundOrder.id.slice(0, 8)} canceled — Printful ${printfulOrderId}`
-        )
+    // A cancel does NOT refund the customer here — that is an admin-clicked
+    // action (refundOrder), never an automatic webhook side effect, so we don't
+    // book a `refund` row for money that hasn't moved. What IS a fact the
+    // moment Printful cancels: their cost is reversed. If this order booked
+    // COGS, offset it with a `refund_cogs_reversal` row so gross profit isn't
+    // understated. Cancel-update + reversal commit together (#37).
+    const cogsEntry = await deps.db.query.ledgerEntry.findFirst({
+      where: and(
+        eq(ledgerEntry.orderId, foundOrder.id),
+        eq(ledgerEntry.type, "cogs")
       ),
-    ]);
+    });
+
+    const cancelUpdate = deps.db
+      .update(orderTable)
+      .set({ status: "canceled", printfulCost: 0, updatedAt: new Date() })
+      .where(eq(orderTable.id, foundOrder.id));
+
+    if (cogsEntry) {
+      await deps.db.batch([
+        cancelUpdate,
+        deps.db.insert(ledgerEntry).values(
+          refundCogsReversalRow(
+            foundOrder.id,
+            cogsEntry.amount,
+            `Order ${foundOrder.id.slice(0, 8)} canceled — COGS reversed (Printful ${printfulOrderId})`
+          )
+        ),
+      ]);
+    } else {
+      await cancelUpdate;
+    }
 
     return { action: "canceled", orderId: foundOrder.id };
   }


### PR DESCRIPTION
Money-safety audit WP1 — four confirmed money-path defects (findings 1–4), plus a round of adversarial-review fixes.

## Findings fixed (round 1)

**1 (HIGH) — cancels never refunded the customer; phantom refund row.** `order_canceled` in `src/lib/webhook-handlers.ts` booked a `refund` ledger row while nothing ever called `stripe.refunds.create`. Cancel webhook now sets `canceled` and, when a `cogs` entry exists, books `refund_cogs_reversal` (offsets the negative cogs row); skips it when no COGS was booked. Refunding the customer is a new **admin-clicked** action: `src/lib/refund-order.ts` `refundOrderCore` (retrieves the session's payment_intent → idempotency-keyed `stripe.refunds.create` → books `refund`), wrapped by `refundOrder` in `src/app/admin/actions.ts` and a Refund/Refunded button in `src/app/admin/orders/[id]/page.tsx`. Idempotent — existing refund row makes a second click a no-op. Also fixes finding 3 (`refund_cogs_reversal` was declared but emitted nowhere).

**2 (MED/HIGH) — stranded printed orders.** `src/lib/printful.ts` gained `getOrderByExternalId` (`GET /orders/@{external_id}`). `src/lib/order-fulfillment.ts` recovers a submission whose DB persist crashed after Printful succeeded, instead of leaving it stuck `paid` forever. New optional dep wired into all four call sites (stripe webhook, cron, admin retry, admin recover).

**3 (webhook resilience).** (a) Image-resolution reads moved inside `submitOrderFulfillment`'s try → transient read error yields `paid_printful_failed` (cron-retryable), not a 400. (b) Cart-clear loop wrapped in try/catch — cleanup failure never fails the webhook.

## Adversarial-review round (round 2)

**1 (HIGH) — the COGS-reversal fix was inert.** `summarizeLedger` (`src/lib/ledger.ts`) summed only sale/stripe_fee/cogs/refund, dropping `refund_cogs_reversal` — so grossProfit stayed understated by the full COGS on every canceled-with-COGS order and the row changed nothing in admin financials. Now folded into net COGS + grossProfit (it's a COGS *correction*, distinct from an unknown pass-through like `tax`, which stays out). Doc updated; the 1C contract test carves the reversal in deliberately; the cancel integration test seeds sale+fee+cogs and asserts `summarizeLedger(...).grossProfit` equals the no-COGS outcome — it fails without the fix.

**2 (MED) — refund crash-window became permanent past Stripe's idempotency TTL.** If the process died after `refunds.create` but before the ledger insert, a replay after the key aged out hit `charge_already_refunded` and threw forever. `refundOrderCore` now catches that Stripe error code (verified against the installed SDK's `StripeError.code` shape) and treats it as success → books the missing row. Tests: already-refunded → ok + one row; non-benign error → rethrow, book nothing.

**3 (LOW/MED) — brittle rejection string-matching.** Replaced with a phrasing-independent probe: on ANY `createOrder` failure, probe `getOrderByExternalId(orderId)`; adopt the order if Printful has it, else rethrow the original error → `paid_printful_failed`. Also recovers a transient-error-after-create for free. Deleted `isDuplicateExternalIdError`. Tests now prove recovery on a generically-worded (500) failure.

**4 (minor) — Refund button hidden for `test`-classified canceled orders** (would attempt a live-key refund and throw).

**5 — loud `console.error`** when a recovered order persists `submitted` with no `costs.total` (COGS unbooked → manual entry); scoped to `null` so dry-run's `0` doesn't spam local runs.

## Tests (real-DB harness; only Stripe/Printful mocked)
- cancel-after-submitted reverses COGS, books no refund, and moves grossProfit to the no-COGS outcome; cancel-without-cogs books neither; redelivery keeps one reversal row.
- admin refund issues Stripe + books refund; second call a no-op; `charge_already_refunded` → ok + books row; non-benign error → rethrow; refuses non-canceled / no-session / no-PI.
- fulfillment recovery adopts an existing Printful order after a generic submit failure; no existing order → `paid_printful_failed`; image-read failure → `paid_printful_failed`; cart-clear throw still returns `submitted`.
- summarizeLedger: reversal folded into profit + net COGS; tax pass-through still excluded.

Full suite **474 pass** · lint **0 errors** · typecheck + build green (build's module-load env checks satisfied with dummy values; unrelated to this change).

## Deliberately left out
- No Stripe-skip for `test`/dry-run orders beyond hiding the button (would invent a convention the codebase doesn't have; bogus orders without a real session/PI already return a clean "cannot refund" reason).
- `recordCancellation` in `ledger.ts` left in place (now unused by product code) rather than pruned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)