### PR TITLE
fix(buy): require explicit size; label designer-picked color

### DIFF
--- a/src/app/d/[imageId]/__tests__/buy-panel.test.tsx
+++ b/src/app/d/[imageId]/__tests__/buy-panel.test.tsx
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { BuyPanel } from "../buy-panel";
+
+vi.mock("../../actions", () => ({
+  buyPublishedDesign: vi.fn().mockResolvedValue({ url: null, needsAuth: false }),
+}));
+
+import { buyPublishedDesign } from "../../actions";
+
+function buyButton() {
+  // Rendered twice (desktop inline + mobile sticky); both share state.
+  return screen.getAllByRole("button", { name: /Buy this design/ })[0];
+}
+
+describe("BuyPanel size gate (#60)", () => {
+  it("starts with no size selected and the CTA disabled", () => {
+    render(<BuyPanel imageId="img-1" isLoggedIn />);
+    expect(buyButton()).toBeDisabled();
+    expect(screen.getAllByText("Choose a size").length).toBeGreaterThan(0);
+    expect(buyPublishedDesign).not.toHaveBeenCalled();
+  });
+
+  it("enables the CTA once a size is picked", () => {
+    render(<BuyPanel imageId="img-1" isLoggedIn />);
+    fireEvent.click(screen.getByRole("button", { name: "M" }));
+    expect(buyButton()).toBeEnabled();
+    expect(screen.queryByText("Choose a size")).not.toBeInTheDocument();
+  });
+
+  it("labels the pinned color as the designer's pick", () => {
+    render(<BuyPanel imageId="img-1" isLoggedIn preferredColor="Black" />);
+    expect(
+      screen.getByText("Shown in Black — designer's pick")
+    ).toBeInTheDocument();
+  });
+
+  it("shows no designer's-pick note without a pinned color", () => {
+    render(<BuyPanel imageId="img-1" isLoggedIn />);
+    expect(screen.queryByText(/designer's pick/)).not.toBeInTheDocument();
+  });
+});

--- a/src/app/d/[imageId]/buy-panel.tsx
+++ b/src/app/d/[imageId]/buy-panel.tsx
@@ -31,31 +31,40 @@ export function BuyPanel({
   const sizes = product?.sizes ?? [];
   const colors = product?.colors ?? [];
 
-  const [size, setSize] = useState(sizes[1] ?? sizes[0] ?? "M");
-  const [color, setColor] = useState(
-    preferredColor && colors.some((c) => c.name === preferredColor)
+  // No default size (#60): the buyer must pick one before the CTA enables,
+  // so nobody checks out in a size they never chose.
+  const [size, setSize] = useState<string | null>(null);
+  // The pinned backdrop color IS defaulted (the design is displayed on it),
+  // but labeled below so it's not a silent pick.
+  const pinnedColorApplied =
+    !!preferredColor && colors.some((c) => c.name === preferredColor);
+  const [color, setColor] = useState<string>(
+    pinnedColorApplied && preferredColor
       ? preferredColor
       : colors[0]?.name ?? "White"
   );
   const [loading, setLoading] = useState(false);
 
-  // Switching product can invalidate the current size/color. Clamp both to
-  // the new product's options.
+  // Switching product can invalidate the current size/color. Size resets to
+  // unselected (never silently re-picked); color clamps to the new options.
   function handleProduct(id: string) {
     const next = getBlank(id);
     if (!next) return;
     setProductId(id);
-    if (!next.sizes.includes(size)) setSize(next.sizes[1] ?? next.sizes[0]);
+    if (size && !next.sizes.includes(size)) setSize(null);
     if (!next.colors.some((c) => c.name === color)) {
       setColor(next.colors[0]?.name ?? "White");
     }
   }
 
+  // Price display before a size is picked uses the base size — S–XL share a
+  // price; a 2XL pick updates it live.
   const { item, shipping, total } = computeOrderTotal(
-    computePrice(0, productId, size).total
+    computePrice(0, productId, size ?? sizes[0] ?? "M").total
   );
 
   async function handleBuy() {
+    if (!size) return;
     setLoading(true);
     try {
       const { url, needsAuth } = await buyPublishedDesign({ imageId, productId, size, color });
@@ -70,9 +79,19 @@ export function BuyPanel({
   }
 
   const cta = isLoggedIn ? (
-    <Button onClick={handleBuy} disabled={loading} size="lg" className="w-full">
-      {loading ? "Redirecting…" : `Buy this design — $${total.toFixed(2)}`}
-    </Button>
+    <div className="space-y-1.5">
+      {!size && (
+        <p className="text-sm text-text-muted text-center">Choose a size</p>
+      )}
+      <Button
+        onClick={handleBuy}
+        disabled={loading || !size}
+        size="lg"
+        className="w-full"
+      >
+        {loading ? "Redirecting…" : `Buy this design — $${total.toFixed(2)}`}
+      </Button>
+    </div>
   ) : (
     <Link href={`/sign-in?next=/d/${imageId}`} className="block">
       <Button size="lg" className="w-full">
@@ -110,7 +129,16 @@ export function BuyPanel({
         onChange={setSize}
         label={product?.sizeLabel ?? "Size"}
       />
-      <ColorPicker colors={colors} value={color} onChange={setColor} />
+      <ColorPicker
+        colors={colors}
+        value={color}
+        onChange={setColor}
+        note={
+          pinnedColorApplied
+            ? `Shown in ${preferredColor} — designer's pick`
+            : undefined
+        }
+      />
 
       <div className="space-y-2 text-sm border-t border-border pt-4">
         <div className="flex justify-between">

--- a/src/app/order/page.tsx
+++ b/src/app/order/page.tsx
@@ -46,7 +46,13 @@ function OrderPageInner() {
   const [imageUrl, setImageUrl] = useState<string | null>(null);
   const [mockupUrl, setMockupUrl] = useState<string | null>(null);
   const [mockupLoading, setMockupLoading] = useState(false);
-  const [size, setSize] = useState(searchParams.get("size") ?? sizes[1] ?? sizes[0] ?? "M");
+  // No default size (#60): start unselected unless the URL carries a valid
+  // one (Stripe cancel → back, or an explicit /preview handoff). The buy
+  // buttons stay disabled until a size is picked.
+  const [size, setSize] = useState<string | null>(() => {
+    const fromUrl = searchParams.get("size");
+    return fromUrl && sizes.includes(fromUrl) ? fromUrl : null;
+  });
   const [color, setColor] = useState(searchParams.get("color") ?? colors[0]?.name ?? "White");
   const [pricing, setPricing] = useState<{
     baseCost: number;
@@ -112,7 +118,7 @@ function OrderPageInner() {
   }, [designId, productId, color]);
 
   useEffect(() => {
-    if (!designId) return;
+    if (!designId || !size) return;
     calculatePrice(designId, productId, size, backActive).then(setPricing);
   }, [designId, productId, size, backActive]);
 
@@ -120,7 +126,8 @@ function OrderPageInner() {
   // source is preserved verbatim (it's captured once, never cleared here).
   useEffect(() => {
     const params = new URLSearchParams(window.location.search);
-    params.set("size", size);
+    if (size) params.set("size", size);
+    else params.delete("size");
     params.set("color", color);
     params.set("product", productId);
     if (backImageId) params.set("back", backImageId);
@@ -129,7 +136,7 @@ function OrderPageInner() {
   }, [size, color, productId, backImageId]);
 
   async function handleCheckout() {
-    if (!designId) return;
+    if (!designId || !size) return;
     setLoading(true);
     try {
       const { url, needsAuth } = await createCheckoutSession({
@@ -153,7 +160,7 @@ function OrderPageInner() {
   }
 
   async function handleAddToCart() {
-    if (!designId) return;
+    if (!designId || !size) return;
     setAddingToCart(true);
     try {
       await addToCart({
@@ -251,9 +258,14 @@ function OrderPageInner() {
           )}
 
           {/* Desktop checkout */}
+          {!size && (
+            <p className="hidden md:block text-sm text-text-muted text-center">
+              Choose a size
+            </p>
+          )}
           <Button
             onClick={handleCheckout}
-            disabled={loading}
+            disabled={loading || !size}
             className="hidden md:block w-full"
             size="lg"
           >
@@ -262,7 +274,7 @@ function OrderPageInner() {
           {cartShown && (
             <Button
               onClick={handleAddToCart}
-              disabled={addingToCart}
+              disabled={addingToCart || !size}
               variant="secondary"
               className="hidden md:block w-full mt-3"
               size="lg"
@@ -275,9 +287,12 @@ function OrderPageInner() {
 
       {/* Mobile sticky checkout bar */}
       <div className="fixed bottom-0 left-0 right-0 z-30 md:hidden bg-background border-t border-border p-4 space-y-2">
+        {!size && (
+          <p className="text-sm text-text-muted text-center">Choose a size</p>
+        )}
         <Button
           onClick={handleCheckout}
-          disabled={loading}
+          disabled={loading || !size}
           className="w-full"
           size="lg"
         >
@@ -290,7 +305,7 @@ function OrderPageInner() {
         {cartShown && (
           <Button
             onClick={handleAddToCart}
-            disabled={addingToCart}
+            disabled={addingToCart || !size}
             variant="secondary"
             className="w-full"
             size="lg"

--- a/src/components/__tests__/product-options.test.tsx
+++ b/src/components/__tests__/product-options.test.tsx
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { SizePicker, ColorPicker } from "../product-options";
+
+const COLORS = [
+  { name: "White", value: "#ffffff" },
+  { name: "Black", value: "#000000" },
+];
+
+describe("SizePicker", () => {
+  it("renders with no size selected when value is null", () => {
+    render(<SizePicker sizes={["S", "M", "L"]} value={null} onChange={() => {}} />);
+    for (const s of ["S", "M", "L"]) {
+      expect(screen.getByRole("button", { name: s })).toHaveAttribute(
+        "aria-pressed",
+        "false"
+      );
+    }
+  });
+
+  it("marks only the selected size pressed", () => {
+    render(<SizePicker sizes={["S", "M", "L"]} value="M" onChange={() => {}} />);
+    expect(screen.getByRole("button", { name: "M" })).toHaveAttribute(
+      "aria-pressed",
+      "true"
+    );
+    expect(screen.getByRole("button", { name: "S" })).toHaveAttribute(
+      "aria-pressed",
+      "false"
+    );
+  });
+
+  it("reports picks via onChange", () => {
+    const onChange = vi.fn();
+    render(<SizePicker sizes={["S", "M"]} value={null} onChange={onChange} />);
+    fireEvent.click(screen.getByRole("button", { name: "M" }));
+    expect(onChange).toHaveBeenCalledWith("M");
+  });
+});
+
+describe("ColorPicker", () => {
+  it("shows the note when provided", () => {
+    render(
+      <ColorPicker
+        colors={COLORS}
+        value="Black"
+        onChange={() => {}}
+        note="Shown in Black — designer's pick"
+      />
+    );
+    expect(
+      screen.getByText("Shown in Black — designer's pick")
+    ).toBeInTheDocument();
+  });
+
+  it("renders no note by default", () => {
+    render(<ColorPicker colors={COLORS} value="White" onChange={() => {}} />);
+    expect(screen.queryByText(/designer's pick/)).not.toBeInTheDocument();
+  });
+});

--- a/src/components/product-options.tsx
+++ b/src/components/product-options.tsx
@@ -5,8 +5,11 @@ import type { BlankColor } from "@/lib/blanks";
 /**
  * Size + color selectors shared by the order flow (`/order`) and the
  * buy-existing flow (`/d/[imageId]`). Presentational only — parents own
- * the selected state and any price/mockup side effects. Phone-first: 40px+
+ * the selected state and any price/mockup side effects. Phone-first: 44px+
  * touch targets per the mobile-UX guidance.
+ *
+ * `value: null` means no size chosen yet (#60) — parents start unselected
+ * and gate their CTA on a pick.
  */
 export function SizePicker({
   sizes,
@@ -15,7 +18,7 @@ export function SizePicker({
   label = "Size",
 }: {
   sizes: string[];
-  value: string;
+  value: string | null;
   onChange: (size: string) => void;
   label?: string;
 }) {
@@ -27,7 +30,8 @@ export function SizePicker({
           <button
             key={s}
             onClick={() => onChange(s)}
-            className={`px-3 py-2.5 md:py-1.5 border-2 rounded-md text-sm transition-colors ${
+            aria-pressed={value === s}
+            className={`min-w-11 min-h-11 md:min-w-0 md:min-h-0 px-3 py-2.5 md:py-1.5 border-2 rounded-md text-sm transition-colors ${
               value === s
                 ? "border-accent bg-accent text-accent-fg font-medium"
                 : "border-border text-text-muted hover:border-border-hover"
@@ -43,16 +47,20 @@ export function SizePicker({
 
 /**
  * Color swatches. Renders nothing when the product has a single color, so
- * callers can drop it in unconditionally.
+ * callers can drop it in unconditionally. `note` renders as small muted text
+ * under the swatches — used to label a non-obvious default (e.g. the
+ * designer-pinned color on the buy page, #60).
  */
 export function ColorPicker({
   colors,
   value,
   onChange,
+  note,
 }: {
   colors: BlankColor[];
   value: string;
   onChange: (color: string) => void;
+  note?: string;
 }) {
   if (colors.length <= 1) return null;
   return (
@@ -73,6 +81,7 @@ export function ColorPicker({
           />
         ))}
       </div>
+      {note && <p className="text-xs text-text-muted mt-2">{note}</p>}
     </div>
   );
 }


### PR DESCRIPTION
Closes #60

Clicking "Buy this design" could land users at checkout with a color and size they never consciously chose. UI-state fix only — server validation via `resolveOrderVariant` is unchanged.

## BuyPanel (`/d/[imageId]`)
- Size starts unselected; Buy CTA disabled with "Choose a size" helper until picked (desktop + mobile sticky bar). Switching product with an incompatible size resets to unselected instead of silently re-picking.
- Pinned backdrop color stays the default (the design is displayed on it) but is labeled: "Shown in <Color> — designer's pick", only when the pin drove the default.
- Price breakdown shows the base-size price until a size is picked (S–XL share a price; 2XL updates live).

## /order (same silent default, same fix)
- `/preview` links to `/order` without a size, so the page silently defaulted to M. Now starts unselected; Buy now + Add to cart disabled with "Choose a size" until picked.
- A valid `?size=` in the URL is still honored (Stripe cancel → back restores the user's pick; `e2e/cart.spec.ts` passes `size=M` explicitly, so no e2e changes needed).

## Shared `SizePicker`/`ColorPicker`
- `SizePicker` accepts `value: string | null`; chips get 44px mobile touch targets (`min-w-11 min-h-11`, compact on desktop) + `aria-pressed`.
- `ColorPicker` gains an optional `note` for labeling non-obvious defaults.
- Other callers (store-buy-panel, compose-form) unchanged — `string` remains assignable.

## Tests
- New `product-options.test.tsx` (5) and `buy-panel.test.tsx` (4): unselected start, CTA gate, designer's-pick note.
- lint 0 errors · 512 tests pass · build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)