### PR TITLE
design: collapse badge palette to neutral + one status pair (gap #1)

### DIFF
--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -415,10 +415,12 @@ first draft were fixed on main 2026-06-14 (`cbedcbe`): Geist restored, 40 raw
 `gray-*` classes swept to semantic tokens, 4 dead token names corrected.
 Remaining:
 
-1. **Badge palette is the only chrome color** — 11 variants across 6 hues.
-   Persona-dependent resolution: A and C collapse to neutral + positive +
-   attention + negative; C collapses hardest (neutral + one pair); B keeps
-   the same collapse but may map "attention" onto its ink accent.
+1. ~~**Badge palette is the only chrome color**~~ — RESOLVED 2026-07-19 under
+   C: `--positive`/`--negative` tokens added; badges collapse to a neutral
+   pill with status carried by text color (shipped/delivered = positive,
+   canceled = negative, everything else neutral; no `--attention` — pending
+   states are neutral under C). Raw `green-400`/`red-400` classes swept onto
+   the tokens (admin money coloring, error lines, danger button hover).
 2. **Dark-only is implicit, not declared** — light-mode Tailwind classes
    break on the dark background when they sneak in. Declare dark-only as a
    principle (it's the brand under all three personas) or do real theming.

--- a/src/app/admin/orders/[id]/page.tsx
+++ b/src/app/admin/orders/[id]/page.tsx
@@ -25,11 +25,11 @@ import {
 type OrderDetail = Awaited<ReturnType<typeof getOrderDetail>>;
 
 const LEDGER_TYPE_LABELS: Record<string, { label: string; color: string }> = {
-  sale: { label: "Sale", color: "text-green-400" },
-  stripe_fee: { label: "Stripe Fee", color: "text-red-400" },
-  cogs: { label: "COGS", color: "text-red-400" },
-  refund: { label: "Refund", color: "text-red-400" },
-  refund_cogs_reversal: { label: "COGS Reversal", color: "text-green-400" },
+  sale: { label: "Sale", color: "text-positive" },
+  stripe_fee: { label: "Stripe Fee", color: "text-negative" },
+  cogs: { label: "COGS", color: "text-negative" },
+  refund: { label: "Refund", color: "text-negative" },
+  refund_cogs_reversal: { label: "COGS Reversal", color: "text-positive" },
 };
 
 export default function OrderDetailPage() {
@@ -288,13 +288,13 @@ export default function OrderDetailPage() {
               {order.printfulCost != null && (
                 <div className="flex justify-between">
                   <span className="text-text-muted">COGS</span>
-                  <span className="text-red-400">-${order.printfulCost.toFixed(2)}</span>
+                  <span className="text-negative">-${order.printfulCost.toFixed(2)}</span>
                 </div>
               )}
               {profit != null && (
                 <div className="flex justify-between border-t border-border pt-1 mt-1">
                   <span className="text-text-muted">Profit</span>
-                  <span className={profit >= 0 ? "text-green-400" : "text-red-400"}>
+                  <span className={profit >= 0 ? "text-positive" : "text-negative"}>
                     ${profit.toFixed(2)}
                   </span>
                 </div>

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -197,7 +197,7 @@ export default function AdminPage() {
         </Card>
         <Card className="p-4">
           <p className="text-xs text-text-muted uppercase">Stripe Fees</p>
-          <p className="text-2xl font-bold mt-1 text-red-400">
+          <p className="text-2xl font-bold mt-1 text-negative">
             ${Math.abs(summary.stripeFees).toFixed(2)}
           </p>
         </Card>
@@ -405,7 +405,7 @@ export default function AdminPage() {
                     </td>
                     <td className="py-3 pr-4 text-xs font-medium">
                       {profit != null ? (
-                        <span className={profit >= 0 ? "text-green-400" : "text-red-400"}>
+                        <span className={profit >= 0 ? "text-positive" : "text-negative"}>
                           ${profit.toFixed(2)}
                         </span>
                       ) : (

--- a/src/app/admin/published/page.tsx
+++ b/src/app/admin/published/page.tsx
@@ -43,7 +43,7 @@ export default async function AdminPublishedPage() {
             <div
               key={img.imageId}
               className={`border rounded-md overflow-hidden ${
-                img.isHidden ? "border-red-400 opacity-60" : "border-border"
+                img.isHidden ? "border-negative opacity-60" : "border-border"
               }`}
             >
               <Link

--- a/src/app/d/[imageId]/editable-naming.tsx
+++ b/src/app/d/[imageId]/editable-naming.tsx
@@ -80,7 +80,7 @@ export function EditableNaming({ imageId, title, description, canEdit }: Props) 
         rows={3}
         className="w-full bg-surface border border-border rounded px-3 py-2 text-base leading-relaxed"
       />
-      {error && <p className="text-sm text-red-400">{error}</p>}
+      {error && <p className="text-sm text-negative">{error}</p>}
       <div className="flex gap-2">
         <Button onClick={handleSave} disabled={saving} size="sm">
           {saving ? "Saving…" : "Save"}

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -134,7 +134,7 @@ export default function DashboardPage() {
           {creating ? "Creating…" : "Create a shop"}
         </Button>
       </form>
-      {error && <p className="mt-2 text-sm text-red-400">{error}</p>}
+      {error && <p className="mt-2 text-sm text-negative">{error}</p>}
 
       {/* Stores */}
       <div className="mt-6 space-y-3">
@@ -381,7 +381,7 @@ function StoreEditPanel({
         </div>
       </div>
 
-      {error && <p className="text-sm text-red-400">{error}</p>}
+      {error && <p className="text-sm text-negative">{error}</p>}
 
       <div className="flex flex-wrap gap-2 pt-1">
         <Button

--- a/src/app/dashboard/products/compose-form.tsx
+++ b/src/app/dashboard/products/compose-form.tsx
@@ -298,7 +298,7 @@ export function ComposeForm({
         </dl>
       </section>
 
-      {error && <p className="mt-3 text-sm text-red-400">{error}</p>}
+      {error && <p className="mt-3 text-sm text-negative">{error}</p>}
 
       <div className="mt-5 flex gap-2">
         <Button

--- a/src/app/designs/page.tsx
+++ b/src/app/designs/page.tsx
@@ -90,7 +90,7 @@ export default function DesignsPage() {
           <p className="text-text-faint">Loading…</p>
         ) : loadError ? (
           <div className="text-center py-16 space-y-2">
-            <p className="text-red-400 font-medium">Failed to load designs.</p>
+            <p className="text-negative font-medium">Failed to load designs.</p>
             <p className="text-xs text-text-muted font-mono">{loadError}</p>
           </div>
         ) : designs.length === 0 ? (

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -12,6 +12,10 @@
   --text-faint: #666666;
   --accent: #ffffff;
   --accent-fg: #000000;
+  /* The one status color pair (Clean Label): money-in/terminal-good vs
+     money-out/destructive. Chrome stays monochrome otherwise. */
+  --positive: #4ade80;
+  --negative: #f87171;
 }
 
 @theme inline {
@@ -25,6 +29,8 @@
   --color-text-faint: var(--text-faint);
   --color-accent: var(--accent);
   --color-accent-fg: var(--accent-fg);
+  --color-positive: var(--positive);
+  --color-negative: var(--negative);
   --font-sans: var(--font-geist-sans);
   --font-mono: var(--font-geist-mono);
 }

--- a/src/app/preview/page.tsx
+++ b/src/app/preview/page.tsx
@@ -735,7 +735,7 @@ function PreviewPageInner() {
           )}
         </div>
         {mockupError && (
-          <p className="text-sm text-red-400 text-center">
+          <p className="text-sm text-negative text-center">
             Couldn&apos;t render the preview.
           </p>
         )}

--- a/src/app/shop/[slug]/[productId]/store-buy-panel.tsx
+++ b/src/app/shop/[slug]/[productId]/store-buy-panel.tsx
@@ -89,7 +89,7 @@ export function StoreBuyPanel({
         </div>
       </div>
 
-      {error && <p className="text-sm text-red-400">{error}</p>}
+      {error && <p className="text-sm text-negative">{error}</p>}
 
       {!buyable ? (
         <p className="text-sm text-text-faint">

--- a/src/components/feedback-widget.tsx
+++ b/src/components/feedback-widget.tsx
@@ -218,7 +218,7 @@ export function FeedbackWidget({
       </div>
 
       {error && (
-        <p className="text-xs text-red-400" role="alert">
+        <p className="text-xs text-negative" role="alert">
           {error}
         </p>
       )}

--- a/src/components/publish-modal.tsx
+++ b/src/components/publish-modal.tsx
@@ -89,7 +89,7 @@ export function PublishModal({
         <BackgroundPicker value={bg} onChange={setBg} disabled={publishing} />
       </div>
 
-      {error && <p className="text-sm text-red-400 mt-3">{error}</p>}
+      {error && <p className="text-sm text-negative mt-3">{error}</p>}
 
       <div className="flex gap-2 mt-5">
         <Button onClick={confirm} disabled={publishing} className="flex-1">

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,17 +1,25 @@
 import { HTMLAttributes, forwardRef } from "react";
 
+// Collapsed palette (Clean Label): neutral + the one status pair. Status is
+// carried by text color on a neutral pill — terminal-good states read
+// positive, canceled reads negative, everything in between stays neutral.
+// Variant names stay 1:1 with status strings so call sites pass them through.
+const neutral = "bg-surface-raised text-text-muted border-border";
+const positive = "bg-surface-raised text-positive border-border";
+const negative = "bg-surface-raised text-negative border-border";
+
 const variants = {
-  default: "bg-surface-raised text-text-muted border-border",
-  pending: "bg-yellow-900/30 text-yellow-400 border-yellow-800",
-  paid: "bg-blue-900/30 text-blue-400 border-blue-800",
-  submitted: "bg-purple-900/30 text-purple-400 border-purple-800",
-  shipped: "bg-green-900/30 text-green-400 border-green-800",
-  delivered: "bg-green-900/50 text-green-300 border-green-700",
-  draft: "bg-surface-raised text-text-muted border-border",
-  approved: "bg-emerald-900/30 text-emerald-400 border-emerald-800",
-  ordered: "bg-blue-900/30 text-blue-400 border-blue-800",
+  default: neutral,
+  pending: neutral,
+  paid: neutral,
+  submitted: neutral,
+  shipped: positive,
+  delivered: positive,
+  draft: neutral,
+  approved: neutral,
+  ordered: neutral,
   archived: "bg-surface-raised text-text-faint border-border",
-  canceled: "bg-red-900/30 text-red-400 border-red-800",
+  canceled: negative,
 } as const;
 
 type BadgeProps = HTMLAttributes<HTMLSpanElement> & {

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -6,7 +6,7 @@ const variants = {
   secondary:
     "border border-border text-text-muted hover:border-border-hover hover:text-foreground",
   danger:
-    "border border-border text-text-muted hover:border-red-500 hover:text-red-400",
+    "border border-border text-text-muted hover:border-negative hover:text-negative",
   ghost:
     "text-text-muted hover:text-foreground",
 } as const;


### PR DESCRIPTION
Design-system gap #1, unblocked by the Option C decision (this morning's #79 was the copy half; this is the first visual-gap resolution).

- **Tokens:** `--positive` / `--negative` added to `globals.css` (green-400 / red-400 values) — the one status pair C allows. No `--attention`: pending states collapse to neutral.
- **Badge:** all 11 variant names kept (call sites pass `order.status` / `design.status` straight through), but visuals collapse to a neutral pill with status carried by text color: shipped/delivered → positive, canceled → negative, everything in between (pending, paid, submitted, ordered, approved, draft) → neutral, archived → faint.
- **Token sweep:** every raw `green-400`/`red-400` class moved onto the tokens — admin financial summary + profit coloring, ledger entry-type colors, error lines sitewide, /admin/published hidden-border, danger button hover (`red-500` → `--negative`, the only visual delta and it's one hover-border shade).

Where you'll see it: /orders and /admin status pills lose their blue/purple/yellow hues — only shipped/delivered read green and canceled red. Admin money coloring is unchanged visually.

Lint 0 errors · 555/555 tests · build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)