### PR TITLE
chore: rename storefront 'Fresh Prints' → 'Shop'

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -89,7 +89,7 @@ export default async function Home() {
       {discover.length > 0 && (
         <section className="py-16 px-4 border-t border-border">
           <div className="max-w-6xl mx-auto">
-            <h2 className="text-2xl font-bold text-center mb-2">Fresh Prints</h2>
+            <h2 className="text-2xl font-bold text-center mb-2">Shop</h2>
             <p className="text-text-muted text-center mb-8">
               Browse and buy designs other makers have published.
             </p>
@@ -99,7 +99,7 @@ export default async function Home() {
                 href="/prints"
                 className="text-sm text-text-muted underline hover:text-foreground transition-colors"
               >
-                See all Fresh Prints →
+                See the whole Shop →
               </Link>
             </div>
           </div>

--- a/src/app/prints/page.tsx
+++ b/src/app/prints/page.tsx
@@ -3,14 +3,14 @@ import { PublishedGrid } from "@/components/published-grid";
 
 export const dynamic = "force-dynamic";
 
-export default async function FreshPrintsPage() {
+export default async function ShopPage() {
   const images = await getDiscoverFeed(60);
 
   return (
     <main className="flex-1 px-4 py-10">
       <div className="max-w-6xl mx-auto">
         <header className="mb-8 text-center">
-          <h1 className="text-3xl font-bold">Fresh Prints</h1>
+          <h1 className="text-3xl font-bold">Shop</h1>
           <p className="text-text-muted mt-2">
             Browse and buy designs other makers have published.
           </p>

--- a/src/components/publish-modal.tsx
+++ b/src/components/publish-modal.tsx
@@ -56,7 +56,7 @@ export function PublishModal({
       onClose={publishing ? () => {} : onClose}
       className="w-[calc(100vw-2rem)] max-w-lg bg-background border border-border rounded-lg p-5 max-h-[90vh] overflow-y-auto"
     >
-      <h2 className="text-lg font-bold">Publish to Fresh Prints</h2>
+      <h2 className="text-lg font-bold">Publish to the Shop</h2>
       <p className="text-sm text-text-muted mt-1">
         Set how your design appears in the storefront. Leave name or
         description blank to auto-generate them.

--- a/src/components/published-grid.tsx
+++ b/src/components/published-grid.tsx
@@ -3,7 +3,7 @@ import type { PublishedImage } from "@/app/d/actions";
 import { publishedBackdrop } from "@/lib/blanks";
 
 /**
- * Shared grid of published ("Fresh Prints") designs. Each card links to the
+ * Shared grid of published (Shop, /prints) designs. Each card links to the
  * buy page at /d/[imageId]. The viewer's own designs are tagged "by you"
  * (set on PublishedImage.isOwn by the feed query).
  */

--- a/src/components/site-header.tsx
+++ b/src/components/site-header.tsx
@@ -43,18 +43,18 @@ export function SiteHeader() {
     Boolean(session) &&
     !(session?.user as { isAnonymous?: boolean } | undefined)?.isAnonymous;
 
-  // Fresh Prints (the community storefront) leads for everyone — it's the
+  // Shop (the community storefront, /prints) leads for everyone — it's the
   // open buy-existing flow. The design-your-own + personal links are
   // auth-gated.
   const links: NavLink[] = isAuthed
     ? [
-        { href: "/prints", label: "Fresh Prints" },
+        { href: "/prints", label: "Shop" },
         { href: "/design", label: "New Design" },
         ...(showDashboard ? [{ href: "/dashboard", label: "Dashboard" }] : []),
         { href: "/designs", label: "My Designs" },
         { href: "/orders", label: "Orders" },
       ]
-    : [{ href: "/prints", label: "Fresh Prints" }];
+    : [{ href: "/prints", label: "Shop" }];
 
   function signOut() {
     authClient.signOut().then(() => {

--- a/src/lib/__tests__/nav.test.ts
+++ b/src/lib/__tests__/nav.test.ts
@@ -55,14 +55,14 @@ describe("breadcrumbTrail", () => {
       href: "/orders",
     });
     expect(breadcrumbTrail("/d/img1", { from: "/prints" }).at(-1)).toEqual({
-      label: "Fresh Prints",
+      label: "Shop",
       href: "/prints",
     });
   });
 
-  it("falls back to Fresh Prints for a design detail with no origin", () => {
+  it("falls back to the Shop for a design detail with no origin", () => {
     expect(breadcrumbTrail("/d/img1").at(-1)).toEqual({
-      label: "Fresh Prints",
+      label: "Shop",
       href: "/prints",
     });
   });

--- a/src/lib/nav.ts
+++ b/src/lib/nav.ts
@@ -34,7 +34,7 @@ function query(
 /**
  * A design detail (/d/[id]) is reachable from several hubs. We record the
  * origin in ?from so "up" returns there; shared links with no origin fall
- * back to Fresh Prints, the public storefront.
+ * back to the Shop, the public storefront.
  */
 function detailParent(from: string | undefined): Crumb {
   switch (from) {
@@ -44,7 +44,7 @@ function detailParent(from: string | undefined): Crumb {
       return { label: "Orders", href: "/orders" };
     case "/prints":
     default:
-      return { label: "Fresh Prints", href: "/prints" };
+      return { label: "Shop", href: "/prints" };
   }
 }
 


### PR DESCRIPTION
Both testers found "Fresh Prints" un-grokkable (Nico, 2026-07-19). Label-only sweep of user-visible copy; no route changes.

## Changes
- Nav label (signed-in + signed-out): `Fresh Prints` → `Shop` (site-header.tsx)
- `/prints` page heading → "Shop"
- Homepage feed section heading → "Shop"; "See all Fresh Prints →" → "See the whole Shop →"
- Publish modal heading → "Publish to the Shop"
- Breadcrumb fallback label in `nav.ts` → "Shop" (+ nav.test.ts assertions)
- Stale comments updated (site-header, nav, published-grid)

## Deliberately deferred
The `/prints` route path stays as-is — no rename, no redirects here. `/shop/[slug]` is already the organizer-store namespace, so moving the public storefront to `/shop` would merge two namespaces and needs its own decision.

## Vocabulary collision to be aware of
"Shop" now means two things in the UI:
1. Nav "Shop" → `/prints` (community storefront, browse/buy published designs)
2. Footer "Open a shop →" → `/dashboard` (organizer store creation), plus organizer copy ("create shop", `/shop/[slug]`)

Per scope, organizer copy is untouched. The sharpest juxtaposition is the homepage: the "Shop" feed section sits above the footer's "Open a shop →". A visitor could read "Open a shop" as "go to the Shop". Flagging rather than inventing new copy — resolving it probably belongs with the /shop namespace decision above.

docs/ and CLAUDE.md history intentionally untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)