### PR TITLE
fix(publish): white backdrop by default; no transparent publish

### DIFF
--- a/src/app/d/[imageId]/published-image-view.tsx
+++ b/src/app/d/[imageId]/published-image-view.tsx
@@ -3,7 +3,7 @@
 import { useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 import { updatePublishedNaming, unpublishImage } from "@/app/designs/actions";
-import { publishedBackdrop } from "@/lib/blanks";
+import { publishedBackdrop, DEFAULT_PUBLISH_BACKGROUND } from "@/lib/blanks";
 import { BackgroundPicker } from "@/components/background-picker";
 import { Button } from "@/components/ui";
 
@@ -31,11 +31,15 @@ export function PublishedImageView({
   canEdit: boolean;
 }) {
   const router = useRouter();
-  const [bg, setBg] = useState<string | null>(initialBackgroundColor);
+  // Legacy rows can carry null; the picker offers no transparent option
+  // (#73), so seed it with the White display default instead.
+  const [bg, setBg] = useState<string>(
+    initialBackgroundColor ?? DEFAULT_PUBLISH_BACKGROUND
+  );
   const [pending, startTransition] = useTransition();
   const backdrop = publishedBackdrop(bg);
 
-  function pick(color: string | null) {
+  function pick(color: string) {
     const prev = bg;
     setBg(color); // optimistic
     startTransition(async () => {

--- a/src/app/d/actions.ts
+++ b/src/app/d/actions.ts
@@ -25,7 +25,7 @@ export type PublishedImage = {
   imageUrl: string;
   title: string | null;
   description: string | null;
-  /** Pinned storefront backdrop (a BACKGROUND_PALETTE color name); null → checkerboard. */
+  /** Pinned storefront backdrop (a BACKGROUND_PALETTE color name); legacy null displays as White (#73). */
   backgroundColor: string | null;
   designerName: string;
   designerId: string;

--- a/src/app/designs/actions.ts
+++ b/src/app/designs/actions.ts
@@ -13,6 +13,7 @@ import { eq, desc, and, not, count, inArray } from "drizzle-orm";
 import { revalidatePath } from "next/cache";
 import { resolveDesignDisplayImageUrls } from "@/lib/design-images";
 import { generatePublishedNaming } from "@/lib/ai";
+import { DEFAULT_PUBLISH_BACKGROUND } from "@/lib/blanks";
 
 export async function getUserDesigns() {
   const session = await auth.api.getSession({ headers: await headers() });
@@ -207,9 +208,9 @@ export async function publishImage(
       publishedAt: new Date(),
       title,
       description,
-      ...(opts.backgroundColor !== undefined
-        ? { backgroundColor: opts.backgroundColor }
-        : {}),
+      // Publish never leaves the backdrop transparent (#73): no pick — or an
+      // explicit null from a legacy caller — persists as White.
+      backgroundColor: opts.backgroundColor ?? DEFAULT_PUBLISH_BACKGROUND,
     })
     .where(eq(designImageTable.id, imageId));
 
@@ -253,8 +254,9 @@ export async function updatePublishedNaming(
 
   // Partial update: only touch fields the caller actually sent. The
   // background control persists backgroundColor alone; the naming editor
-  // sends title + description. backgroundColor can be explicit null (clear
-  // to checkerboard), so the guard is `!== undefined`, not truthiness.
+  // sends title + description. The picker no longer offers a transparent
+  // option (#73); a legacy null still displays as White via
+  // publishedBackdrop, so the guard stays `!== undefined`, not truthiness.
   await db
     .update(designImageTable)
     .set({

--- a/src/app/designs/page.tsx
+++ b/src/app/designs/page.tsx
@@ -104,13 +104,11 @@ export default function DesignsPage() {
           <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
             {designs.map((design) => {
               // Published designs render over their chosen storefront
-              // backdrop (matching PublishedGrid); unpublished — or a null
-              // backdrop — keep the checkerboard.
-              const backdrop = publishedBackdrop(
-                design.primaryImagePublishedAt
-                  ? design.primaryImageBackgroundColor
-                  : null
-              );
+              // backdrop (matching PublishedGrid; null → White, #73);
+              // unpublished ones keep the checkerboard working view.
+              const backdrop = design.primaryImagePublishedAt
+                ? publishedBackdrop(design.primaryImageBackgroundColor)
+                : { className: "bg-checkerboard", style: undefined };
               return (
               <div key={design.id} className="border rounded-lg overflow-hidden group">
                 <Link href={getDesignHref(design)} className="block">

--- a/src/components/background-picker.tsx
+++ b/src/components/background-picker.tsx
@@ -3,39 +3,26 @@
 import { BACKGROUND_PALETTE } from "@/lib/blanks";
 
 /**
- * Backdrop swatches for a published design. "None" clears to the
- * checkerboard; the rest are shirt colors from the default product palette.
- * Presentational — the parent owns the selected value and persistence.
- * Phone-first: 40px touch targets.
+ * Backdrop swatches for a published design — shirt colors from the default
+ * product palette. No "none"/transparent option: published art always sits
+ * on a color in the Shop (#73). Presentational — the parent owns the
+ * selected value and persistence. Phone-first: 40px touch targets.
  */
 export function BackgroundPicker({
   value,
   onChange,
   disabled = false,
 }: {
-  value: string | null;
-  onChange: (color: string | null) => void;
+  value: string;
+  onChange: (color: string) => void;
   disabled?: boolean;
 }) {
   return (
     <div>
       <label className="block text-sm font-medium mb-2">
-        Background — {value ?? "None"}
+        Background — {value}
       </label>
       <div className="flex flex-wrap gap-2.5 md:gap-2">
-        <button
-          type="button"
-          onClick={() => onChange(null)}
-          disabled={disabled}
-          title="None (checkerboard)"
-          aria-label="No background"
-          aria-pressed={value === null}
-          className={`w-10 h-10 md:w-8 md:h-8 rounded-full border-2 bg-checkerboard transition-colors disabled:opacity-50 ${
-            value === null
-              ? "border-accent ring-2 ring-offset-1 ring-accent ring-offset-background"
-              : "border-border"
-          }`}
-        />
         {BACKGROUND_PALETTE.map((c) => (
           <button
             key={c.name}

--- a/src/components/publish-modal.tsx
+++ b/src/components/publish-modal.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { Modal, Button } from "@/components/ui";
 import { BackgroundPicker } from "@/components/background-picker";
+import { DEFAULT_PUBLISH_BACKGROUND } from "@/lib/blanks";
 import { publishImage } from "@/app/designs/actions";
 
 /**
@@ -28,7 +29,7 @@ export function PublishModal({
   const router = useRouter();
   const [title, setTitle] = useState("");
   const [description, setDescription] = useState("");
-  const [bg, setBg] = useState<string | null>(null);
+  const [bg, setBg] = useState<string>(DEFAULT_PUBLISH_BACKGROUND);
   const [publishing, setPublishing] = useState(false);
   const [error, setError] = useState<string | null>(null);
 

--- a/src/lib/__tests__/blanks.test.ts
+++ b/src/lib/__tests__/blanks.test.ts
@@ -15,6 +15,9 @@ import {
   BLANKS,
   ACTIVE_BLANKS,
   DEFAULT_BLANK_ID,
+  publishedBackdrop,
+  DEFAULT_PUBLISH_BACKGROUND,
+  BACKGROUND_PALETTE,
 } from "../blanks";
 
 describe("getBlank", () => {
@@ -305,5 +308,31 @@ describe("placements (#25 back printing)", () => {
     expect(multiPlacementEnabled()).toBe(true);
     if (prev === undefined) delete process.env.MULTI_PLACEMENT_ENABLED;
     else process.env.MULTI_PLACEMENT_ENABLED = prev;
+  });
+});
+
+describe("publishedBackdrop", () => {
+  it("resolves a palette color name to its hex", () => {
+    expect(publishedBackdrop("Black")).toEqual({
+      className: "",
+      style: { backgroundColor: "#0c0c0c" },
+    });
+  });
+
+  it("legacy null displays as White, never checkerboard (#73)", () => {
+    expect(publishedBackdrop(null)).toEqual({
+      className: "",
+      style: { backgroundColor: "#ffffff" },
+    });
+    expect(publishedBackdrop(undefined)).toEqual({
+      className: "",
+      style: { backgroundColor: "#ffffff" },
+    });
+  });
+
+  it("the publish default is a real palette color", () => {
+    expect(
+      BACKGROUND_PALETTE.some((c) => c.name === DEFAULT_PUBLISH_BACKGROUND)
+    ).toBe(true);
   });
 });

--- a/src/lib/blanks.ts
+++ b/src/lib/blanks.ts
@@ -511,18 +511,30 @@ export const BACKGROUND_PALETTE: BlankColor[] =
   getBlankOrThrow(DEFAULT_BLANK_ID).colors;
 
 /**
+ * Backdrop color published designs get when the owner didn't pick one.
+ * Transparent art on a checkerboard reads badly in the Shop (#73), so
+ * publish defaults to White and legacy null rows display as White too.
+ */
+export const DEFAULT_PUBLISH_BACKGROUND = "White";
+
+/**
  * Resolves a published design's backdrop. Art is a transparent PNG layered
- * over either a pinned shirt color (background_color, a name from
- * BACKGROUND_PALETTE) or — when null — the neutral checkerboard.
+ * over a pinned shirt color (background_color, a name from
+ * BACKGROUND_PALETTE). Legacy rows with null background_color display on
+ * White — no transparent/checkerboard backdrop in the Shop (#73).
  */
 export function publishedBackdrop(colorName: string | null | undefined): {
   className: string;
   style?: { backgroundColor: string };
 } {
-  if (!colorName) return { className: "bg-checkerboard" };
   return {
     className: "",
-    style: { backgroundColor: getColorHex(DEFAULT_BLANK_ID, colorName) },
+    style: {
+      backgroundColor: getColorHex(
+        DEFAULT_BLANK_ID,
+        colorName ?? DEFAULT_PUBLISH_BACKGROUND
+      ),
+    },
   };
 }
 


### PR DESCRIPTION
Closes #73.

- Publish modal backdrop picker defaults to White; the transparent/"None" swatch is removed from `BackgroundPicker` (used by both the modal and the owner row on `/d/[imageId]`), so a published image can't be set back to transparent.
- `publishImage` always persists a backdrop: White when none is picked.
- `publishedBackdrop()` resolves null to White instead of checkerboard, so existing published rows with null `background_color` display as White on all Shop surfaces (home feed, `PublishedGrid`, `/d/[imageId]`, `/designs` published cards). Display-default was chosen over a data backfill: no migration, and reversible if the default ever changes.
- `/designs` cards branch explicitly — unpublished designs keep the checkerboard working view.
- `/admin/published` keeps checkerboard intentionally: moderation benefits from seeing the actual transparent asset.
- Tests: `publishedBackdrop` coverage added in `blanks.test.ts` (color → hex, null/undefined → White, default is a real palette color).

Out of scope: `/shop/[slug]/[productId]` shows store-product artwork on checkerboard — different object (organizer product), not a published design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)