### PR TITLE
feat(preview): instant artwork-on-color preview while Printful mockup renders

### DIFF
--- a/src/app/preview/page.tsx
+++ b/src/app/preview/page.tsx
@@ -24,13 +24,7 @@ import { ProductSilhouette } from "./product-silhouette";
 import { Breadcrumbs } from "@/components/breadcrumbs";
 import { breadcrumbTrail } from "@/lib/nav";
 import { ensureGuestSession } from "@/lib/ensure-guest-session";
-
-const LOADING_MESSAGES = [
-  "Rendering your design…",
-  "Placing design on product…",
-  "Almost there…",
-  "Adding finishing touches…",
-];
+import { resolveHeroDisplay } from "@/lib/instant-preview";
 
 type Placement = "front" | "back";
 
@@ -73,13 +67,21 @@ function PreviewPageInner() {
   });
   const [mockupLoading, setMockupLoading] = useState(false);
   const [mockupError, setMockupError] = useState(false);
+  // Most recent ready artwork per placement — keeps the instant
+  // artwork-on-color layer populated while a product/color change
+  // re-resolves the placement render (#57).
+  const [lastArtwork, setLastArtwork] = useState<{
+    front: string | null;
+    back: string | null;
+  }>({ front: null, back: null });
+  // URL of the mockup image the browser has finished loading; drives the
+  // crossfade from the instant layer to the exact Printful render.
+  const [loadedMockupUrl, setLoadedMockupUrl] = useState<string | null>(null);
   const [hasPrimary, setHasPrimary] = useState<boolean | null>(null);
   const [lightboxOpen, setLightboxOpen] = useState(false);
   const [zoomed, setZoomed] = useState(false);
   const [panOrigin, setPanOrigin] = useState({ x: 50, y: 50 });
   const [scale, setScale] = useState(1.0);
-
-  const [loadingMessageIdx, setLoadingMessageIdx] = useState(0);
 
   // Multi-placement (#25). Off-by-default flag keeps the back UI dark in
   // prod; when off, activePlacement never leaves "front" so the whole flow
@@ -189,6 +191,7 @@ function PreviewPageInner() {
           imageUrl: result.imageUrl,
           aspectRatio: result.aspectRatio,
         });
+        setLastArtwork((m) => ({ ...m, [placement]: result.imageUrl }));
         // Fresh placement render invalidates client mockup entries for this
         // product + placement. Server clears DB mockupUrls on insert.
         const prefix = `${productId}:${placement}:`;
@@ -261,18 +264,6 @@ function PreviewPageInner() {
     }
   }
 
-  // Rotate loading messages while mockup generates
-  useEffect(() => {
-    if (!mockupLoading) {
-      setLoadingMessageIdx(0);
-      return;
-    }
-    const timer = setInterval(() => {
-      setLoadingMessageIdx((i) => (i + 1) % LOADING_MESSAGES.length);
-    }, 4000);
-    return () => clearInterval(timer);
-  }, [mockupLoading]);
-
   // Auto-trigger the real Printful mockup whenever the active placement's
   // render settles (initial load, color/product change, placement switch).
   useEffect(() => {
@@ -342,8 +333,10 @@ function PreviewPageInner() {
   function chooseBackSource(id: string) {
     setBackImageId(id);
     setBackPickerOpen(false);
-    // New back source invalidates the back mockup only.
+    // New back source invalidates the back mockup only. Its instant-layer
+    // artwork too — the previous pick's artwork would be misleading.
     setMockups((m) => ({ ...m, back: null }));
+    setLastArtwork((m) => ({ ...m, back: null }));
     setMockupError(false);
     setMockupLoading(false);
   }
@@ -378,6 +371,17 @@ function PreviewPageInner() {
   const colorHex =
     colors.find((c) => c.name === colorName)?.value ?? "#ffffff";
   const productName = product?.name ?? "design";
+  // Instant preview (#57): what the hero shows right now — artwork on a
+  // shirt-colored silhouette immediately, exact mockup crossfaded in on top.
+  const display = resolveHeroDisplay({
+    renderStatus: renderState.status,
+    artworkUrl: designImageUrl,
+    lastArtworkUrl: lastArtwork[activePlacement],
+    mockupUrl: activeMockup,
+    mockupLoading,
+    mockupError,
+    loadedMockupUrl,
+  });
   // Approve needs the front mockup; a chosen back also needs its mockup.
   const approveReady =
     !!mockups.front && (!backImageId || !!mockups.back);
@@ -508,16 +512,7 @@ function PreviewPageInner() {
             activeMockup && !mockupLoading ? "cursor-zoom-in" : ""
           }`}
         >
-          {regenerating && (
-            <div className="absolute inset-0 flex flex-col items-center justify-center bg-surface-alt animate-pulse z-20">
-              <div className="w-12 h-12 border-2 border-accent border-t-transparent rounded-full animate-spin mb-3" />
-              <span className="text-sm text-text-muted text-center px-4">
-                Preparing your design for the {productName}…
-              </span>
-            </div>
-          )}
-
-          {renderState.status === "error" && (
+          {display.showError && (
             <div className="absolute inset-0 flex flex-col items-center justify-center gap-2 bg-surface-alt z-20 px-4 text-center">
               <span className="text-sm text-text-muted">
                 Couldn&rsquo;t prepare your design for the {productName}.
@@ -528,32 +523,41 @@ function PreviewPageInner() {
             </div>
           )}
 
-          {!regenerating && mockupLoading && (
-            <div className="absolute inset-0 flex flex-col items-center justify-center bg-surface-alt animate-pulse z-10">
-              <div className="w-12 h-12 border-2 border-accent border-t-transparent rounded-full animate-spin mb-3" />
-              <span className="text-sm text-text-muted transition-opacity">
-                {LOADING_MESSAGES[loadingMessageIdx]}
-              </span>
-            </div>
-          )}
+          {/* Instant layer (#57): the design artwork on a shirt-colored
+              silhouette, shown immediately on any product/color/placement
+              change while the exact Printful mockup renders. */}
+          <div className="w-full h-full p-2">
+            <ProductSilhouette
+              productType={product?.type ?? "shirt"}
+              color={colorHex}
+              designImageUrl={display.artworkUrl}
+              scale={scale}
+              printArea={product?.printArea ?? { width: 12, height: 16 }}
+            />
+          </div>
 
-          {!mockupLoading && activeMockup && (
+          {/* Exact Printful mockup — crossfades in over the instant layer
+              once its image bytes arrive. */}
+          {display.mockupUrl && (
             <img
-              src={activeMockup}
+              key={display.mockupUrl}
+              src={display.mockupUrl}
               alt={`Your design on a ${colorName} ${productName}`}
-              className="w-full h-full object-cover"
+              onLoad={() => setLoadedMockupUrl(display.mockupUrl)}
+              className={`absolute inset-0 w-full h-full object-cover transition-opacity duration-300 ${
+                display.mockupVisible ? "opacity-100" : "opacity-0"
+              }`}
             />
           )}
 
-          {!mockupLoading && !activeMockup && (
-            <div className="w-full h-full p-2">
-              <ProductSilhouette
-                productType={product?.type ?? "shirt"}
-                color={colorHex}
-                designImageUrl={designImageUrl}
-                scale={scale}
-                printArea={product?.printArea ?? { width: 12, height: 16 }}
-              />
+          {display.pendingExact && (
+            <div className="pointer-events-none absolute inset-x-0 bottom-2 z-10 flex justify-center">
+              <span className="inline-flex items-center gap-2 rounded-full bg-black/60 px-3 py-1.5 text-xs text-white backdrop-blur-sm">
+                <span className="h-3 w-3 animate-spin rounded-full border-2 border-white/70 border-t-transparent" />
+                {regenerating
+                  ? `Preparing your design…`
+                  : "Rendering exact preview…"}
+              </span>
             </div>
           )}
         </button>

--- a/src/lib/__tests__/instant-preview.test.ts
+++ b/src/lib/__tests__/instant-preview.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect } from "vitest";
+import { resolveHeroDisplay, type HeroDisplayInput } from "../instant-preview";
+
+const base: HeroDisplayInput = {
+  renderStatus: "ready",
+  artworkUrl: "https://r2/art.png",
+  lastArtworkUrl: null,
+  mockupUrl: null,
+  mockupLoading: false,
+  mockupError: false,
+  loadedMockupUrl: null,
+};
+
+describe("resolveHeroDisplay", () => {
+  it("first load: render resolving, no artwork yet -> bare shirt + pending", () => {
+    const d = resolveHeroDisplay({
+      ...base,
+      renderStatus: "loading",
+      artworkUrl: null,
+    });
+    expect(d).toEqual({
+      showError: false,
+      artworkUrl: null,
+      mockupUrl: null,
+      mockupVisible: false,
+      pendingExact: true,
+    });
+  });
+
+  it("render ready, mockup fetch not yet triggered -> artwork + pending", () => {
+    const d = resolveHeroDisplay(base);
+    expect(d.artworkUrl).toBe("https://r2/art.png");
+    expect(d.mockupUrl).toBeNull();
+    expect(d.pendingExact).toBe(true);
+  });
+
+  it("mockup fetch in flight -> artwork stays, pending", () => {
+    const d = resolveHeroDisplay({ ...base, mockupLoading: true });
+    expect(d.artworkUrl).toBe("https://r2/art.png");
+    expect(d.mockupUrl).toBeNull();
+    expect(d.pendingExact).toBe(true);
+  });
+
+  it("mockup fetched but image bytes not loaded -> mounted, hidden, pending", () => {
+    const d = resolveHeroDisplay({ ...base, mockupUrl: "https://r2/mock.png" });
+    expect(d.mockupUrl).toBe("https://r2/mock.png");
+    expect(d.mockupVisible).toBe(false);
+    expect(d.pendingExact).toBe(true);
+  });
+
+  it("mockup image loaded -> visible, not pending", () => {
+    const d = resolveHeroDisplay({
+      ...base,
+      mockupUrl: "https://r2/mock.png",
+      loadedMockupUrl: "https://r2/mock.png",
+    });
+    expect(d.mockupVisible).toBe(true);
+    expect(d.pendingExact).toBe(false);
+  });
+
+  it("returning to a cached, already-loaded mockup shows it immediately", () => {
+    // Color A -> B -> A: A's URL is still the last-loaded image.
+    const d = resolveHeroDisplay({
+      ...base,
+      mockupUrl: "https://r2/mock-a.png",
+      loadedMockupUrl: "https://r2/mock-a.png",
+    });
+    expect(d.mockupVisible).toBe(true);
+    expect(d.pendingExact).toBe(false);
+  });
+
+  it("stale loaded URL from a previous selection does not show the new mockup", () => {
+    const d = resolveHeroDisplay({
+      ...base,
+      mockupUrl: "https://r2/mock-b.png",
+      loadedMockupUrl: "https://r2/mock-a.png",
+    });
+    expect(d.mockupVisible).toBe(false);
+    expect(d.pendingExact).toBe(true);
+  });
+
+  it("re-resolving render (product/color change) falls back to last artwork", () => {
+    const d = resolveHeroDisplay({
+      ...base,
+      renderStatus: "loading",
+      artworkUrl: null,
+      lastArtworkUrl: "https://r2/prev-art.png",
+    });
+    expect(d.artworkUrl).toBe("https://r2/prev-art.png");
+    expect(d.pendingExact).toBe(true);
+  });
+
+  it("render error -> error overlay, nothing pending, no mockup mounted", () => {
+    const d = resolveHeroDisplay({
+      ...base,
+      renderStatus: "error",
+      artworkUrl: null,
+      mockupUrl: "https://r2/mock.png",
+    });
+    expect(d.showError).toBe(true);
+    expect(d.mockupUrl).toBeNull();
+    expect(d.pendingExact).toBe(false);
+  });
+
+  it("mockup error -> artwork stays, indicator suppressed (retry UI takes over)", () => {
+    const d = resolveHeroDisplay({ ...base, mockupError: true });
+    expect(d.artworkUrl).toBe("https://r2/art.png");
+    expect(d.pendingExact).toBe(false);
+  });
+
+  it("idle (back placement, no source picked) -> nothing pending", () => {
+    const d = resolveHeroDisplay({
+      ...base,
+      renderStatus: "idle",
+      artworkUrl: null,
+    });
+    expect(d.pendingExact).toBe(false);
+    expect(d.artworkUrl).toBeNull();
+  });
+
+  it("in-flight fetch never mounts a mockup even if state briefly overlaps", () => {
+    const d = resolveHeroDisplay({
+      ...base,
+      mockupLoading: true,
+      mockupUrl: "https://r2/mock.png",
+    });
+    expect(d.mockupUrl).toBeNull();
+  });
+});

--- a/src/lib/instant-preview.ts
+++ b/src/lib/instant-preview.ts
@@ -1,0 +1,57 @@
+/**
+ * Instant artwork-on-color preview for /preview (#57).
+ *
+ * The exact Printful mockup takes seconds to render. Instead of hiding the
+ * hero behind a spinner while it loads, the page shows the design artwork on
+ * a shirt-colored silhouette immediately (the same fallback treatment the
+ * order emails use) and crossfades the real mockup in when it arrives.
+ *
+ * Pure — resolves which layers the hero shows from the render/mockup state.
+ */
+
+export type HeroDisplayInput = {
+  /** Placement-render state for the active (product, placement, source). */
+  renderStatus: "idle" | "loading" | "ready" | "error";
+  /** Artwork URL of the current ready render; null while loading. */
+  artworkUrl: string | null;
+  /** Most recent ready artwork for the active placement — keeps the instant
+   * layer populated while a product/color change re-resolves the render. */
+  lastArtworkUrl: string | null;
+  /** The Printful mockup URL for the current selection, if fetched. */
+  mockupUrl: string | null;
+  mockupLoading: boolean;
+  mockupError: boolean;
+  /** URL of the mockup image the browser has finished loading (onLoad). */
+  loadedMockupUrl: string | null;
+};
+
+export type HeroDisplay = {
+  /** Placement render failed — the page shows its error overlay. */
+  showError: boolean;
+  /** Artwork for the instant silhouette layer (null → bare shirt). */
+  artworkUrl: string | null;
+  /** Mockup to mount (and fade in once its bytes load); null while a fetch
+   * for the current selection is still in flight. */
+  mockupUrl: string | null;
+  /** True once the mounted mockup has actually loaded — drives the fade. */
+  mockupVisible: boolean;
+  /** Show the subtle "Rendering exact preview…" indicator. */
+  pendingExact: boolean;
+};
+
+export function resolveHeroDisplay(i: HeroDisplayInput): HeroDisplay {
+  const showError = i.renderStatus === "error";
+  // While a new mockup is being fetched the previous one is already cleared
+  // by the page; only mount a mockup that matches the current selection.
+  const mockupUrl = !showError && !i.mockupLoading ? i.mockupUrl : null;
+  const mockupVisible = mockupUrl !== null && i.loadedMockupUrl === mockupUrl;
+  const artworkUrl =
+    (i.renderStatus === "ready" ? i.artworkUrl : null) ?? i.lastArtworkUrl;
+  // Pending whenever the exact mockup isn't on screen yet but is on its way:
+  // render resolving, mockup fetch in flight, fetch about to auto-trigger,
+  // or mockup fetched but image bytes still downloading. Suppressed on
+  // errors (retry UI takes over) and in idle (nothing will be fetched).
+  const pendingExact =
+    !showError && !i.mockupError && !mockupVisible && i.renderStatus !== "idle";
+  return { showError, artworkUrl, mockupUrl, mockupVisible, pendingExact };
+}


### PR DESCRIPTION
Part of #57 (first checkbox).

## Problem

Switching product, color, or placement on /preview waited on a Printful mockup render behind an opaque pulsing spinner — a multi-second hang with no feedback, worst on phones.

## Change

- The hero now shows the design artwork on the shirt-colored `ProductSilhouette` **immediately** on any product/color/placement change (same fallback treatment the order emails use via `getColorHex`), with a subtle "Rendering exact preview…" pill.
- The real Printful mockup still fetches exactly as before and **crossfades in** (300ms opacity) once its image bytes load. Returning to an already-loaded cached mockup shows it instantly, no fade.
- Last-ready artwork is kept per placement so the instant layer stays populated while a product/color change re-resolves the placement render; cleared when a new back source is picked (previous artwork would mislead). Front/Back toggle behavior unchanged.
- New pure helper `src/lib/instant-preview.ts` `resolveHeroDisplay()` centralizes the layer logic — 12 unit tests cover first load, in-flight fetch, bytes-loading gap, cached revisit, render error, mockup error (indicator suppressed so the retry UI reads clearly), and back-placement idle.
- Loading-message rotation (`LOADING_MESSAGES`) removed — the preview itself is the feedback now.
- `/d/[imageId]` BuyPanel checked and left untouched: it renders artwork-on-backdrop with no mockup fetch on color switch, so it doesn't have this problem.

No server/API changes; approve CTA still gates on the real mockup.

## Verification

- `npm run lint` — 0 errors
- `npm test` — 515 passed (48 files), incl. 12 new
- `npm run build` — clean (CI-style env)

🤖 Generated with [Claude Code](https://claude.com/claude-code)