### PR TITLE
fix(chat): always render choice chips; align copy to 'draw'

### DIFF
--- a/src/app/design/chat-panel.tsx
+++ b/src/app/design/chat-panel.tsx
@@ -104,7 +104,9 @@ export function ChatPanel({
     return () => clearTimeout(t);
   }, [isEmpty, input]);
 
-  const GENERATE_TRIGGERS = /^(yes|yeah|yep|do it|go|generate|let'?s do it|go ahead|make it|yes please|sure|ok generate)/i;
+  // "draw it"/"draw" included: chat copy now nudges "tap Draw it", so typing
+  // it should behave like tapping it.
+  const GENERATE_TRIGGERS = /^(yes|yeah|yep|do it|go|generate|draw it|draw|let'?s do it|go ahead|make it|yes please|sure|ok generate)/i;
 
   // Shared submit path for both the composer and a tapped quick-reply chip, so
   // generate-intent detection and input clearing behave identically.

--- a/src/app/design/image-gallery.tsx
+++ b/src/app/design/image-gallery.tsx
@@ -61,7 +61,7 @@ export function ImageGallery({
         <div className="p-3">
           {images.length === 0 && !generating && (
             <p className="text-xs text-text-faint text-center mt-8">
-              No images yet. Chat about your idea, then hit Generate.
+              No images yet. Chat about your idea, then hit Draw it.
             </p>
           )}
           <div className="grid grid-cols-2 gap-2">

--- a/src/lib/__tests__/ai.test.ts
+++ b/src/lib/__tests__/ai.test.ts
@@ -247,6 +247,136 @@ describe("chatAboutDesign options", () => {
     const result = await chatAboutDesign("anything", [], []);
     expect(result.options).toEqual([]);
   });
+
+  it("salvages chips when the model lists choices in prose with empty options", async () => {
+    const mockCreate = await getMockCreate();
+    mockCreate.mockResolvedValue({
+      content: [{
+        type: "text",
+        text: JSON.stringify({
+          message: "Nice — a fox it is. What style are you after?\n\n1. Watercolor\n2. Vintage\n3. Bold vector",
+          readyToGenerate: false,
+          options: [],
+        }),
+      }],
+    });
+
+    const { chatAboutDesign } = await import("../ai");
+    const result = await chatAboutDesign("a fox", [], []);
+
+    expect(result.options).toEqual([
+      { label: "Watercolor", value: "Watercolor" },
+      { label: "Vintage", value: "Vintage" },
+      { label: "Bold vector", value: "Bold vector" },
+    ]);
+    // The list is stripped from the prose; the question survives.
+    expect(result.message).toBe("Nice — a fox it is. What style are you after?");
+  });
+
+  it("never overrides structured options with the prose fallback", async () => {
+    const mockCreate = await getMockCreate();
+    mockCreate.mockResolvedValue({
+      content: [{
+        type: "text",
+        text: JSON.stringify({
+          message: "Pick one:\n1. Watercolor\n2. Vintage",
+          readyToGenerate: false,
+          options: [{ label: "Halftone", value: "Halftone screen-print" }],
+        }),
+      }],
+    });
+
+    const { chatAboutDesign } = await import("../ai");
+    const result = await chatAboutDesign("a fox", [], []);
+
+    expect(result.options).toEqual([
+      { label: "Halftone", value: "Halftone screen-print" },
+    ]);
+    expect(result.message).toContain("1. Watercolor");
+  });
+});
+
+describe("extractProseOptions", () => {
+  it("converts a trailing numbered list of short choices", async () => {
+    const { extractProseOptions } = await import("../ai");
+    const result = extractProseOptions(
+      "What style do you want?\n\n1. Watercolor\n2. Vintage\n3. Bold vector"
+    );
+    expect(result?.message).toBe("What style do you want?");
+    expect(result?.options).toEqual([
+      { label: "Watercolor", value: "Watercolor" },
+      { label: "Vintage", value: "Vintage" },
+      { label: "Bold vector", value: "Bold vector" },
+    ]);
+  });
+
+  it("converts hyphen bullets", async () => {
+    const { extractProseOptions } = await import("../ai");
+    const result = extractProseOptions(
+      "Which direction?\n- Hand-drawn ink\n- Vintage screen-print"
+    );
+    expect(result?.message).toBe("Which direction?");
+    expect(result?.options).toEqual([
+      { label: "Hand-drawn ink", value: "Hand-drawn ink" },
+      { label: "Vintage screen-print", value: "Vintage screen-print" },
+    ]);
+  });
+
+  it('accepts the "1)" marker style', async () => {
+    const { extractProseOptions } = await import("../ai");
+    const result = extractProseOptions("Pick a mood\n1) Playful\n2) Moody");
+    expect(result?.options).toEqual([
+      { label: "Playful", value: "Playful" },
+      { label: "Moody", value: "Moody" },
+    ]);
+  });
+
+  it("leaves numbered instructions alone (sentence-like items)", async () => {
+    const { extractProseOptions } = await import("../ai");
+    // Instruction steps: long, verb-led sentences with punctuation — must NOT
+    // become chips.
+    expect(
+      extractProseOptions(
+        "Here's how it works:\n1. Describe your idea in the chat below.\n2. Tap Draw it to see the first render.\n3. Head to preview once you like it."
+      )
+    ).toBeNull();
+    // Even without terminal periods, long items are not chips.
+    expect(
+      extractProseOptions(
+        "Next steps\n1. Describe the fox you have in mind\n2. Tap the Draw it button when ready"
+      )
+    ).toBeNull();
+  });
+
+  it("returns null for plain prose", async () => {
+    const { extractProseOptions } = await import("../ai");
+    expect(extractProseOptions("A watercolor fox sounds great. Ready?")).toBeNull();
+  });
+
+  it("returns null when the message is nothing but a list", async () => {
+    const { extractProseOptions } = await import("../ai");
+    expect(extractProseOptions("1. Watercolor\n2. Vintage")).toBeNull();
+  });
+
+  it("returns null for a single list line", async () => {
+    const { extractProseOptions } = await import("../ai");
+    expect(extractProseOptions("Try this:\n1. Watercolor")).toBeNull();
+  });
+
+  it("returns null for more than 5 items", async () => {
+    const { extractProseOptions } = await import("../ai");
+    const items = Array.from({ length: 6 }, (_, i) => `${i + 1}. Style ${i + 1}`);
+    expect(extractProseOptions(`Pick one\n${items.join("\n")}`)).toBeNull();
+  });
+
+  it("ignores a list followed by more prose (not trailing)", async () => {
+    const { extractProseOptions } = await import("../ai");
+    expect(
+      extractProseOptions(
+        "Options:\n1. Watercolor\n2. Vintage\nBut honestly the vintage one prints better."
+      )
+    ).toBeNull();
+  });
 });
 
 describe("extractChatEnvelope", () => {
@@ -342,6 +472,31 @@ describe("assessReadiness", () => {
 
     expect(result.ready).toBe(false);
     expect(result.question).toContain("What style");
+  });
+
+  it("salvages chips from a numbered-list clarifying question", async () => {
+    const mockCreate = await getMockCreate();
+    mockCreate.mockResolvedValue({
+      content: [{
+        type: "text",
+        text: JSON.stringify({
+          ready: false,
+          question: "What style?\n1. Watercolor\n2. Vintage\n3. Bold vector",
+          options: [],
+        }),
+      }],
+    });
+
+    const { assessReadiness } = await import("../ai");
+    const result = await assessReadiness([], [], "a fox");
+
+    expect(result.ready).toBe(false);
+    expect(result.question).toBe("What style?");
+    expect(result.options).toEqual([
+      { label: "Watercolor", value: "Watercolor" },
+      { label: "Vintage", value: "Vintage" },
+      { label: "Bold vector", value: "Bold vector" },
+    ]);
   });
 
   it("returns ready=true for a concrete subject + style", async () => {
@@ -556,7 +711,7 @@ describe("constructFluxPrompt", () => {
       []
     );
 
-    expect(result.message).toBe("Let me generate that for you.");
+    expect(result.message).toBe("Let me draw that for you.");
     expect(result.fluxPrompt).toContain("graphic design illustration");
   });
 

--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -10,7 +10,7 @@ function buildImageGalleryContext(images: DesignImage[]): string {
   return `\nImages so far:\n${lines.join("\n")}\n\nEntries marked [user upload] are reference images the user provided. Use them as style/content inspiration. When the user references images by number (e.g., "#2"), you know which image they mean.`;
 }
 
-const CHAT_SYSTEM_PROMPT = `You are a t-shirt design advisor for PRNTD. Help users refine their design ideas through conversation. You do NOT generate images — the user clicks "Generate" when ready.
+const CHAT_SYSTEM_PROMPT = `You are a t-shirt design advisor for PRNTD. Help users refine their design ideas through conversation. You do NOT draw images — the user taps "Draw it" when ready. In user-facing copy always say "draw" / "Draw it", never "generate".
 
 Output format — respond with raw JSON only (no markdown fences around the JSON itself):
 {
@@ -27,14 +27,15 @@ The "options" field (tappable quick-replies — THIS is how you offer choices):
 - Whenever you ask a multiple-choice question or suggest directions to pick from, put each choice in "options" as { "label": short tappable text, "value": the full message sent as the user's reply if they tap it }.
 - "label" is what the user taps — keep it short (1-3 words, e.g. "Watercolor", "Bold vector", "Vintage badge"). "value" is the natural-language turn submitted on tap (e.g. "Let's go with a vintage screen-print look").
 - Offer 2-5 options. The user can still type freely instead — options are a shortcut, not the only path.
-- Ask ONE question per turn. When several things are still open, pick the single most useful one and ask only that, with its choices as options. Do NOT stack multiple questions, and never put a bulleted or numbered list of choices in "message" — that is the clutter the options buttons replace. Keep "message" to the one question (plus a brief lead-in if needed).
+- Ask ONE question per turn. When several things are still open, pick the single most useful one and ask only that, with its choices as options. Do NOT stack multiple questions.
+- NEVER enumerate choices in prose. No "1. / 2. / 3.", no "a) / b)", no hyphen or bullet lists of choices inside "message" — ever. Choices rendered in prose don't become tappable buttons, which breaks the phone UI. Every choice goes in "options"; "message" carries only the one question (plus a brief lead-in if needed).
 - Omit "options" (or use []) when there's nothing to pick — a plain nudge or acknowledgement.
 
 Style rules for the "message" field:
 - Be terse and professional. 2-4 short sentences max.
 - Use markdown sparingly: **bold** for emphasis, line breaks between sections. No numbered lists of choices — those go in "options".
 - No filler, no flattery, no "great idea!" — just useful input.
-- End with a short question or nudge toward Generate.
+- End with a short question or nudge toward Draw it (e.g. "when you're ready, tap Draw it").
 - Frame your responses as directions to try, not edits to apply. Use "try", "aim for", "this version", "this direction" — not "fix", "remove", "edit".
 
 Handling negations (very important):
@@ -50,7 +51,7 @@ CRITICAL: The "message" field is conversational prose for the user — never put
 
 What the UI actually offers (do NOT invent other features):
 - A chat box (this conversation).
-- A "Generate" button that triggers a new image from the conversation so far.
+- A "Draw it" button that draws a new image from the conversation so far.
 - An image gallery showing past generations, each with a "Use as reference" action to feed it back into the next generation.
 - Buttons to proceed to product preview / order.
 - That's it. There is no "Remove Background" button, no inpainting, no manual editor, no layer tools, no upload-to-edit. If the user asks for something the UI doesn't have, say so plainly — do not invent an interaction. If the user insists a feature exists, do not capitulate; say you don't have a way to do that here.
@@ -68,7 +69,7 @@ const GENERATE_SYSTEM_PROMPT = `You are a t-shirt design assistant for PRNTD. Yo
 
 Read the conversation to understand what the user wants — both the SUBJECT and the AESTHETIC — then respond with raw JSON (no markdown, no code fences):
 {
-  "message": "Brief acknowledgment of what you're generating",
+  "message": "Brief acknowledgment of what you're drawing (user-facing — say 'draw', never 'generate')",
   "fluxPrompt": "Detailed image generation prompt for Ideogram",
   "negativePrompt": "Optional. Things to push the model AWAY from. Use when the user asks for an aesthetic the model tends to ignore (see Style section below). Empty string if not needed.",
   "referenceImage": null or number (e.g. 2) — set this to the # of a previous design if the user is refining/building on it
@@ -143,6 +144,72 @@ export function quickReplyFromOptions(raw: unknown): ChatOption[] {
     if (out.length >= MAX_OPTIONS) break;
   }
   return out;
+}
+
+const PROSE_LIST_ITEM = /^\s*(?:\d{1,2}[.)]\s+|[-*•]\s+)(.+)$/;
+const MAX_PROSE_OPTION_WORDS = 5;
+
+/**
+ * Deterministic fallback for the "numbered list instead of options" failure:
+ * despite the prompt, the model sometimes answers a multiple-choice question
+ * as a numbered/bulleted list in prose, so no chips render. When a reply's
+ * options are empty and the message ENDS with a short list of option-like
+ * fragments, convert those lines into options and strip them from the prose.
+ *
+ * Deliberately conservative — only converts when ALL hold, so numbered
+ * instructions or explanatory lists are left alone:
+ * - the list is the trailing block of the message (nothing after it);
+ * - 2–5 items, every one a short fragment (≤ 40 chars, ≤ 5 words) with no
+ *   sentence-ending punctuation — instructions read as sentences, choices
+ *   read as labels;
+ * - prose remains before the list (the question survives the strip).
+ *
+ * Returns null when the message shouldn't be converted.
+ */
+export function extractProseOptions(
+  text: string
+): { message: string; options: ChatOption[] } | null {
+  const lines = text.trimEnd().split("\n");
+  const items: string[] = [];
+  let i = lines.length - 1;
+  while (i >= 0) {
+    const m = lines[i].match(PROSE_LIST_ITEM);
+    if (!m) break;
+    items.unshift(m[1].trim());
+    i--;
+  }
+  if (items.length < 2 || items.length > MAX_OPTIONS) return null;
+  for (const item of items) {
+    if (
+      !item ||
+      item.length > MAX_OPTION_LABEL ||
+      item.split(/\s+/).length > MAX_PROSE_OPTION_WORDS ||
+      /[.!?:;,]$/.test(item)
+    ) {
+      return null;
+    }
+  }
+  const message = lines.slice(0, i + 1).join("\n").trimEnd();
+  if (!message) return null;
+  return {
+    message,
+    options: quickReplyFromOptions(items.map((label) => ({ label }))),
+  };
+}
+
+/**
+ * Apply the prose-list fallback to a parsed envelope: only when the model
+ * sent no structured options does the message get scanned for a trailing
+ * choice list. Structured options always win untouched.
+ */
+function withProseOptionsFallback<
+  T extends { message: string; options: ChatOption[] },
+>(envelope: T): T {
+  if (envelope.options.length > 0) return envelope;
+  const salvaged = extractProseOptions(envelope.message);
+  return salvaged
+    ? { ...envelope, message: salvaged.message, options: salvaged.options }
+    : envelope;
 }
 
 /**
@@ -255,17 +322,21 @@ export async function chatAboutDesign(
 
   try {
     const parsed = JSON.parse(text);
-    return {
+    return withProseOptionsFallback({
       message: typeof parsed.message === "string" ? parsed.message : text,
       readyToGenerate: parsed.readyToGenerate === true,
       options: quickReplyFromOptions(parsed.options),
-    };
+    });
   } catch {
     // Mixed prose + envelope (the model sometimes emits both) — salvage the
     // envelope rather than showing the user the raw JSON blob.
     const envelope = extractChatEnvelope(text);
-    if (envelope) return envelope;
-    return { message: text, readyToGenerate: false, options: [] };
+    if (envelope) return withProseOptionsFallback(envelope);
+    return withProseOptionsFallback({
+      message: text,
+      readyToGenerate: false,
+      options: [],
+    });
   }
 }
 
@@ -279,7 +350,7 @@ const READINESS_SYSTEM_PROMPT = `You judge whether a t-shirt design idea is conc
 Ready ONLY when BOTH are clear:
 - SUBJECT — what is depicted.
 - STYLE/medium — e.g. clean vector, watercolor, vintage screen-print, hand-drawn ink, bold graphic.
-A clear subject with no style is NOT ready: set ready=false and ask for the style. When asking for a style, fill "options" with 3-5 tappable style choices: { "label": short text (e.g. "Bold vector"), "value": the natural-language reply sent on tap (e.g. "Go with a bold flat vector look") }. Do NOT number choices in "question" — they render as tappable buttons. Omit "options" (or use []) when ready. Keep "question" to 1-2 sentences. When genuinely uncertain, lean ready=true — a real idea should never be blocked.`;
+A clear subject with no style is NOT ready: set ready=false and ask for the style. When asking for a style, fill "options" with 3-5 tappable style choices: { "label": short text (e.g. "Bold vector"), "value": the natural-language reply sent on tap (e.g. "Go with a bold flat vector look") }. NEVER enumerate choices in prose — no numbered ("1.", "2."), lettered, or bulleted lists inside "question"; every choice belongs in "options", where it renders as a tappable button. Omit "options" (or use []) when ready. Keep "question" to 1-2 sentences; in user-facing copy say "draw" / "Draw it", never "generate". When genuinely uncertain, lean ready=true — a real idea should never be blocked.`;
 
 /**
  * Fast pre-check used by Generate/Compare to decide "render vs ask" without
@@ -313,11 +384,21 @@ export async function assessReadiness(
     text = text.replace(/^```(?:json)?\s*\n?/m, "").replace(/\n?```\s*$/m, "").trim();
 
     const parsed = JSON.parse(text);
-    return {
+    const result = {
       ready: parsed.ready !== false,
       question: typeof parsed.question === "string" ? parsed.question : "",
       options: quickReplyFromOptions(parsed.options),
     };
+    // Same prose-list fallback as chat: a clarifying question that enumerates
+    // its choices as a numbered/bulleted list still renders tappable chips.
+    if (!result.ready && result.options.length === 0 && result.question) {
+      const salvaged = extractProseOptions(result.question);
+      if (salvaged) {
+        result.question = salvaged.message;
+        result.options = salvaged.options;
+      }
+    }
+    return result;
   } catch (err) {
     // Fail open: a parse problem, outage, or model error must never block a
     // real idea. constructFluxPrompt's own guard remains the backstop.
@@ -452,7 +533,7 @@ export async function constructFluxPrompt(
   if (!text) {
     console.error("constructFluxPrompt: empty response from Claude");
     return {
-      message: "Let me generate that for you.",
+      message: "Let me draw that for you.",
       fluxPrompt: "graphic design illustration, high quality, printable",
       negativePrompt: null,
       referenceImage: null,


### PR DESCRIPTION
Closes #55 — two defects from phone user testing.

## 1. Inconsistent QuickReply chips

The model sometimes answered a multiple-choice question as a numbered list in prose, so no chips rendered. Fixed both ends:

- **Prompts hardened** (`src/lib/ai.ts` CHAT + READINESS): explicit ban on enumerating choices in prose — no numbered/lettered/bulleted lists in `message`/`question`; every choice goes in `options`.
- **Deterministic fallback** — new pure `extractProseOptions()`: when a reply's `options` is empty and the message *ends* with a short list of option-like fragments, those lines become chips and are stripped from the prose. Conservative by design — converts only when ALL hold:
  - trailing block of 2–5 list lines (`1.`, `1)`, `-`, `*`, `•`), nothing after it
  - each item ≤ 40 chars, ≤ 5 words, no sentence-ending punctuation
  - prose remains before the list (the question survives)

  Numbered instructions, sentence-like items, non-trailing lists, and list-only messages are left untouched. Structured `options` always win. Applied in `chatAboutDesign` (all three parse paths) and `assessReadiness`.

## 2. "generate" vs "Draw it" copy

Prompt instructions + user-visible strings aligned to the draw vocabulary: chat prompt describes the "Draw it" button and nudges "tap Draw it"; builder fallback "Let me draw that for you."; gallery empty state "then hit Draw it." Code identifiers (`generateDesign`, `readyToGenerate`, …) unchanged. Also added `draw it`/`draw` to `GENERATE_TRIGGERS` so typing the button's name acts like tapping it.

## Tests

13 new unit tests (`src/lib/__tests__/ai.test.ts`): the numbered/hyphen/`1)` conversions, the instruction/prose/non-trailing/list-only/6+-item rejections, chip salvage through `chatAboutDesign` and `assessReadiness`, and structured-options-win. Lint 0 errors, 515 tests pass, build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)