### PR TITLE
fix(preview): taps always register during mockup load; back design from My Designs or Shop

### DIFF
--- a/src/app/cart/actions.ts
+++ b/src/app/cart/actions.ts
@@ -19,6 +19,7 @@ import {
 import { computePrice, computeCartTotal, estimateShipping } from "@/lib/pricing";
 import { multiPlacementEnabled } from "@/lib/blanks";
 import { resolveDesignDisplayImageUrls } from "@/lib/design-images";
+import { assertUsableBackImage } from "@/lib/back-sources";
 import { estimateOrderCosts } from "@/lib/printful";
 import { stripe } from "@/lib/stripe";
 import { buildCartCheckoutSessionParams } from "@/lib/checkout";
@@ -96,6 +97,11 @@ export async function addToCart(params: {
   });
   const frontId = design?.primaryImageId ?? null;
   const backId = multiPlacementEnabled() && params.back ? params.back : null;
+  if (backId) {
+    // Same choke-point guard as createCheckoutSession (#72): only this
+    // thread's images, the user's own designs, or published Shop images.
+    await assertUsableBackImage(backId, params.designId, userId);
+  }
   const placements: Record<string, string> | null = frontId
     ? { front: frontId, ...(backId ? { back: backId } : {}) }
     : null;

--- a/src/app/order/actions.ts
+++ b/src/app/order/actions.ts
@@ -18,6 +18,7 @@ import {
   DEFAULT_BLANK_ID,
 } from "@/lib/blanks";
 import { getDesignDisplayImageUrl } from "@/lib/design-images";
+import { assertUsableBackImage } from "@/lib/back-sources";
 
 export async function calculatePrice(
   designId: string,
@@ -64,6 +65,9 @@ export async function createCheckoutSession(params: {
   // Only honor a back design when the flag is on — keeps a stray `?back=` param
   // from charging the upcharge / pinning a back while the feature is dark.
   const backImageId = multiPlacementEnabled() ? params.back ?? null : null;
+  if (backImageId) {
+    await assertUsableBackImage(backImageId, params.designId, session.user.id);
+  }
   const pricing = await calculatePrice(
     params.designId,
     resolvedProductId,

--- a/src/app/preview/actions.ts
+++ b/src/app/preview/actions.ts
@@ -2,7 +2,7 @@
 
 import { headers } from "next/headers";
 import { after } from "next/server";
-import { auth } from "@/lib/auth";
+import { auth, isAnonymousUser } from "@/lib/auth";
 import { db } from "@/lib/db";
 import { design as designTable } from "@/lib/db/schema";
 import { eq } from "drizzle-orm";
@@ -21,9 +21,14 @@ import { generateAnchoredTransparent } from "@/lib/replicate";
 import {
   insertDesignImage,
   findPlacementRender,
-  getDesignImageById,
+  getDesignImageWithOwner,
   getDesignDisplayImageUrl,
 } from "@/lib/design-images";
+import { canUseAsPlacementSource } from "@/lib/design-publish";
+import {
+  getBackSourceGroups,
+  type BackSourceGroup,
+} from "@/lib/back-sources";
 
 const COST_PER_GENERATION = 0.03;
 
@@ -34,6 +39,33 @@ const COST_PER_GENERATION = 0.03;
  */
 export async function isMultiPlacementEnabled(): Promise<boolean> {
   return multiPlacementEnabled();
+}
+
+/**
+ * Source groups for the /preview back-design picker (#72): the current
+ * thread's images, the user's other designs' display images, and published
+ * Shop images. Anonymous guests get This design + Shop only — their other
+ * designs join My Designs once they claim the account.
+ */
+export async function getBackDesignSources(
+  designId: string
+): Promise<{ groups: BackSourceGroup[] }> {
+  const session = await auth.api.getSession({ headers: await headers() });
+  if (!session) throw new Error("Unauthorized");
+
+  const found = await db.query.design.findFirst({
+    where: eq(designTable.id, designId),
+    columns: { id: true, userId: true },
+  });
+  if (!found || found.userId !== session.user.id) {
+    throw new Error("Unauthorized");
+  }
+
+  const groups = await getBackSourceGroups({
+    designId,
+    userId: isAnonymousUser(session.user) ? null : session.user.id,
+  });
+  return { groups };
 }
 
 export async function generateMockup(
@@ -90,11 +122,25 @@ export async function generateMockup(
     placement.id,
     sourceImageId
   );
-  const sourceImageUrl =
-    placementRender?.imageUrl ??
-    (sourceImageId
-      ? (await getDesignImageById(sourceImageId))?.imageUrl
-      : await getDesignDisplayImageUrl(designId));
+  let sourceImageUrl = placementRender?.imageUrl ?? null;
+  if (!sourceImageUrl && sourceImageId) {
+    // Explicit source pick — may live on another design (#72). Same guard as
+    // getOrCreatePlacementRender so an arbitrary id can't be mocked up.
+    const source = await getDesignImageWithOwner(sourceImageId);
+    if (
+      source &&
+      canUseAsPlacementSource({
+        image: source,
+        imageOwnerId: source.ownerId,
+        orderDesignId: designId,
+        userId: session.user.id,
+      })
+    ) {
+      sourceImageUrl = source.imageUrl;
+    }
+  } else if (!sourceImageUrl) {
+    sourceImageUrl = await getDesignDisplayImageUrl(designId);
+  }
   if (!sourceImageUrl) throw new Error("No design image");
 
   // Compute scaled position (centered within print area)
@@ -185,10 +231,19 @@ export async function getOrCreatePlacementRender(
     throw new Error("No source image — design has no source pick yet");
   }
 
-  const primary = await getDesignImageById(anchorId);
+  const primary = await getDesignImageWithOwner(anchorId);
   if (!primary) throw new Error("Source image row missing");
-  if (primary.designId !== designId) {
-    throw new Error("Source image does not belong to this design");
+  // Cross-design sources are allowed for the origins the back picker offers
+  // (own designs, published Shop images) — anything else is rejected (#72).
+  if (
+    !canUseAsPlacementSource({
+      image: primary,
+      imageOwnerId: primary.ownerId,
+      orderDesignId: designId,
+      userId: session.user.id,
+    })
+  ) {
+    throw new Error("Source image is not available for this design");
   }
 
   const product = getBlankOrThrow(productId);

--- a/src/app/preview/page.tsx
+++ b/src/app/preview/page.tsx
@@ -2,12 +2,13 @@
 
 import { Suspense, useEffect, useRef, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
-import { getDesign, approveDesign, getDesignGallery } from "../design/actions";
+import { getDesign, approveDesign } from "../design/actions";
 import {
   generateMockup,
   getOrCreatePlacementRender,
   ensureMockupsPrefetched,
   isMultiPlacementEnabled,
+  getBackDesignSources,
 } from "./actions";
 import Link from "next/link";
 import { Button } from "@/components/ui";
@@ -19,7 +20,8 @@ import {
   type AspectRatio,
 } from "@/lib/blanks";
 import { BACK_PLACEMENT_UPCHARGE } from "@/lib/pricing";
-import type { SourceImage } from "@/lib/design-images";
+import type { BackSourceGroup } from "@/lib/back-sources";
+import { createLatestWins } from "@/lib/latest-wins";
 import { ProductSilhouette } from "./product-silhouette";
 import { Breadcrumbs } from "@/components/breadcrumbs";
 import { breadcrumbTrail } from "@/lib/nav";
@@ -89,16 +91,17 @@ function PreviewPageInner() {
   const [multiPlacement, setMultiPlacement] = useState(false);
   const [activePlacement, setActivePlacement] = useState<Placement>("front");
   const [backImageId, setBackImageId] = useState<string | null>(null);
-  const [backSources, setBackSources] = useState<SourceImage[] | null>(null);
+  const [backGroups, setBackGroups] = useState<BackSourceGroup[] | null>(null);
   const [backPickerOpen, setBackPickerOpen] = useState(false);
 
   // Client-side cache: "productId:placement:colorName:scale" -> mockup R2 URL
   const mockupCache = useRef<Map<string, string>>(new Map());
-  // Track the latest requested selection so a stale Printful response
-  // (color clicked, then changed) can't overwrite the current one.
-  const latestColorRef = useRef(colorName);
-  const latestProductRef = useRef(productId);
-  const latestPlacementRef = useRef<Placement>(activePlacement);
+  // Latest-wins token (#71): every selection tap supersedes all in-flight
+  // mockup fetches, so a stale Printful response — whatever field it was for
+  // (color, product, placement, back pick, scale) — can never overwrite the
+  // newer selection's state. Replaces per-field ref comparisons, which missed
+  // A→B→A sequences.
+  const mockupReq = useRef(createLatestWins()).current;
 
   const colors = product?.colors ?? [];
   const regenerating = renderState.status === "loading";
@@ -218,6 +221,10 @@ function PreviewPageInner() {
   // effect). Caches per productId:placement:color:scale.
   async function renderMockupFor(placement: Placement) {
     if (!designId) return;
+    // Latest-wins (#71): this fetch supersedes any earlier in-flight one, and
+    // only applies its own result if nothing newer has started (or a selection
+    // tap invalidated it) by the time it lands.
+    const token = mockupReq.begin();
 
     // Non-front placements render from the picked source; thread it through so
     // the mockup matches the pick and the cache key doesn't collide (#25).
@@ -231,6 +238,7 @@ function PreviewPageInner() {
 
     const cached = mockupCache.current.get(cacheKey);
     if (cached) {
+      // Synchronous, so this call is still the latest by construction.
       setMockups((m) => ({ ...m, [placement]: cached }));
       setMockupError(false);
       return;
@@ -239,10 +247,6 @@ function PreviewPageInner() {
     setMockupLoading(true);
     setMockupError(false);
     setMockups((m) => ({ ...m, [placement]: null }));
-    const stillCurrent = () =>
-      latestColorRef.current === colorName &&
-      latestProductRef.current === productId &&
-      latestPlacementRef.current === placement;
     try {
       const result = await generateMockup(
         designId,
@@ -252,30 +256,48 @@ function PreviewPageInner() {
         placement,
         sourceImageId
       );
-      if (stillCurrent()) {
+      if (mockupReq.isCurrent(token)) {
         mockupCache.current.set(cacheKey, result.mockupUrl);
         setMockups((m) => ({ ...m, [placement]: result.mockupUrl }));
       }
     } catch (err) {
       console.error("Mockup generation failed:", err);
-      if (stillCurrent()) setMockupError(true);
+      if (mockupReq.isCurrent(token)) setMockupError(true);
     } finally {
-      if (stillCurrent()) setMockupLoading(false);
+      if (mockupReq.isCurrent(token)) setMockupLoading(false);
     }
   }
 
   // Auto-trigger the real Printful mockup whenever the active placement's
   // render settles (initial load, color/product change, placement switch).
+  // Self-healing (#71): the full state deps mean any settle into "render
+  // ready, no mockup, not loading, no error" re-fires the fetch — a
+  // superseded stale resolution can't leave the page stuck mockup-less.
+  // mockupError blocks the auto-fire so a persistent failure doesn't loop;
+  // retry is the explicit button.
   useEffect(() => {
     if (!designImageUrl) return;
-    if (regenerating || mockupLoading || mockups[activePlacement]) return;
+    if (regenerating || mockupLoading || mockupError || mockups[activePlacement])
+      return;
     void renderMockupFor(activePlacement);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [designImageUrl, productId, colorName, activePlacement, regenerating]);
+  }, [
+    designImageUrl,
+    productId,
+    colorName,
+    activePlacement,
+    regenerating,
+    mockupLoading,
+    mockupError,
+    mockups,
+  ]);
 
   function handleColorChange(name: string) {
+    if (name === colorName) return;
+    // Supersede any in-flight mockup fetch the moment the tap lands (#71) —
+    // its stale result must not overwrite this newer selection.
+    mockupReq.invalidate();
     setColorName(name);
-    latestColorRef.current = name;
     // A new color invalidates both placements' mockups.
     setMockups({ front: null, back: null });
     setMockupError(false);
@@ -287,14 +309,12 @@ function PreviewPageInner() {
     const newProduct = getBlank(newProductId);
     if (!newProduct) return;
     const newColor = newProduct.colors[0]?.name ?? "White";
+    mockupReq.invalidate();
     setProductId(newProductId);
-    latestProductRef.current = newProductId;
     setColorName(newColor);
-    latestColorRef.current = newColor;
     // Reset to front: the new product may not support back, and back
     // renders are product-specific. Keep backImageId (a thread source id).
     setActivePlacement("front");
-    latestPlacementRef.current = "front";
     setBackPickerOpen(false);
     setMockups({ front: null, back: null });
     setMockupError(false);
@@ -308,8 +328,10 @@ function PreviewPageInner() {
 
   function switchPlacement(placement: Placement) {
     if (placement === activePlacement) return;
+    // A placement tap always registers, even mid-fetch (#71) — the stale
+    // fetch is superseded, never awaited.
+    mockupReq.invalidate();
     setActivePlacement(placement);
-    latestPlacementRef.current = placement;
     setMockupError(false);
     setMockupLoading(false);
     if (placement === "back" && !backImageId) {
@@ -320,19 +342,23 @@ function PreviewPageInner() {
 
   async function openBackPicker() {
     setBackPickerOpen(true);
-    if (backSources || !designId) return;
+    if (backGroups || !designId) return;
     try {
-      const { sources } = await getDesignGallery(designId);
-      setBackSources(sources);
+      const { groups } = await getBackDesignSources(designId);
+      setBackGroups(groups);
     } catch (err) {
-      console.error("getDesignGallery failed:", err);
-      setBackSources([]);
+      console.error("getBackDesignSources failed:", err);
+      setBackGroups([]);
     }
   }
 
   function chooseBackSource(id: string) {
-    setBackImageId(id);
     setBackPickerOpen(false);
+    // Re-picking the current source is a no-op — clearing state for it
+    // would strand the hero with no mockup and nothing to re-fire.
+    if (id === backImageId) return;
+    mockupReq.invalidate();
+    setBackImageId(id);
     // New back source invalidates the back mockup only. Its instant-layer
     // artwork too — the previous pick's artwork would be misleading.
     setMockups((m) => ({ ...m, back: null }));
@@ -455,8 +481,7 @@ function PreviewPageInner() {
               <button
                 key={pl}
                 onClick={() => switchPlacement(pl)}
-                disabled={regenerating || mockupLoading}
-                className={`px-4 py-2 text-sm font-medium capitalize transition-colors disabled:opacity-50 disabled:cursor-not-allowed ${
+                className={`px-4 py-2 text-sm font-medium capitalize transition-colors ${
                   activePlacement === pl
                     ? "bg-accent text-accent-fg"
                     : "text-text-muted hover:text-foreground"
@@ -476,32 +501,43 @@ function PreviewPageInner() {
 
       {/* Hero: back-source picker (Back, no source) or the mockup/preview */}
       {showBackPicker ? (
-        <div className="w-64 md:w-80 flex flex-col items-center gap-3">
+        <div className="w-64 md:w-80 flex flex-col items-center gap-3 max-h-[60vh] overflow-y-auto">
           <p className="text-sm text-text-muted text-center">
-            Pick an image from this design to print on the back.
+            Pick an image to print on the back.
           </p>
-          {backSources === null ? (
+          {backGroups === null ? (
             <div className="w-12 h-12 border-2 border-accent border-t-transparent rounded-full animate-spin" />
-          ) : backSources.length === 0 ? (
+          ) : backGroups.length === 0 ? (
             <p className="text-sm text-text-faint text-center">
               No images yet. <Link href={`/design?id=${designId}`} className="underline">Add one in the designer.</Link>
             </p>
           ) : (
-            <div className="grid grid-cols-3 gap-2 w-full">
-              {backSources.map((s) => (
-                <button
-                  key={s.id}
-                  onClick={() => chooseBackSource(s.id)}
-                  className="aspect-square rounded-md overflow-hidden border-2 border-border hover:border-accent bg-checkerboard"
-                >
-                  <img
-                    src={s.imageUrl}
-                    alt="Design option"
-                    className="w-full h-full object-contain"
-                  />
-                </button>
-              ))}
-            </div>
+            backGroups.map((group) => (
+              <div key={group.id} className="w-full">
+                <h3 className="text-xs font-medium uppercase tracking-wide text-text-muted mb-1.5">
+                  {group.label}
+                </h3>
+                <div className="grid grid-cols-3 gap-2 w-full">
+                  {group.images.map((s) => (
+                    <button
+                      key={s.id}
+                      onClick={() => chooseBackSource(s.id)}
+                      className={`aspect-square min-h-11 rounded-md overflow-hidden border-2 bg-checkerboard ${
+                        s.id === backImageId
+                          ? "border-accent"
+                          : "border-border hover:border-accent"
+                      }`}
+                    >
+                      <img
+                        src={s.imageUrl}
+                        alt={`${group.label} option`}
+                        className="w-full h-full object-contain"
+                      />
+                    </button>
+                  ))}
+                </div>
+              </div>
+            ))
           )}
         </div>
       ) : (

--- a/src/lib/__tests__/back-sources.integration.test.ts
+++ b/src/lib/__tests__/back-sources.integration.test.ts
@@ -1,0 +1,206 @@
+/**
+ * Back-design source groups + choke-point guard (#72), against a real
+ * in-memory libSQL (the #28 pattern). Proves the picker's reach and the
+ * checkout guard agree: everything the groups return passes
+ * assertUsableBackImage; a stranger's unpublished or hidden image does not.
+ */
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { eq } from "drizzle-orm";
+import { createTestDb } from "./test-db";
+import * as schema from "@/lib/db/schema";
+import { makeUser } from "./factories";
+
+type Db = Awaited<ReturnType<typeof createTestDb>>;
+let testDb: Db;
+
+// vi.mock is hoisted; the getter defers db access until call time, by when
+// beforeEach has assigned the per-test database.
+vi.mock("@/lib/db", () => ({
+  get db() {
+    return testDb;
+  },
+}));
+
+const { getBackSourceGroups, assertUsableBackImage } = await import(
+  "@/lib/back-sources"
+);
+const { getDesignImageById } = await import("@/lib/design-images");
+
+async function makeDesignWithImage(
+  db: Db,
+  userId: string,
+  opts: { published?: boolean; hidden?: boolean } = {}
+): Promise<{ designId: string; imageId: string }> {
+  const [design] = await db
+    .insert(schema.design)
+    .values({ userId })
+    .returning();
+  const [image] = await db
+    .insert(schema.designImage)
+    .values({
+      designId: design.id,
+      aspectRatio: "1:1",
+      imageUrl: `https://img.example/${design.id}.png`,
+      publishedAt: opts.published ? new Date() : null,
+      isHidden: opts.hidden ?? false,
+    })
+    .returning();
+  return { designId: design.id, imageId: image.id };
+}
+
+describe("getBackSourceGroups / assertUsableBackImage (#72)", () => {
+  beforeEach(async () => {
+    testDb = await createTestDb();
+  });
+
+  async function seed() {
+    await makeUser(testDb, "nico");
+    await makeUser(testDb, "stranger");
+
+    // Current thread: two source images, one of them published.
+    const [d1] = await testDb
+      .insert(schema.design)
+      .values({ userId: "nico" })
+      .returning();
+    const [s1] = await testDb
+      .insert(schema.designImage)
+      .values({
+        designId: d1.id,
+        aspectRatio: "1:1",
+        imageUrl: "https://img.example/s1.png",
+      })
+      .returning();
+    const [s2] = await testDb
+      .insert(schema.designImage)
+      .values({
+        designId: d1.id,
+        aspectRatio: "1:1",
+        imageUrl: "https://img.example/s2.png",
+        publishedAt: new Date(),
+      })
+      .returning();
+
+    // Another design of nico's, with a primary → My Designs.
+    const [d2] = await testDb
+      .insert(schema.design)
+      .values({ userId: "nico" })
+      .returning();
+    const [p2] = await testDb
+      .insert(schema.designImage)
+      .values({
+        designId: d2.id,
+        aspectRatio: "1:1",
+        imageUrl: "https://img.example/p2.png",
+      })
+      .returning();
+    await testDb
+      .update(schema.design)
+      .set({ primaryImageId: p2.id })
+      .where(eq(schema.design.id, d2.id));
+
+    // Nico design with no primary → excluded from My Designs.
+    await testDb.insert(schema.design).values({ userId: "nico" });
+
+    // Stranger: one published (Shop), one hidden, one unpublished.
+    const pub = await makeDesignWithImage(testDb, "stranger", {
+      published: true,
+    });
+    const hidden = await makeDesignWithImage(testDb, "stranger", {
+      published: true,
+      hidden: true,
+    });
+    const priv = await makeDesignWithImage(testDb, "stranger", {});
+
+    return { d1: d1.id, s1: s1.id, s2: s2.id, d2: d2.id, p2: p2.id, pub, hidden, priv };
+  }
+
+  it("returns the three groups, scoped and filtered", async () => {
+    const ids = await seed();
+    const groups = await getBackSourceGroups({
+      designId: ids.d1,
+      userId: "nico",
+    });
+
+    const byId = new Map(groups.map((g) => [g.id, g]));
+
+    // This design: both thread sources, including the published one.
+    expect(byId.get("this-design")?.images.map((i) => i.id).sort()).toEqual(
+      [ids.s1, ids.s2].sort()
+    );
+
+    // My Designs: the other design's primary; not the current thread's, not
+    // the primary-less design.
+    expect(byId.get("my-designs")?.images.map((i) => i.id)).toEqual([ids.p2]);
+
+    // Shop: the stranger's published image only — no hidden, no unpublished,
+    // and not the current thread's published image (already in This design).
+    expect(byId.get("shop")?.images.map((i) => i.id)).toEqual([
+      ids.pub.imageId,
+    ]);
+  });
+
+  it("anonymous users get no My Designs group", async () => {
+    const ids = await seed();
+    const groups = await getBackSourceGroups({
+      designId: ids.d1,
+      userId: null,
+    });
+    expect(groups.map((g) => g.id)).not.toContain("my-designs");
+    expect(groups.map((g) => g.id)).toContain("this-design");
+    expect(groups.map((g) => g.id)).toContain("shop");
+  });
+
+  it("everything the groups return passes the checkout guard", async () => {
+    const ids = await seed();
+    const groups = await getBackSourceGroups({
+      designId: ids.d1,
+      userId: "nico",
+    });
+    for (const g of groups) {
+      for (const img of g.images) {
+        await expect(
+          assertUsableBackImage(img.id, ids.d1, "nico")
+        ).resolves.toBeUndefined();
+      }
+    }
+  });
+
+  it("rejects a stranger's unpublished image at the choke point", async () => {
+    const ids = await seed();
+    await expect(
+      assertUsableBackImage(ids.priv.imageId, ids.d1, "nico")
+    ).rejects.toThrow("Back image is not available");
+  });
+
+  it("rejects a hidden image at the choke point", async () => {
+    const ids = await seed();
+    await expect(
+      assertUsableBackImage(ids.hidden.imageId, ids.d1, "nico")
+    ).rejects.toThrow("Back image is not available");
+  });
+
+  it("rejects an unknown image id", async () => {
+    const ids = await seed();
+    await expect(
+      assertUsableBackImage("no-such-image", ids.d1, "nico")
+    ).rejects.toThrow("Back image is not available");
+  });
+
+  it("allows the stranger's published image cross-user (Shop path)", async () => {
+    const ids = await seed();
+    await expect(
+      assertUsableBackImage(ids.pub.imageId, ids.d1, "nico")
+    ).resolves.toBeUndefined();
+  });
+
+  it("the webhook's id resolver finds a cross-design back image", async () => {
+    // Fulfillment resolves placements.back purely by design_image id
+    // (getDesignImageById via resolveImageUrlById) with no design scoping, so
+    // an order on design d1 whose back pins another design's image still
+    // resolves to the right URL for the Printful submission.
+    const ids = await seed();
+    const row = await getDesignImageById(ids.pub.imageId);
+    expect(row?.imageUrl).toBe(`https://img.example/${ids.pub.designId}.png`);
+    expect(row?.designId).not.toBe(ids.d1);
+  });
+});

--- a/src/lib/__tests__/design-publish.test.ts
+++ b/src/lib/__tests__/design-publish.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   imageReferencedByOrders,
   canBuyPublishedImage,
+  canUseAsPlacementSource,
   buildForkChain,
   dedupeFeedByDesign,
   type ForkChainRow,
@@ -232,5 +233,51 @@ describe("dedupeFeedByDesign", () => {
     ]);
     expect(out).toHaveLength(1);
     expect(out[0].title).toBe("Keep me");
+  });
+});
+
+describe("canUseAsPlacementSource (#72)", () => {
+  const base = { designId: "d-other", publishedAt: null, isHidden: false };
+  const ctx = { imageOwnerId: "owner", orderDesignId: "d-order", userId: "buyer" };
+
+  it("allows an image from the order's own design, even unpublished", () => {
+    expect(
+      canUseAsPlacementSource({
+        image: { ...base, designId: "d-order" },
+        ...ctx,
+      })
+    ).toBe(true);
+  });
+
+  it("allows an image whose design the user owns (My Designs)", () => {
+    expect(
+      canUseAsPlacementSource({
+        image: base,
+        ...ctx,
+        imageOwnerId: "buyer",
+      })
+    ).toBe(true);
+  });
+
+  it("allows a published, not-hidden image from anyone (Shop)", () => {
+    expect(
+      canUseAsPlacementSource({
+        image: { ...base, publishedAt: new Date() },
+        ...ctx,
+      })
+    ).toBe(true);
+  });
+
+  it("rejects a stranger's unpublished image", () => {
+    expect(canUseAsPlacementSource({ image: base, ...ctx })).toBe(false);
+  });
+
+  it("rejects a published-but-hidden image (moderation wins)", () => {
+    expect(
+      canUseAsPlacementSource({
+        image: { ...base, publishedAt: new Date(), isHidden: true },
+        ...ctx,
+      })
+    ).toBe(false);
   });
 });

--- a/src/lib/__tests__/latest-wins.test.ts
+++ b/src/lib/__tests__/latest-wins.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from "vitest";
+import { createLatestWins } from "../latest-wins";
+
+describe("createLatestWins", () => {
+  it("a fresh request is current", () => {
+    const g = createLatestWins();
+    const t = g.begin();
+    expect(g.isCurrent(t)).toBe(true);
+  });
+
+  it("a later begin supersedes an in-flight request", () => {
+    const g = createLatestWins();
+    const stale = g.begin();
+    const fresh = g.begin();
+    expect(g.isCurrent(stale)).toBe(false);
+    expect(g.isCurrent(fresh)).toBe(true);
+  });
+
+  it("invalidate supersedes without starting a request", () => {
+    const g = createLatestWins();
+    const t = g.begin();
+    g.invalidate();
+    expect(g.isCurrent(t)).toBe(false);
+  });
+
+  it("A→B→A: the original A request stays stale after re-selecting A", () => {
+    // The field-comparison approach this replaces passed here: the stale
+    // request's fields matched the re-selected ones, so it applied early.
+    const g = createLatestWins();
+    const requestA1 = g.begin(); // fetch for color A
+    g.invalidate(); // tap color B
+    const requestB = g.begin(); // fetch for color B
+    g.invalidate(); // tap color A again
+    const requestA2 = g.begin(); // new fetch for color A
+    expect(g.isCurrent(requestA1)).toBe(false);
+    expect(g.isCurrent(requestB)).toBe(false);
+    expect(g.isCurrent(requestA2)).toBe(true);
+  });
+
+  it("independent guards don't interfere", () => {
+    const a = createLatestWins();
+    const b = createLatestWins();
+    const ta = a.begin();
+    b.begin();
+    b.invalidate();
+    expect(a.isCurrent(ta)).toBe(true);
+  });
+});

--- a/src/lib/back-sources.ts
+++ b/src/lib/back-sources.ts
@@ -1,0 +1,177 @@
+/**
+ * Back-design source groups for the /preview picker (#72).
+ *
+ * The back of a shirt can print any of three image origins:
+ *  - This design: the current thread's source images (the original picker).
+ *  - My Designs: the display (primary) image of the user's other designs.
+ *  - Shop: published, not-hidden images — the discover-feed surface.
+ *
+ * Mirror of `canUseAsPlacementSource` (design-publish.ts): everything this
+ * returns passes that guard, and the guard rejects anything outside these
+ * groups at the checkout choke points.
+ */
+import { db } from "@/lib/db";
+import {
+  design as designTable,
+  designImage as designImageTable,
+} from "@/lib/db/schema";
+import { eq, and, ne, desc, inArray, isNotNull } from "drizzle-orm";
+import {
+  getDesignSourceImages,
+  getDesignImageWithOwner,
+} from "@/lib/design-images";
+import {
+  dedupeFeedByDesign,
+  canUseAsPlacementSource,
+} from "@/lib/design-publish";
+
+/**
+ * Validate a back-placement image id before it can reach an order (#72).
+ * Allowed origins mirror the picker groups below: the order's own design
+ * thread, a design the buyer owns, or a published + not-hidden Shop image.
+ * Throws on anything else — called at the checkout choke points
+ * (createCheckoutSession, addToCart) so a forged id can't get a private
+ * image printed.
+ */
+export async function assertUsableBackImage(
+  backImageId: string,
+  designId: string,
+  userId: string
+): Promise<void> {
+  const image = await getDesignImageWithOwner(backImageId);
+  if (
+    !image ||
+    !canUseAsPlacementSource({
+      image,
+      imageOwnerId: image.ownerId,
+      orderDesignId: designId,
+      userId,
+    })
+  ) {
+    throw new Error("Back image is not available");
+  }
+}
+
+export type BackSourceImage = {
+  id: string;
+  imageUrl: string;
+};
+
+export type BackSourceGroup = {
+  id: "this-design" | "my-designs" | "shop";
+  label: string;
+  images: BackSourceImage[];
+};
+
+const GROUP_LIMIT = 24;
+
+/**
+ * Assemble the picker's groups. `userId` is the design owner's id for the
+ * My Designs group — pass null for anonymous guests, who get only
+ * This design + Shop. Empty groups are omitted.
+ */
+export async function getBackSourceGroups(params: {
+  designId: string;
+  userId: string | null;
+}): Promise<BackSourceGroup[]> {
+  const [thisDesign, myDesigns, shop] = await Promise.all([
+    getDesignSourceImages(params.designId),
+    params.userId
+      ? getOtherDesignPrimaries(params.userId, params.designId)
+      : Promise.resolve([]),
+    getShopImages(params.designId),
+  ]);
+
+  const groups: BackSourceGroup[] = [];
+  if (thisDesign.length > 0) {
+    groups.push({
+      id: "this-design",
+      label: "This design",
+      images: thisDesign.map((s) => ({ id: s.id, imageUrl: s.imageUrl })),
+    });
+  }
+  if (myDesigns.length > 0) {
+    groups.push({ id: "my-designs", label: "My designs", images: myDesigns });
+  }
+  if (shop.length > 0) {
+    groups.push({ id: "shop", label: "Shop", images: shop });
+  }
+  return groups;
+}
+
+/**
+ * Display images of the user's other designs: each design's primary image,
+ * most recently touched design first. Designs without a primary (never
+ * produced a source image) are skipped.
+ */
+async function getOtherDesignPrimaries(
+  userId: string,
+  excludeDesignId: string
+): Promise<BackSourceImage[]> {
+  const designs = await db
+    .select({
+      id: designTable.id,
+      primaryImageId: designTable.primaryImageId,
+    })
+    .from(designTable)
+    .where(
+      and(
+        eq(designTable.userId, userId),
+        ne(designTable.id, excludeDesignId),
+        isNotNull(designTable.primaryImageId)
+      )
+    )
+    .orderBy(desc(designTable.updatedAt))
+    .limit(GROUP_LIMIT);
+
+  const primaryIds = designs
+    .map((d) => d.primaryImageId)
+    .filter((v): v is string => Boolean(v));
+  if (primaryIds.length === 0) return [];
+
+  const imageRows = await db
+    .select({ id: designImageTable.id, imageUrl: designImageTable.imageUrl })
+    .from(designImageTable)
+    .where(inArray(designImageTable.id, primaryIds));
+  const byId = new Map(imageRows.map((r) => [r.id, r.imageUrl]));
+
+  // Preserve the designs' recency order; drop dangling primary pointers.
+  const out: BackSourceImage[] = [];
+  for (const d of designs) {
+    const url = d.primaryImageId ? byId.get(d.primaryImageId) : undefined;
+    if (d.primaryImageId && url) out.push({ id: d.primaryImageId, imageUrl: url });
+  }
+  return out;
+}
+
+/**
+ * Published, not-hidden images — the getDiscoverFeed surface, collapsed to
+ * one card per design (dedupeFeedByDesign), newest published first. The
+ * current design's own published images are excluded: they already appear
+ * under This design.
+ */
+async function getShopImages(
+  excludeDesignId: string
+): Promise<BackSourceImage[]> {
+  const rows = await db
+    .select({
+      id: designImageTable.id,
+      designId: designImageTable.designId,
+      imageUrl: designImageTable.imageUrl,
+      publishedAt: designImageTable.publishedAt,
+    })
+    .from(designImageTable)
+    .where(
+      and(
+        isNotNull(designImageTable.publishedAt),
+        eq(designImageTable.isHidden, false),
+        ne(designImageTable.designId, excludeDesignId)
+      )
+    )
+    .orderBy(desc(designImageTable.publishedAt))
+    .limit(GROUP_LIMIT * 4);
+
+  return dedupeFeedByDesign(rows.map((r) => ({ ...r, publishedAt: r.publishedAt! })))
+    .slice(0, GROUP_LIMIT)
+    .map((r) => ({ id: r.id, imageUrl: r.imageUrl }));
+}

--- a/src/lib/design-images.ts
+++ b/src/lib/design-images.ts
@@ -223,6 +223,43 @@ export async function getDesignImageById(
 }
 
 /**
+ * Fetch a design_image plus the fields the placement-source guard needs:
+ * publish/moderation state and the owning design's user id (#72). One
+ * joined query so checkout/preview call sites can gate a cross-design
+ * back pick without a second round trip.
+ */
+export async function getDesignImageWithOwner(
+  id: string
+): Promise<{
+  id: string;
+  designId: string;
+  imageUrl: string;
+  aspectRatio: AspectRatio;
+  prompt: string | null;
+  publishedAt: Date | null;
+  isHidden: boolean;
+  ownerId: string;
+} | null> {
+  const rows = await db
+    .select({
+      id: designImageTable.id,
+      designId: designImageTable.designId,
+      imageUrl: designImageTable.imageUrl,
+      aspectRatio: designImageTable.aspectRatio,
+      prompt: designImageTable.prompt,
+      publishedAt: designImageTable.publishedAt,
+      isHidden: designImageTable.isHidden,
+      ownerId: designTable.userId,
+    })
+    .from(designImageTable)
+    .innerJoin(designTable, eq(designTable.id, designImageTable.designId))
+    .where(eq(designImageTable.id, id))
+    .limit(1);
+  if (!rows[0]) return null;
+  return { ...rows[0], aspectRatio: rows[0].aspectRatio as AspectRatio };
+}
+
+/**
  * Find the design_image row whose imageUrl matches a target URL, scoped
  * to a design. Used at order-creation time to pin the order to the
  * specific image that was on screen when the customer clicked checkout.

--- a/src/lib/design-publish.ts
+++ b/src/lib/design-publish.ts
@@ -65,6 +65,38 @@ export function canBuyPublishedImage(image: {
 }
 
 /**
+ * Decide whether an image may be used as a placement source (the back of a
+ * shirt) on an order for `orderDesignId` (#72). Three allowed origins,
+ * matching the /preview picker's groups:
+ *
+ *  - This design: the image belongs to the order's own design thread.
+ *  - My Designs: the requesting user owns the image's design.
+ *  - Shop: the image is published and not admin-hidden (the buy-existing
+ *    surface — same visibility rule as canBuyPublishedImage).
+ *
+ * Checked at the checkout choke points (createCheckoutSession / addToCart)
+ * so a forged image id can't get a private image printed, and at the
+ * preview render/mockup actions so the picker's reach and the guard agree.
+ */
+export function canUseAsPlacementSource(params: {
+  image: {
+    designId: string;
+    publishedAt: Date | null;
+    isHidden: boolean;
+  };
+  /** Owner of the image's design. */
+  imageOwnerId: string;
+  /** The design the order/preview is for. */
+  orderDesignId: string;
+  /** The requesting user. */
+  userId: string;
+}): boolean {
+  if (params.image.designId === params.orderDesignId) return true;
+  if (params.imageOwnerId === params.userId) return true;
+  return params.image.publishedAt !== null && !params.image.isHidden;
+}
+
+/**
  * Collapse a published-image feed to one entry per design. Publishing
  * happens per design_image, so a maker who publishes several generations
  * within one design would otherwise flood the storefront with

--- a/src/lib/latest-wins.ts
+++ b/src/lib/latest-wins.ts
@@ -1,0 +1,35 @@
+/**
+ * Latest-wins guard for async UI flows (#71).
+ *
+ * /preview fires async resolutions (placement render, Printful mockup) for
+ * whatever product/color/placement is selected. A tap mid-flight must always
+ * register: the new selection supersedes the old one, and the stale
+ * resolution — whenever it lands — must not write its result over the newer
+ * selection's state.
+ *
+ * Monotonic token: `begin()` marks a new request as the latest; `invalidate()`
+ * supersedes everything in flight without starting one (a selection tap);
+ * `isCurrent(token)` is the apply-gate a resolution checks before touching
+ * state. Field-comparison guards (the old three-ref approach) miss
+ * A→B→A sequences — the stale A resolution compares equal to the re-selected
+ * A and applies early; a token can't be re-equal.
+ */
+export type LatestWins = {
+  /** Start a new request. Returns its token; all earlier tokens go stale. */
+  begin: () => number;
+  /** Supersede all in-flight requests without starting a new one. */
+  invalidate: () => void;
+  /** Whether `token` still identifies the latest request. */
+  isCurrent: (token: number) => boolean;
+};
+
+export function createLatestWins(): LatestWins {
+  let current = 0;
+  return {
+    begin: () => ++current,
+    invalidate: () => {
+      current++;
+    },
+    isCurrent: (token: number) => token === current,
+  };
+}


### PR DESCRIPTION
## #71 — selection taps register immediately

- New `src/lib/latest-wins.ts` request-token guard (unit-tested), replacing the three per-field refs in the mockup fetch. Every tap — color, product, placement, back pick — calls `invalidate()`, so a stale in-flight Printful resolution can never apply its result over the newer selection. The token also covers A→B→A sequences and scale, which field comparison missed.
- Front/Back toggle no longer `disabled` during render/mockup load — placement taps always register; superseded fetches are dropped, not awaited.
- The auto-trigger effect now has full state deps (self-healing: any settle into "render ready, no mockup, not loading, no error" re-fires the fetch) with an explicit `mockupError` gate so failures don't loop.
- Same-value taps (same color / same back source) are no-ops instead of clearing state with nothing left to re-fire it.

## #72 — back-design sources: This design / My designs / Shop

- `src/lib/back-sources.ts` (`getBackSourceGroups`, real-DB integration tests) + `getBackDesignSources` server action: This design (thread sources), My designs (primary images of the user's other designs; anonymous guests skip this group), Shop (published + not-hidden, one per design, current design excluded).
- Picker renders grouped sections in the existing hero-panel pattern — 3-col thumbnails ≥44px, current pick highlighted, scrollable on phones.
- **Choke-point guard**: new pure `canUseAsPlacementSource` (this thread OR user-owned design OR published+not-hidden) enforced via `assertUsableBackImage` in `createCheckoutSession`, `addToCart`, `getOrCreatePlacementRender`, and `generateMockup`'s source fallback — a forged image id can't get a stranger's private image mocked up or printed.
- Fulfillment verified: `submitOrderFulfillment` resolves `placements.back` purely by design_image id (`resolveImageUrlById` → `getDesignImageById`, no design scoping), so cross-design ids flow through unchanged; locked by an integration test.

Closes #71. Closes #72.

🤖 Generated with [Claude Code](https://claude.com/claude-code)