### PR TITLE
fix(designs): apply published backdrop color to /designs cards

### DIFF
--- a/src/app/designs/actions.ts
+++ b/src/app/designs/actions.ts
@@ -40,36 +40,50 @@ export async function getUserDesigns() {
     designs.map((d) => d.id)
   );
 
-  // Look up publish state for each primary image so the cards can
-  // show Publish vs Published correctly. Best-effort: if this query
+  // Look up publish state (+ chosen storefront backdrop) for each primary
+  // image so the cards can show Publish vs Published correctly and render
+  // published designs over their backdrop color. Best-effort: if this query
   // fails the cards just hide the publish badge — the design list
   // itself must still render.
   const primaryIds = designs
     .map((d) => d.primaryImageId)
     .filter((id): id is string => id !== null);
-  let publishedAtById = new Map<string, Date | null>();
+  let primaryById = new Map<
+    string,
+    { publishedAt: Date | null; backgroundColor: string | null }
+  >();
   if (primaryIds.length) {
     try {
       const primaryRows = await db
         .select({
           id: designImageTable.id,
           publishedAt: designImageTable.publishedAt,
+          backgroundColor: designImageTable.backgroundColor,
         })
         .from(designImageTable)
         .where(inArray(designImageTable.id, primaryIds));
-      publishedAtById = new Map(primaryRows.map((r) => [r.id, r.publishedAt]));
+      primaryById = new Map(
+        primaryRows.map((r) => [
+          r.id,
+          { publishedAt: r.publishedAt, backgroundColor: r.backgroundColor },
+        ])
+      );
     } catch (err) {
       console.error("getUserDesigns: publish-state lookup failed", err);
     }
   }
 
-  return designs.map((d) => ({
-    ...d,
-    imageUrl: imageUrls.get(d.id) ?? null,
-    primaryImagePublishedAt: d.primaryImageId
-      ? publishedAtById.get(d.primaryImageId) ?? null
-      : null,
-  }));
+  return designs.map((d) => {
+    const primary = d.primaryImageId
+      ? primaryById.get(d.primaryImageId)
+      : undefined;
+    return {
+      ...d,
+      imageUrl: imageUrls.get(d.id) ?? null,
+      primaryImagePublishedAt: primary?.publishedAt ?? null,
+      primaryImageBackgroundColor: primary?.backgroundColor ?? null,
+    };
+  });
 }
 
 /**

--- a/src/app/designs/page.tsx
+++ b/src/app/designs/page.tsx
@@ -5,6 +5,7 @@ import { useEffect, useState } from "react";
 import { getUserDesigns, deleteDesign, archiveDesign, unpublishImage } from "./actions";
 import { Badge, Button } from "@/components/ui";
 import { PublishModal } from "@/components/publish-modal";
+import { publishedBackdrop } from "@/lib/blanks";
 
 type Design = Awaited<ReturnType<typeof getUserDesigns>>[number];
 
@@ -101,10 +102,22 @@ export default function DesignsPage() {
           </div>
         ) : (
           <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
-            {designs.map((design) => (
+            {designs.map((design) => {
+              // Published designs render over their chosen storefront
+              // backdrop (matching PublishedGrid); unpublished — or a null
+              // backdrop — keep the checkerboard.
+              const backdrop = publishedBackdrop(
+                design.primaryImagePublishedAt
+                  ? design.primaryImageBackgroundColor
+                  : null
+              );
+              return (
               <div key={design.id} className="border rounded-lg overflow-hidden group">
                 <Link href={getDesignHref(design)} className="block">
-                  <div className="aspect-square bg-checkerboard flex items-center justify-center">
+                  <div
+                    className={`aspect-square flex items-center justify-center ${backdrop.className}`}
+                    style={backdrop.style}
+                  >
                     {design.imageUrl ? (
                       <img
                         src={design.imageUrl}
@@ -190,7 +203,8 @@ export default function DesignsPage() {
                   )}
                 </div>
               </div>
-            ))}
+              );
+            })}
           </div>
         )}
       </main>


### PR DESCRIPTION
Closes #58

/designs card thumbnails showed published designs on the transparent checkerboard instead of their chosen backdrop color.

- `getUserDesigns` (src/app/designs/actions.ts) now selects `design_image.background_color` alongside publish state for each primary image and returns it as `primaryImageBackgroundColor`.
- The card thumbnail (src/app/designs/page.tsx) resolves it through `publishedBackdrop()` — the same helper PublishedGrid and /d/[id] use — so the two surfaces stay visually consistent. Unpublished designs, and published ones with a null backdrop, keep the checkerboard.

No pure helper changed, so no new tests; lint, test (503), and build are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)