### PR TITLE
copy: /design header title — static "Design"

### DIFF
--- a/src/app/design/page.tsx
+++ b/src/app/design/page.tsx
@@ -281,9 +281,7 @@ function DesignPageInner() {
             trail={breadcrumbTrail("/design", { id: designId.current })}
             current="Design"
           />
-          <h1 className="text-lg font-semibold mt-1">
-            {empty ? "Start designing" : "Design something"}
-          </h1>
+          <h1 className="text-lg font-semibold mt-1">Design</h1>
         </div>
       </div>
 


### PR DESCRIPTION
One string the #79 sweep missed, spotted on prod: the /design header still read "Start designing" (empty) / "Design something" (thread). Both collapse to a static "Design" — matches the breadcrumb, accurate for new and revisited threads.

Lint + design-page tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)