### PR TITLE
copy: sitewide sweep to Clean Label (persona Option C)

### DIFF
--- a/e2e/guest-funnel.spec.ts
+++ b/e2e/guest-funnel.spec.ts
@@ -11,7 +11,7 @@ test("/design loads for a signed-out visitor", async ({ page }) => {
   await expect(page).not.toHaveURL(/sign-in/);
   // Empty-state hero composer is the whole page when there's no content.
   await expect(
-    page.getByPlaceholder(/Describe your design/).first()
+    page.getByRole("textbox", { name: "Describe a design" }).first()
   ).toBeVisible();
 });
 

--- a/e2e/landing.spec.ts
+++ b/e2e/landing.spec.ts
@@ -1,6 +1,6 @@
 /**
- * Maker landing ("Type It, Wear It"): the signed-out homepage is a composer.
- * Submitting an idea navigates to /design?prompt=…, which auto-fires Draw-it.
+ * Maker landing: the signed-out homepage is a composer. Submitting an idea
+ * navigates to /design?prompt=…, which auto-fires one generation.
  * The thin-prompt test uses a deliberately vague idea so the fast readiness
  * check answers with a clarifying question — CI never pays for a render there.
  */
@@ -10,17 +10,17 @@ import { EXAMPLES } from "../src/lib/design-examples";
 test("signed-out homepage shows the hero composer", async ({ page }) => {
   await page.goto("/");
   await expect(
-    page.getByRole("heading", { name: "Type an idea. Wear it." })
+    page.getByRole("heading", { name: "Design a shirt by describing it." })
   ).toBeVisible();
-  await expect(page.getByPlaceholder(/Describe your design/)).toBeVisible();
+  await expect(page.getByPlaceholder("Describe a design")).toBeVisible();
 });
 
 test("a thin prompt seeds /design and gets a clarifying reply", async ({
   page,
 }) => {
   await page.goto("/");
-  await page.getByPlaceholder(/Describe your design/).fill("something cool");
-  await page.getByRole("button", { name: "Draw it" }).click();
+  await page.getByPlaceholder("Describe a design").fill("something cool");
+  await page.getByRole("button", { name: "Generate" }).click();
 
   await expect(page).toHaveURL(/\/design/);
   // The seed shows up as the first user turn.

--- a/src/app/d/[imageId]/__tests__/buy-panel.test.tsx
+++ b/src/app/d/[imageId]/__tests__/buy-panel.test.tsx
@@ -10,7 +10,7 @@ import { buyPublishedDesign } from "../../actions";
 
 function buyButton() {
   // Rendered twice (desktop inline + mobile sticky); both share state.
-  return screen.getAllByRole("button", { name: /Buy this design/ })[0];
+  return screen.getAllByRole("button", { name: /Order — \$/ })[0];
 }
 
 describe("BuyPanel size gate (#60)", () => {

--- a/src/app/d/[imageId]/buy-panel.tsx
+++ b/src/app/d/[imageId]/buy-panel.tsx
@@ -89,7 +89,7 @@ export function BuyPanel({
         size="lg"
         className="w-full"
       >
-        {loading ? "Redirecting…" : `Buy this design — $${total.toFixed(2)}`}
+        {loading ? "Redirecting…" : `Order — $${total.toFixed(2)}`}
       </Button>
     </div>
   ) : (

--- a/src/app/design/__tests__/chat-panel.test.tsx
+++ b/src/app/design/__tests__/chat-panel.test.tsx
@@ -1,6 +1,6 @@
-import { render, screen, fireEvent, within, act } from "@testing-library/react";
+import { render, screen, fireEvent, within } from "@testing-library/react";
 import { describe, it, expect, vi, beforeAll, afterEach } from "vitest";
-import { ChatPanel, DRAWING_LINES } from "../chat-panel";
+import { ChatPanel } from "../chat-panel";
 import type { ChatMessage } from "@/lib/db/schema";
 
 beforeAll(() => {
@@ -75,19 +75,13 @@ describe("ChatPanel quick-reply placement", () => {
   });
 });
 
-describe("ChatPanel drawing status", () => {
-  it("shows a canned line while generating and rotates it every few seconds (#70)", () => {
-    vi.useFakeTimers();
+describe("ChatPanel generating status", () => {
+  it("shows a single static line while generating (Clean Label)", () => {
     render(
       <ChatPanel {...baseProps} generating messages={[thread[0]]} />
     );
-    const status = screen.getByTestId("drawing-status");
-    const first = status.textContent;
-    expect(DRAWING_LINES).toContain(first);
-    act(() => {
-      vi.advanceTimersByTime(3000);
-    });
-    expect(status.textContent).not.toBe(first);
-    expect(DRAWING_LINES).toContain(status.textContent);
+    expect(screen.getByTestId("drawing-status")).toHaveTextContent(
+      "Generating…"
+    );
   });
 });

--- a/src/app/design/chat-panel.tsx
+++ b/src/app/design/chat-panel.tsx
@@ -8,36 +8,15 @@ import type { DesignImage } from "@/lib/design-images";
 import { Button, QuickReply } from "@/components/ui";
 import { EXAMPLES } from "@/lib/design-examples";
 
-// Rotating status shown while a render is in flight — a canned client-side
-// set (no API call), randomized start so repeat draws don't always open on
-// the same line. A Haiku-generated riff can replace this later.
-export const DRAWING_LINES = [
-  "Drawing your design…",
-  "Mixing the inks…",
-  "Sketching the outlines…",
-  "Warming up the pens…",
-  "Filling in the colors…",
-  "Stepping back to squint at it…",
-  "Adding the finishing touches…",
-];
-
+// Waiting states name the operation and stop (Clean Label): one static line,
+// no rotation.
 function DrawingStatus() {
-  const [index, setIndex] = useState(() =>
-    Math.floor(Math.random() * DRAWING_LINES.length)
-  );
-  useEffect(() => {
-    const t = setInterval(
-      () => setIndex((i) => (i + 1) % DRAWING_LINES.length),
-      3000
-    );
-    return () => clearInterval(t);
-  }, []);
   return (
     <div
       className="rounded-lg px-4 py-2 text-text-muted animate-pulse"
       data-testid="drawing-status"
     >
-      {DRAWING_LINES[index]}
+      Generating…
     </div>
   );
 }
@@ -70,8 +49,6 @@ export function ChatPanel({
     [images]
   );
   const [input, setInput] = useState("");
-  const [showSuggestions, setShowSuggestions] = useState(false);
-  const engagedRef = useRef(false);
   const [dragging, setDragging] = useState(false);
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
@@ -119,27 +96,8 @@ export function ChatPanel({
     if (!loading && !generating) inputRef.current?.focus();
   }, [loading, generating]);
 
-  // Empty state: after 8s of inactivity (input untouched), quietly reveal
-  // example chips. The moment the user types, drop them — and don't re-arm
-  // once they've engaged.
-  useEffect(() => {
-    if (!isEmpty) return;
-    if (input.length > 0) {
-      engagedRef.current = true;
-      // Hide immediately on the first keystroke; one extra render is fine.
-      // eslint-disable-next-line react-hooks/set-state-in-effect
-      setShowSuggestions(false);
-      return;
-    }
-    if (engagedRef.current) return;
-    // 8s, not 4s: long enough that someone still reading the hero or composing
-    // their first line won't get nudged; short enough to help if they stall.
-    const t = setTimeout(() => setShowSuggestions(true), 8000);
-    return () => clearTimeout(t);
-  }, [isEmpty, input]);
-
-  // "draw it"/"draw" included: chat copy now nudges "tap Draw it", so typing
-  // it should behave like tapping it.
+  // "draw it"/"draw" kept for muscle memory from the old button label; typing
+  // any of these behaves like tapping Generate.
   const GENERATE_TRIGGERS = /^(yes|yeah|yep|do it|go|generate|draw it|draw|let'?s do it|go ahead|make it|yes please|sure|ok generate)/i;
 
   // Shared submit path for both the composer and a tapped quick-reply chip, so
@@ -168,22 +126,19 @@ export function ChatPanel({
   }
 
   const busy = loading || generating;
-  // Soft nudge: until Claude judges the subject concrete, Draw it sits as a
+  // Soft nudge: until Claude judges the subject concrete, Generate sits as a
   // secondary button and a hint shows — it pops to primary when ready. Always
   // clickable; the fast thin-check catches a too-thin click in ~1s rather
   // than greying the button into looking broken.
-  const notReadyTitle = "Say a bit more about what to draw — Draw it still works.";
+  const notReadyTitle = "Add more detail, or generate anyway.";
   const showStyleHint = !readyToGenerate && messages.length > 0;
 
   if (isEmpty) {
     return (
       <div className="flex-1 flex flex-col items-center justify-center min-w-0 px-6 text-center">
         <h2 className="text-2xl sm:text-3xl font-semibold text-foreground">
-          What shall we draw together?
+          Describe a design
         </h2>
-        <p className="mt-2 text-sm text-text-muted">
-          Describe it in plain words. Refine as we go.
-        </p>
         <form
           onSubmit={handleSend}
           className="mt-6 w-full max-w-xl flex gap-2"
@@ -192,7 +147,7 @@ export function ChatPanel({
             ref={inputRef}
             value={input}
             onChange={(e) => setInput(e.target.value)}
-            placeholder="Describe your design..."
+            aria-label="Describe a design"
             className="flex-1 px-3 py-2 bg-surface border border-border rounded-md text-white placeholder:text-text-faint focus:border-border-hover focus:outline-none"
             disabled={loading}
           />
@@ -200,23 +155,19 @@ export function ChatPanel({
             Send
           </Button>
         </form>
-        {showSuggestions && (
-          <div className="mt-6 space-y-2">
-            <p className="text-xs text-text-faint">Need a suggestion?</p>
-            <div className="flex flex-wrap justify-center gap-2">
-              {EXAMPLES.slice(0, 3).map((example) => (
-                <button
-                  key={example}
-                  type="button"
-                  onClick={() => setInput(example)}
-                  className="text-xs px-3 py-1.5 border border-border rounded-full text-text-muted hover:text-foreground hover:border-border-hover transition-colors"
-                >
-                  {example}
-                </button>
-              ))}
-            </div>
-          </div>
-        )}
+        {/* Chips always visible, catalog-style (no reveal delay). */}
+        <div className="mt-6 flex flex-wrap justify-center gap-2">
+          {EXAMPLES.slice(0, 3).map((example) => (
+            <button
+              key={example}
+              type="button"
+              onClick={() => setInput(example)}
+              className="text-xs px-3 py-1.5 border border-border rounded-full text-text-muted hover:text-foreground hover:border-border-hover transition-colors"
+            >
+              {example}
+            </button>
+          ))}
+        </div>
       </div>
     );
   }
@@ -254,10 +205,7 @@ export function ChatPanel({
       <div className="flex-1 overflow-y-auto p-4 space-y-4" data-testid="chat-messages">
         {messages.length === 0 && (
           <div className="text-center text-text-muted mt-20 space-y-4">
-            <p className="text-lg">What should your design look like?</p>
-            <p className="text-sm">
-              Describe a design. Chat to refine the idea, then hit Draw it.
-            </p>
+            <p className="text-lg">Describe a design</p>
             <div className="flex flex-wrap justify-center gap-2 mt-4">
               {EXAMPLES.map((example) => (
                 <button
@@ -319,7 +267,7 @@ export function ChatPanel({
         {loading && (
           <div className="flex justify-start">
             <div className="rounded-lg px-4 py-2 text-text-faint">
-              Thinking...
+              Thinking…
             </div>
           </div>
         )}
@@ -334,7 +282,7 @@ export function ChatPanel({
       {/* Not-ready hint — only when there are no tappable options to offer instead */}
       {showStyleHint && options.length === 0 && (
         <div className="px-4 pt-2 text-xs text-text-muted">
-          Say a bit more about what to draw — or just tap Draw it.
+          Add more detail, or tap Generate.
         </div>
       )}
 
@@ -359,7 +307,7 @@ export function ChatPanel({
             ref={inputRef}
             value={input}
             onChange={(e) => setInput(e.target.value)}
-            placeholder="Describe your design or drop an image..."
+            placeholder="Describe a design or drop an image"
             className="flex-1 min-h-[44px] px-3 py-2 bg-surface border border-border rounded-md text-white placeholder:text-text-faint focus:border-border-hover focus:outline-none"
             disabled={busy}
           />
@@ -381,7 +329,7 @@ export function ChatPanel({
             disabled={busy || (messages.length === 0 && !input.trim())}
             title={readyToGenerate ? undefined : notReadyTitle}
           >
-            Draw it
+            Generate
           </Button>
         </div>
       </form>

--- a/src/app/design/image-gallery.tsx
+++ b/src/app/design/image-gallery.tsx
@@ -61,7 +61,7 @@ export function ImageGallery({
         <div className="p-3">
           {images.length === 0 && !generating && (
             <p className="text-xs text-text-faint text-center mt-8">
-              No images yet. Chat about your idea, then hit Draw it.
+              No images yet.
             </p>
           )}
           <div className="grid grid-cols-2 gap-2">
@@ -89,7 +89,7 @@ export function ImageGallery({
             {generating && (
               <div className="aspect-square rounded-lg border-2 border-border flex items-center justify-center bg-surface">
                 <div className="text-[10px] text-text-faint animate-pulse text-center px-2">
-                  Drawing your design…
+                  Generating…
                 </div>
               </div>
             )}

--- a/src/app/design/page.tsx
+++ b/src/app/design/page.tsx
@@ -77,7 +77,7 @@ function DesignPageInner() {
     ensureGuestSession();
   }, []);
 
-  // Landing seed: /design?prompt=… fires Draw-it once with the seeded idea
+  // Landing seed: /design?prompt=… fires one generation with the seeded idea
   // (new designs only — never when resuming via ?id=). Ref-guarded so React
   // Strict Mode's double effect can't fire it twice; the param is stripped
   // immediately so refresh/back doesn't resubmit — via history.replaceState
@@ -139,7 +139,7 @@ function DesignPageInner() {
     } catch {
       setMessages((prev) => [
         ...prev,
-        makeOptimisticMessage("assistant", "Something went wrong. Try again?"),
+        makeOptimisticMessage("assistant", "Something went wrong. Try again."),
       ]);
     } finally {
       setLoading(false);
@@ -176,7 +176,7 @@ function DesignPageInner() {
     } catch {
       setMessages((prev) => [
         ...prev,
-        makeOptimisticMessage("assistant", "Image generation failed. Try again?"),
+        makeOptimisticMessage("assistant", "Generation failed. Try again."),
       ]);
     } finally {
       setGenerating(false);
@@ -243,7 +243,7 @@ function DesignPageInner() {
     } catch {
       setMessages((prev) => [
         ...prev,
-        makeOptimisticMessage("assistant", "Image upload failed. Try again?"),
+        makeOptimisticMessage("assistant", "Upload failed. Try again."),
       ]);
     } finally {
       setLoading(false);

--- a/src/app/designs/page.tsx
+++ b/src/app/designs/page.tsx
@@ -87,7 +87,7 @@ export default function DesignsPage() {
         </div>
 
         {loading ? (
-          <p className="text-text-faint">Loading...</p>
+          <p className="text-text-faint">Loading…</p>
         ) : loadError ? (
           <div className="text-center py-16 space-y-2">
             <p className="text-red-400 font-medium">Failed to load designs.</p>
@@ -97,7 +97,7 @@ export default function DesignsPage() {
           <div className="text-center py-16 space-y-4">
             <p className="text-text-faint text-lg">No designs yet.</p>
             <Link href="/design">
-              <Button>Start your first design</Button>
+              <Button>Start a design</Button>
             </Link>
           </div>
         ) : (

--- a/src/app/opengraph-image.tsx
+++ b/src/app/opengraph-image.tsx
@@ -1,6 +1,6 @@
 import { ImageResponse } from "next/og";
 
-export const alt = "PRNTD — AI-powered custom apparel";
+export const alt = "PRNTD — Design a shirt by describing it";
 export const size = { width: 1200, height: 630 };
 export const contentType = "image/png";
 
@@ -40,7 +40,7 @@ export default function Image() {
             color: "#999999",
           }}
         >
-          AI-powered custom apparel
+          Design a shirt by describing it.
         </div>
         <div
           style={{
@@ -50,7 +50,7 @@ export default function Image() {
             color: "#666666",
           }}
         >
-          Describe it · generate it · wear it · prntd.org
+          prntd.org
         </div>
         {/* accent underline strip */}
         <div

--- a/src/app/order/confirm/page.tsx
+++ b/src/app/order/confirm/page.tsx
@@ -39,7 +39,7 @@ function ConfirmPageInner() {
   if (loading) {
     return (
       <div className="min-h-screen flex items-center justify-center">
-        Loading order details...
+        Loading…
       </div>
     );
   }
@@ -67,15 +67,7 @@ function ConfirmPageInner() {
       <div className="flex-1 flex flex-col items-center justify-center">
       <div className="max-w-md w-full text-center space-y-6">
         <div className="text-5xl">&#10003;</div>
-        <h1 className="text-2xl font-bold">Order confirmed!</h1>
-        <p className="text-text-muted">
-          Your custom t-shirt is being prepared. Check your order status
-          anytime on{" "}
-          <Link href="/orders" className="underline underline-offset-2">
-            My Orders
-          </Link>
-          .
-        </p>
+        <h1 className="text-2xl font-bold">Order confirmed.</h1>
 
         <Card className="p-4 text-sm space-y-2 text-left">
           <div className="flex justify-between">

--- a/src/app/order/page.tsx
+++ b/src/app/order/page.tsx
@@ -269,7 +269,7 @@ function OrderPageInner() {
             className="hidden md:block w-full"
             size="lg"
           >
-            {loading ? "Redirecting to checkout..." : "Buy now"}
+            {loading ? "Redirecting…" : "Order"}
           </Button>
           {cartShown && (
             <Button
@@ -297,10 +297,10 @@ function OrderPageInner() {
           size="lg"
         >
           {loading
-            ? "Redirecting..."
+            ? "Redirecting…"
             : breakdown
-              ? `Buy now — $${breakdown.total.toFixed(2)}`
-              : "Buy now"}
+              ? `Order — $${breakdown.total.toFixed(2)}`
+              : "Order"}
         </Button>
         {cartShown && (
           <Button

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -36,7 +36,7 @@ export default async function Home() {
         <section className="py-12 px-4">
           <div className="max-w-2xl mx-auto">
             <h2 className="text-lg font-semibold text-center mb-6">
-              Made by chatting here
+              Made on PRNTD
             </h2>
             <div className="grid grid-cols-2 gap-4">
               {proof.map((img) => {
@@ -89,17 +89,14 @@ export default async function Home() {
       {discover.length > 0 && (
         <section className="py-16 px-4 border-t border-border">
           <div className="max-w-6xl mx-auto">
-            <h2 className="text-2xl font-bold text-center mb-2">Shop</h2>
-            <p className="text-text-muted text-center mb-8">
-              Browse and buy designs other makers have published.
-            </p>
+            <h2 className="text-2xl font-bold text-center mb-8">Shop</h2>
             <PublishedGrid images={discover} />
             <div className="text-center mt-8">
               <Link
                 href="/prints"
                 className="text-sm text-text-muted underline hover:text-foreground transition-colors"
               >
-                See the whole Shop →
+                See all →
               </Link>
             </div>
           </div>

--- a/src/app/preview/page.tsx
+++ b/src/app/preview/page.tsx
@@ -551,7 +551,7 @@ function PreviewPageInner() {
           {display.showError && (
             <div className="absolute inset-0 flex flex-col items-center justify-center gap-2 bg-surface-alt z-20 px-4 text-center">
               <span className="text-sm text-text-muted">
-                Couldn&rsquo;t prepare your design for the {productName}.
+                Couldn&rsquo;t render the preview.
               </span>
               <span className="text-xs text-text-faint">
                 Use “Try again” below.
@@ -591,8 +591,8 @@ function PreviewPageInner() {
               <span className="inline-flex items-center gap-2 rounded-full bg-black/60 px-3 py-1.5 text-xs text-white backdrop-blur-sm">
                 <span className="h-3 w-3 animate-spin rounded-full border-2 border-white/70 border-t-transparent" />
                 {regenerating
-                  ? `Preparing your design…`
-                  : "Rendering exact preview…"}
+                  ? "Preparing…"
+                  : "Rendering preview…"}
               </span>
             </div>
           )}
@@ -727,7 +727,7 @@ function PreviewPageInner() {
               disabled={regenerating || mockupLoading || !approveReady}
             >
               {regenerating
-                ? "Preparing design…"
+                ? "Preparing…"
                 : mockupLoading || !approveReady
                   ? "Rendering preview…"
                   : `Use this design`}

--- a/src/app/prints/page.tsx
+++ b/src/app/prints/page.tsx
@@ -12,7 +12,7 @@ export default async function ShopPage() {
         <header className="mb-8 text-center">
           <h1 className="text-3xl font-bold">Shop</h1>
           <p className="text-text-muted mt-2">
-            Browse and buy designs other makers have published.
+            Designs published by other makers.
           </p>
         </header>
 

--- a/src/components/home-hero.tsx
+++ b/src/components/home-hero.tsx
@@ -43,13 +43,8 @@ export function HomeHero({
         <div className="flex items-center justify-between">
           <div>
             <h1 className="text-3xl font-bold tracking-tight">
-              {hasDesigns ? "Welcome back" : "Get started"}
+              {hasDesigns ? "Your designs" : "Start a design"}
             </h1>
-            <p className="text-text-muted mt-1">
-              {hasDesigns
-                ? "Continue a design or start fresh."
-                : "Make your first design."}
-            </p>
           </div>
           <Link href="/design">
             <Button>New Design</Button>
@@ -72,10 +67,10 @@ export function HomeHero({
         {loaded && !hasDesigns && (
           <div className="text-center py-12 border border-border rounded-lg">
             <p className="text-text-muted mb-4">
-              Describe what you want. Chat to refine. Generate when ready.
+              Design a shirt by describing it.
             </p>
             <Link href="/design">
-              <Button>Start your first design</Button>
+              <Button>Start a design</Button>
             </Link>
           </div>
         )}

--- a/src/components/maker-hero.tsx
+++ b/src/components/maker-hero.tsx
@@ -4,12 +4,13 @@ import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { Button } from "@/components/ui";
 import { EXAMPLES } from "@/lib/design-examples";
+import { minRetailPrice } from "@/lib/pricing";
 
 /**
  * Signed-out landing hero — the composer IS the landing. Typing an idea (or
- * tapping a chip) navigates to /design?prompt=…, which auto-fires Draw-it.
- * Unlike the in-chat chips (which prefill), landing chips navigate
- * immediately: here they demo the product.
+ * tapping a chip) navigates to /design?prompt=…, which auto-fires a
+ * generation. Unlike the in-chat chips (which prefill), landing chips
+ * navigate immediately: here they demo the product.
  */
 export function MakerHero() {
   const router = useRouter();
@@ -25,11 +26,11 @@ export function MakerHero() {
     <main className="flex-1 flex flex-col items-center justify-center px-4 py-16 text-center">
       <div className="w-full max-w-2xl space-y-6">
         <h1 className="text-4xl sm:text-5xl font-bold tracking-tight">
-          Type an idea. Wear it.
+          Design a shirt by describing it.
         </h1>
         <p className="text-lg text-text-muted max-w-lg mx-auto">
-          AI draws your design in seconds. Free to try — pay only if you
-          order.
+          Free to design. Printed and shipped from $
+          {minRetailPrice().toFixed(2)}.
         </p>
         <form
           onSubmit={(e) => {
@@ -41,7 +42,7 @@ export function MakerHero() {
           <input
             value={input}
             onChange={(e) => setInput(e.target.value)}
-            placeholder="Describe your design..."
+            placeholder="Describe a design"
             className="flex-1 min-h-[44px] px-3 py-2 bg-surface border border-border rounded-md text-white placeholder:text-text-faint focus:border-border-hover focus:outline-none"
           />
           <Button
@@ -50,7 +51,7 @@ export function MakerHero() {
             className="min-h-[44px]"
             disabled={!input.trim()}
           >
-            Draw it
+            Generate
           </Button>
         </form>
         <div className="flex flex-wrap justify-center gap-2">

--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -10,7 +10,9 @@ function buildImageGalleryContext(images: DesignImage[]): string {
   return `\nImages so far:\n${lines.join("\n")}\n\nEntries marked [user upload] are reference images the user provided. Use them as style/content inspiration. When the user references images by number (e.g., "#2"), you know which image they mean.`;
 }
 
-const CHAT_SYSTEM_PROMPT = `You are a t-shirt design advisor for PRNTD. Help users refine their design ideas through conversation. You do NOT draw images — the user taps "Draw it" when ready. In user-facing copy always say "draw" / "Draw it", never "generate".
+const CHAT_SYSTEM_PROMPT = `You are a t-shirt design advisor for PRNTD. Help users refine their design ideas through conversation. You do NOT generate images — the user taps "Generate" when ready. In user-facing copy say "generate" / "Generate" (the button label).
+
+Voice (Clean Label): every sentence is the shortest accurate version of itself. State facts; never sell, reassure, or perform. No exclamation points, no jokes, no whimsy.
 
 Output format — respond with raw JSON only (no markdown fences around the JSON itself):
 {
@@ -20,9 +22,9 @@ Output format — respond with raw JSON only (no markdown fences around the JSON
 }
 
 Readiness + pacing for "readyToGenerate":
-- Set true as soon as there is a concrete SUBJECT (the WHAT — what's depicted). Style is a refinement, not a gate: when the subject is clear but style is open, set true, nudge toward Draw it, and put 3-5 style directions in "options" so picking one stays optional.
+- Set true as soon as there is a concrete SUBJECT (the WHAT — what's depicted). Style is a refinement, not a gate: when the subject is clear but style is open, set true, nudge toward Generate, and put 3-5 style directions in "options" so picking one stays optional.
 - Set false ONLY when the subject itself is too vague to draw anything (e.g. "something cool", "a design for my team") — then "message" is the ONE question that pins it down.
-- Ask at most ONE clarifying question per new idea. Never ask two in a row: if the user's answer is still loose, go with your best interpretation and nudge toward Draw it instead of asking again.
+- Ask at most ONE clarifying question per new idea. Never ask two in a row: if the user's answer is still loose, go with your best interpretation and nudge toward Generate instead of asking again.
 
 The "options" field (tappable quick-replies — THIS is how you offer choices):
 - Whenever you ask a multiple-choice question or suggest directions to pick from, put each choice in "options" as { "label": short tappable text, "value": the full message sent as the user's reply if they tap it }.
@@ -39,7 +41,7 @@ Style rules for the "message" field:
 - Be terse and professional. 2-4 short sentences max.
 - Use markdown sparingly: **bold** for emphasis, line breaks between sections. No numbered lists of choices — those go in "options".
 - No filler, no flattery, no "great idea!" — just useful input.
-- End with a short question or nudge toward Draw it (e.g. "when you're ready, tap Draw it").
+- End with a short question or nudge toward Generate (e.g. "when you're ready, tap Generate").
 - Frame your responses as directions to try, not edits to apply. Use "try", "aim for", "this version", "this direction" — not "fix", "remove", "edit".
 
 Handling negations (very important):
@@ -55,7 +57,7 @@ CRITICAL: The "message" field is conversational prose for the user — never put
 
 What the UI actually offers (do NOT invent other features):
 - A chat box (this conversation).
-- A "Draw it" button that draws a new image from the conversation so far.
+- A "Generate" button that generates a new image from the conversation so far.
 - An image gallery showing past generations, each with a "Use as reference" action to feed it back into the next generation.
 - Buttons to proceed to product preview / order.
 - That's it. There is no "Remove Background" button, no inpainting, no manual editor, no layer tools, no upload-to-edit. If the user asks for something the UI doesn't have, say so plainly — do not invent an interaction. If the user insists a feature exists, do not capitulate; say you don't have a way to do that here.
@@ -73,7 +75,7 @@ const GENERATE_SYSTEM_PROMPT = `You are a t-shirt design assistant for PRNTD. Yo
 
 Read the conversation to understand what the user wants — both the SUBJECT and the AESTHETIC — then respond with raw JSON (no markdown, no code fences):
 {
-  "message": "Brief acknowledgment of what you're drawing (user-facing — say 'draw', never 'generate')",
+  "message": "Brief factual acknowledgment of what is being generated (user-facing — plain, no exclamation points)",
   "fluxPrompt": "Detailed image generation prompt for Ideogram",
   "negativePrompt": "Optional. Things to push the model AWAY from. Use when the user asks for an aesthetic the model tends to ignore (see Style section below). Empty string if not needed.",
   "referenceImage": null or number (e.g. 2) — set this to the # of a previous design if the user is refining/building on it
@@ -353,7 +355,7 @@ const READINESS_SYSTEM_PROMPT = `You judge whether a t-shirt design idea is conc
 
 Ready as soon as the SUBJECT (what is depicted) is concrete. Style/medium is NOT required — when it's unstated, the drawing step picks a fitting style the user can refine afterward. Not ready ONLY when the subject is too vague to draw anything (e.g. "something cool", "a shirt for my team"): then ask ONE question, with 2-5 likely directions in "options" as tappable chips { "label": short text, "value": the natural-language reply sent on tap }.
 NEVER name the choices inside "question" — not as a numbered/bulleted list and not mid-sentence. "Is it a funny scenario, a pun caption, or something absurdist?" is WRONG; "What's the vibe?" with those three in "options" is RIGHT — chips render each choice once, and prose repeats them.
-Ask at most one clarifying question per idea: if the conversation shows one was already asked, lean ready=true rather than asking another. Omit "options" (or use []) when ready. Keep "question" to 1-2 sentences; in user-facing copy say "draw" / "Draw it", never "generate". When genuinely uncertain, lean ready=true — a real idea should never be blocked.`;
+Ask at most one clarifying question per idea: if the conversation shows one was already asked, lean ready=true rather than asking another. Omit "options" (or use []) when ready. Keep "question" to 1-2 sentences; in user-facing copy say "generate" / "Generate" (the button label). When genuinely uncertain, lean ready=true — a real idea should never be blocked.`;
 
 /**
  * Fast pre-check used by Generate/Compare to decide "render vs ask" without

--- a/src/lib/design-examples.ts
+++ b/src/lib/design-examples.ts
@@ -1,11 +1,12 @@
 /**
  * Example design prompts shared by the landing hero chips (tap = navigate to
- * /design?prompt= and draw immediately) and the in-chat empty-state chips
- * (tap = prefill the composer). One list, two jobs.
+ * /design?prompt= and generate immediately) and the in-chat empty-state chips
+ * (tap = prefill the composer). One list, two jobs. Each chip is also the
+ * literal generation prompt, so every entry keeps a subject + style.
  */
 export const EXAMPLES = [
-  "A minimalist mountain landscape in blue and white",
-  "A retro sunset with palm tree silhouettes",
-  "An abstract geometric wolf head",
-  'Bold text saying "HELLO" in a graffiti style',
+  "Minimalist mountain landscape",
+  "Retro sunset, palm silhouettes",
+  "Geometric wolf head",
+  '"HELLO" in graffiti letters',
 ];

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -183,9 +183,9 @@ export async function sendOrderConfirmation(params: {
     to: params.to,
     subject: `Order confirmed — ${label} (${lineSummary(params.lines)})`,
     html: emailLayout({
-      preheader: `We're printing your ${printing} now.`,
+      preheader: `Your ${printing} is being printed.`,
       heading: "Your order is confirmed",
-      intro: `We're printing your ${printing} now. We'll email you again when it ships with tracking.`,
+      intro: `Your ${printing} is being printed. You'll get another email with tracking when it ships.`,
       images: params.images,
       bodyHtml: detailTable(rows),
       ctaLabel: "View your orders",


### PR DESCRIPTION
Applies the 2026-07-19 persona decision (Option C — The Clean Label, `docs/design-system.md` Part 1) across every user-facing surface. Net −70 lines.

## What changed

**The flagged item first:** PR #77's rotating playful drawing-status lines ("Mixing the inks…", "Warming up the pens…") are gone — one static `Generating…` in the chat thread and the gallery tile. `DRAWING_LINES` export removed.

**Button rename:** "Draw it" → **"Generate"** (landing hero + composer). The chat, generate, and readiness system prompts flip their vocabulary rule to match (they previously enforced *never say generate*) and gain C voice rules (shortest accurate sentence, no exclamation points, no jokes). Typed "draw it"/"draw" still triggers generation (muscle memory).

**Per surface (C samples from the doc):**
- Landing hero: "Design a shirt by describing it." / "Free to design. Printed and shipped from $X." — price from `minRetailPrice()`, never hardcoded. Placeholder "Describe a design".
- Chips: "Minimalist mountain landscape" · "Retro sunset, palm silhouettes" · "Geometric wolf head" · '"HELLO" in graffiti letters' (chips are also the literal prompts; each keeps subject + style).
- /design empty state: heading "Describe a design" (input gets `aria-label`, no duplicated placeholder), sub-line deleted, **chips always visible** — the 8s reveal delay is removed per C's visual delta. In-thread empty variant deflated too.
- Order CTAs: "Buy now" / "Buy this design — $X" → "Order" / "Order — $X" (/order desktop + sticky bar, /d/[imageId] BuyPanel).
- /order/confirm: "Order confirmed." — reassurance paragraph deleted (buttons already route onward).
- Home: proof strip "Made on PRNTD"; Shop teaser sub-line deleted; "See the whole Shop →" → "See all →"; signed-in hero drops "Welcome back"/"Get started" for "Your designs"/"Start a design".
- /prints sub: "Designs published by other makers."
- /preview: "Preparing your design…"/"Rendering exact preview…" → "Preparing…"/"Rendering preview…"; error strings unified on "Couldn't render the preview."
- Chat errors: "Generation failed. Try again." / "Upload failed. Try again." / "Something went wrong. Try again."
- Shipping-confirmation email: "We're printing your X now." → "Your X is being printed." (C: no "we").
- OG share image tagline: "Design a shirt by describing it."

**Tests:** chat-panel rotation test → static-line assertion; buy-panel CTA matcher; e2e landing + guest-funnel selectors updated (guest-funnel now finds the composer by role/aria-label since the empty-state placeholder is gone).

Not touched: /admin (internal, already flat), auth pages, pricing-breakdown labels (trust surface, already C), publish modal (already factual).

## Verification
- `npm run lint` 0 errors · `npm test` 555/555 · `npm run build` green
- e2e will run against the Vercel preview on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)