### PR TITLE
fix(chat): chips in context, no option repetition, one-question pacing, livelier waiting

### DIFF
--- a/src/app/design/__tests__/chat-panel.test.tsx
+++ b/src/app/design/__tests__/chat-panel.test.tsx
@@ -1,0 +1,93 @@
+import { render, screen, fireEvent, within, act } from "@testing-library/react";
+import { describe, it, expect, vi, beforeAll, afterEach } from "vitest";
+import { ChatPanel, DRAWING_LINES } from "../chat-panel";
+import type { ChatMessage } from "@/lib/db/schema";
+
+beforeAll(() => {
+  // jsdom has no scrollIntoView; the panel auto-scrolls on every turn.
+  window.HTMLElement.prototype.scrollIntoView = vi.fn();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+function msg(role: "user" | "assistant", content: string): ChatMessage {
+  return {
+    id: `m-${role}-${Math.random().toString(36).slice(2, 8)}`,
+    designId: "d1",
+    role,
+    content,
+    imageId: null,
+    createdAt: new Date(),
+  };
+}
+
+const baseProps = {
+  images: [],
+  loading: false,
+  generating: false,
+  onSend: () => {},
+  onGenerate: () => {},
+  readyToGenerate: true,
+  options: [],
+  onUploadImage: () => {},
+  isEmpty: false,
+};
+
+const thread = [msg("user", "Something funny involving a frog"), msg("assistant", "What's the vibe?")];
+
+const options = [
+  { label: "Funny scenario", value: "A frog in a funny scenario" },
+  // Note: a value starting with "go"/"draw"/"make it" would hit the
+  // generate-trigger regex and route to onGenerate — intended behavior.
+  { label: "Pun caption", value: "A pun caption over the frog" },
+];
+
+describe("ChatPanel quick-reply placement", () => {
+  it("renders chips inside the message list, under the latest assistant message (#69)", () => {
+    render(<ChatPanel {...baseProps} messages={thread} options={options} />);
+    // Chips live in the scrolling message flow, not stranded above the composer.
+    const messagesBox = screen.getByTestId("chat-messages");
+    const chips = within(messagesBox).getByTestId("chat-options");
+    expect(
+      within(chips).getByRole("button", { name: "Funny scenario" })
+    ).toBeInTheDocument();
+    // Directly after the last message: nothing between them but the chips row.
+    const lastMessage = within(messagesBox).getByTestId("chat-message-assistant");
+    expect(lastMessage.nextElementSibling).toBe(chips);
+  });
+
+  it("submits the option value as the user's turn on tap", () => {
+    const onSend = vi.fn();
+    render(
+      <ChatPanel {...baseProps} onSend={onSend} messages={thread} options={options} />
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Pun caption" }));
+    expect(onSend).toHaveBeenCalledWith("A pun caption over the frog");
+  });
+
+  it("hides chips while a turn is in flight", () => {
+    render(
+      <ChatPanel {...baseProps} generating messages={thread} options={options} />
+    );
+    expect(screen.queryByTestId("chat-options")).toBeNull();
+  });
+});
+
+describe("ChatPanel drawing status", () => {
+  it("shows a canned line while generating and rotates it every few seconds (#70)", () => {
+    vi.useFakeTimers();
+    render(
+      <ChatPanel {...baseProps} generating messages={[thread[0]]} />
+    );
+    const status = screen.getByTestId("drawing-status");
+    const first = status.textContent;
+    expect(DRAWING_LINES).toContain(first);
+    act(() => {
+      vi.advanceTimersByTime(3000);
+    });
+    expect(status.textContent).not.toBe(first);
+    expect(DRAWING_LINES).toContain(status.textContent);
+  });
+});

--- a/src/app/design/chat-panel.tsx
+++ b/src/app/design/chat-panel.tsx
@@ -8,6 +8,40 @@ import type { DesignImage } from "@/lib/design-images";
 import { Button, QuickReply } from "@/components/ui";
 import { EXAMPLES } from "@/lib/design-examples";
 
+// Rotating status shown while a render is in flight — a canned client-side
+// set (no API call), randomized start so repeat draws don't always open on
+// the same line. A Haiku-generated riff can replace this later.
+export const DRAWING_LINES = [
+  "Drawing your design…",
+  "Mixing the inks…",
+  "Sketching the outlines…",
+  "Warming up the pens…",
+  "Filling in the colors…",
+  "Stepping back to squint at it…",
+  "Adding the finishing touches…",
+];
+
+function DrawingStatus() {
+  const [index, setIndex] = useState(() =>
+    Math.floor(Math.random() * DRAWING_LINES.length)
+  );
+  useEffect(() => {
+    const t = setInterval(
+      () => setIndex((i) => (i + 1) % DRAWING_LINES.length),
+      3000
+    );
+    return () => clearInterval(t);
+  }, []);
+  return (
+    <div
+      className="rounded-lg px-4 py-2 text-text-muted animate-pulse"
+      data-testid="drawing-status"
+    >
+      {DRAWING_LINES[index]}
+    </div>
+  );
+}
+
 export function ChatPanel({
   messages,
   images,
@@ -134,11 +168,11 @@ export function ChatPanel({
   }
 
   const busy = loading || generating;
-  // Soft nudge: until Claude judges the idea concrete (subject + style),
-  // Generate sits as a secondary button and a style hint shows — it pops to
-  // primary when ready. Always clickable; the fast thin-check catches a
-  // too-thin click in ~1s rather than greying the button into looking broken.
-  const notReadyTitle = "Add a style (e.g. watercolor, vintage, bold vector) to sharpen the idea — Draw it still works.";
+  // Soft nudge: until Claude judges the subject concrete, Draw it sits as a
+  // secondary button and a hint shows — it pops to primary when ready. Always
+  // clickable; the fast thin-check catches a too-thin click in ~1s rather
+  // than greying the button into looking broken.
+  const notReadyTitle = "Say a bit more about what to draw — Draw it still works.";
   const showStyleHint = !readyToGenerate && messages.length > 0;
 
   if (isEmpty) {
@@ -215,8 +249,9 @@ export function ChatPanel({
         }}
       />
 
-      {/* Messages */}
-      <div className="flex-1 overflow-y-auto p-4 space-y-4">
+      {/* Messages — laid out naturally from the top; the composer stays
+          pinned at the bottom, but content is never spread to fill the gap. */}
+      <div className="flex-1 overflow-y-auto p-4 space-y-4" data-testid="chat-messages">
         {messages.length === 0 && (
           <div className="text-center text-text-muted mt-20 space-y-4">
             <p className="text-lg">What should your design look like?</p>
@@ -269,6 +304,18 @@ export function ChatPanel({
             </div>
           );
         })}
+        {/* Quick-reply chips for the latest assistant turn — rendered in the
+            message flow, directly under the question they answer (options
+            state only ever holds the latest turn's chips, so older messages
+            never re-show theirs). Tap answers the question, no "type a
+            number" needed. Hidden while a turn is in flight. */}
+        {!busy && options.length > 0 && (
+          <div className="flex justify-start" data-testid="chat-options">
+            <div className="max-w-[80%] px-4">
+              <QuickReply options={options} onSelect={submitTurn} disabled={busy} />
+            </div>
+          </div>
+        )}
         {loading && (
           <div className="flex justify-start">
             <div className="rounded-lg px-4 py-2 text-text-faint">
@@ -278,26 +325,16 @@ export function ChatPanel({
         )}
         {generating && (
           <div className="flex justify-start">
-            <div className="rounded-lg px-4 py-2 text-text-muted animate-pulse">
-              Drawing your design…
-            </div>
+            <DrawingStatus />
           </div>
         )}
         <div ref={messagesEndRef} />
       </div>
 
-      {/* Quick-reply chips for the last assistant turn — tap answers the
-          question, no "type a number" needed. Hidden while a turn is in flight. */}
-      {!busy && options.length > 0 && (
-        <div className="px-4 pt-2">
-          <QuickReply options={options} onSelect={submitTurn} disabled={busy} />
-        </div>
-      )}
-
-      {/* Style hint — only when there are no tappable options to offer instead */}
+      {/* Not-ready hint — only when there are no tappable options to offer instead */}
       {showStyleHint && options.length === 0 && (
         <div className="px-4 pt-2 text-xs text-text-muted">
-          Add a style — watercolor, vintage, bold vector — to sharpen the idea.
+          Say a bit more about what to draw — or just tap Draw it.
         </div>
       )}
 

--- a/src/lib/__tests__/ai.test.ts
+++ b/src/lib/__tests__/ai.test.ts
@@ -273,6 +273,27 @@ describe("chatAboutDesign options", () => {
     expect(result.message).toBe("Nice — a fox it is. What style are you after?");
   });
 
+  it("prompts one-question pacing and forbids enumerating choices in prose (with example)", async () => {
+    const mockCreate = await getMockCreate();
+    mockCreate.mockResolvedValue({
+      content: [{ type: "text", text: JSON.stringify({ message: "ok", readyToGenerate: true }) }],
+    });
+
+    const { chatAboutDesign } = await import("../ai");
+    await chatAboutDesign("a frog", [], []);
+
+    const system = mockCreate.mock.calls[0][0].system as string;
+    // Issue #69: options must never be repeated in the message text — not
+    // even mid-sentence — and the prompt carries a wrong-vs-right example.
+    expect(system).toContain("NEVER enumerate choices in prose");
+    expect(system).toContain("not as a list and not mid-sentence");
+    expect(system).toContain("WRONG:");
+    expect(system).toContain("RIGHT:");
+    // Issue #70: subject alone is ready; at most one clarifying question.
+    expect(system).toContain("Style is a refinement, not a gate");
+    expect(system).toContain("at most ONE clarifying question");
+  });
+
   it("never overrides structured options with the prose fallback", async () => {
     const mockCreate = await getMockCreate();
     mockCreate.mockResolvedValue({
@@ -513,6 +534,23 @@ describe("assessReadiness", () => {
     );
 
     expect(result.ready).toBe(true);
+  });
+
+  it("gates on subject only and forbids naming choices in the question", async () => {
+    const mockCreate = await getMockCreate();
+    mockCreate.mockResolvedValue({
+      content: [{ type: "text", text: JSON.stringify({ ready: true, question: "" }) }],
+    });
+
+    const { assessReadiness } = await import("../ai");
+    await assessReadiness([], [], "a frog");
+
+    const system = mockCreate.mock.calls[0][0].system as string;
+    // Issue #70: a clear subject draws immediately — style never blocks.
+    expect(system).toContain("Style/medium is NOT required");
+    expect(system).toContain("at most one clarifying question");
+    // Issue #69: choices live in options, never in the question prose.
+    expect(system).toContain("NEVER name the choices");
   });
 
   it("uses the fast Haiku model, not Sonnet", async () => {

--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -19,16 +19,20 @@ Output format — respond with raw JSON only (no markdown fences around the JSON
   "options": [ { "label": "Watercolor", "value": "Make it a soft watercolor style" } ]
 }
 
-Readiness rubric for "readyToGenerate":
-- Set true ONLY when the conversation has pinned down BOTH a concrete subject (the WHAT — what's depicted) AND a concrete visual style/medium (the HOW — e.g. clean vector, watercolor, vintage screen-print, hand-drawn ink). A subject with no style is NOT ready — that is the case that produces a clarifying question instead of an image.
-- Otherwise set false, and make "message" the question or nudge that moves toward whichever of subject/style is still missing.
+Readiness + pacing for "readyToGenerate":
+- Set true as soon as there is a concrete SUBJECT (the WHAT — what's depicted). Style is a refinement, not a gate: when the subject is clear but style is open, set true, nudge toward Draw it, and put 3-5 style directions in "options" so picking one stays optional.
+- Set false ONLY when the subject itself is too vague to draw anything (e.g. "something cool", "a design for my team") — then "message" is the ONE question that pins it down.
+- Ask at most ONE clarifying question per new idea. Never ask two in a row: if the user's answer is still loose, go with your best interpretation and nudge toward Draw it instead of asking again.
 
 The "options" field (tappable quick-replies — THIS is how you offer choices):
 - Whenever you ask a multiple-choice question or suggest directions to pick from, put each choice in "options" as { "label": short tappable text, "value": the full message sent as the user's reply if they tap it }.
 - "label" is what the user taps — keep it short (1-3 words, e.g. "Watercolor", "Bold vector", "Vintage badge"). "value" is the natural-language turn submitted on tap (e.g. "Let's go with a vintage screen-print look").
 - Offer 2-5 options. The user can still type freely instead — options are a shortcut, not the only path.
 - Ask ONE question per turn. When several things are still open, pick the single most useful one and ask only that, with its choices as options. Do NOT stack multiple questions.
-- NEVER enumerate choices in prose. No "1. / 2. / 3.", no "a) / b)", no hyphen or bullet lists of choices inside "message" — ever. Choices rendered in prose don't become tappable buttons, which breaks the phone UI. Every choice goes in "options"; "message" carries only the one question (plus a brief lead-in if needed).
+- NEVER enumerate choices in prose — not as a list and not mid-sentence. The chips render each choice once, right under your message; naming them in "message" too shows everything twice. Ask the question WITHOUT naming the choices:
+  WRONG: "message": "Is it a situational joke (frog in a funny scenario), a pun caption, or a weird absurdist image?"
+  RIGHT: "message": "A funny frog — love it. What's the vibe?" with options Funny scenario / Pun caption / Weird absurdist.
+- No "1. / 2. / 3.", no "a) / b)", no hyphen or bullet lists of choices inside "message" — ever. Choices rendered in prose don't become tappable buttons, which breaks the phone UI. Every choice goes in "options"; "message" carries only the one question (plus a brief lead-in if needed).
 - Omit "options" (or use []) when there's nothing to pick — a plain nudge or acknowledgement.
 
 Style rules for the "message" field:
@@ -85,7 +89,7 @@ Style — be faithful to the user's intent:
 - DO NOT default to clean / vector / digital illustration unless the user asks for it.
 - If the user asks for hand-painted, brushy, watercolor, distressed, screen-print, sumi-e, pen-and-ink, charcoal, vintage, handmade, scratchy, woodcut, lithograph, halftone, riso, zine, etc. — write that into the prompt with concrete texture cues, and use the negativePrompt field to push AWAY from "clean vector, smooth gradients, digital font, polished illustration, perfect curves".
 - If the user asks for clean / minimal / vector / flat / modern / corporate — write that.
-- If the user is silent on style, ASK before generating rather than guessing.
+- If the user is silent on style, pick a style that suits the subject and say which you chose in "message" — do not stop to ask. Only a subject too vague to draw anything warrants a question instead of an image.
 - Style vocabulary translation tips:
   - "brushy" / "hand-painted" → "sumi-e brush strokes, uneven ink pressure, ink pooling at stroke ends, raw bristle texture, imperfect edges"
   - "distressed" / "vintage" → "halftone screen-print, deliberate ink gaps, slight registration offset, worn texture, faded mid-tones"
@@ -340,17 +344,16 @@ export async function chatAboutDesign(
   }
 }
 
-const READINESS_SYSTEM_PROMPT = `You judge whether a t-shirt design idea is concrete enough to generate an image. Reply with raw JSON only (no markdown fences):
+const READINESS_SYSTEM_PROMPT = `You judge whether a t-shirt design idea is concrete enough to draw. Reply with raw JSON only (no markdown fences):
 {
   "ready": true | false,
-  "question": "if not ready, ONE short question asking for whichever of subject or style is missing; empty string if ready",
-  "options": [ { "label": "Watercolor", "value": "Make it a soft watercolor style" } ]
+  "question": "if not ready, ONE short question pinning down the subject; empty string if ready",
+  "options": [ { "label": "Funny scenario", "value": "A frog in a funny scenario" } ]
 }
 
-Ready ONLY when BOTH are clear:
-- SUBJECT — what is depicted.
-- STYLE/medium — e.g. clean vector, watercolor, vintage screen-print, hand-drawn ink, bold graphic.
-A clear subject with no style is NOT ready: set ready=false and ask for the style. When asking for a style, fill "options" with 3-5 tappable style choices: { "label": short text (e.g. "Bold vector"), "value": the natural-language reply sent on tap (e.g. "Go with a bold flat vector look") }. NEVER enumerate choices in prose — no numbered ("1.", "2."), lettered, or bulleted lists inside "question"; every choice belongs in "options", where it renders as a tappable button. Omit "options" (or use []) when ready. Keep "question" to 1-2 sentences; in user-facing copy say "draw" / "Draw it", never "generate". When genuinely uncertain, lean ready=true — a real idea should never be blocked.`;
+Ready as soon as the SUBJECT (what is depicted) is concrete. Style/medium is NOT required — when it's unstated, the drawing step picks a fitting style the user can refine afterward. Not ready ONLY when the subject is too vague to draw anything (e.g. "something cool", "a shirt for my team"): then ask ONE question, with 2-5 likely directions in "options" as tappable chips { "label": short text, "value": the natural-language reply sent on tap }.
+NEVER name the choices inside "question" — not as a numbered/bulleted list and not mid-sentence. "Is it a funny scenario, a pun caption, or something absurdist?" is WRONG; "What's the vibe?" with those three in "options" is RIGHT — chips render each choice once, and prose repeats them.
+Ask at most one clarifying question per idea: if the conversation shows one was already asked, lean ready=true rather than asking another. Omit "options" (or use []) when ready. Keep "question" to 1-2 sentences; in user-facing copy say "draw" / "Draw it", never "generate". When genuinely uncertain, lean ready=true — a real idea should never be blocked.`;
 
 /**
  * Fast pre-check used by Generate/Compare to decide "render vs ask" without


### PR DESCRIPTION
Closes #69. Closes #70.

- Chips render in the message flow, directly under the latest assistant message (only the latest turn carries options); tap still submits via the existing submitTurn path. Removing the above-composer chip slot also removes the dead vertical gap.
- CHAT + READINESS prompts forbid enumerating choices in prose (including mid-sentence) with a wrong-vs-right example; the `extractProseOptions` trailing-list fallback stays as the deterministic backstop.
- Pacing: readiness is subject-only — clear subject → readyToGenerate=true with style as optional chips; at most one clarifying question per idea. The GENERATE prompt now picks a fitting style when unstated instead of asking — without this, a subject-only Draw click would pass readiness and then get re-asked by the Sonnet builder anyway.
- Rotating canned status lines while a render is in flight (client-side, randomized start, 3s cycle; Haiku riff can come later).

Tests: prompt-content assertions in `ai.test.ts`; new `chat-panel.test.tsx` covering chip placement in the message list, tap-to-submit, hidden-while-busy, and status rotation. Lint 0 errors, 534 tests pass, build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)