### PR TITLE
feat: remembered product/size defaults (#44) (collapse slice 3)

### DIFF
--- a/src/app/d/[imageId]/buy-panel.tsx
+++ b/src/app/d/[imageId]/buy-panel.tsx
@@ -6,6 +6,7 @@ import { Button } from "@/components/ui";
 import { SizePicker, ColorPicker } from "@/components/product-options";
 import { ACTIVE_BLANKS, DEFAULT_BLANK_ID, getBlank } from "@/lib/blanks";
 import { computePrice, computeOrderTotal } from "@/lib/pricing";
+import type { PurchaseDefaults } from "@/lib/purchase-defaults";
 import { buyPublishedDesign } from "../actions";
 
 /**
@@ -20,20 +21,31 @@ export function BuyPanel({
   imageId,
   isLoggedIn,
   preferredColor,
+  remembered,
 }: {
   imageId: string;
   isLoggedIn: boolean;
   /** The design's pinned backdrop color; pre-selected when this product carries it. */
   preferredColor?: string | null;
+  /** Last-purchase defaults (#44); null for guests/first purchase. */
+  remembered?: PurchaseDefaults | null;
 }) {
-  const [productId, setProductId] = useState(DEFAULT_BLANK_ID);
+  // Remembered product wins over the static default (#44). No URL params on
+  // this surface, so precedence is remembered > static.
+  const [productId, setProductId] = useState(
+    () => (remembered && getBlank(remembered.blankId) ? remembered.blankId : DEFAULT_BLANK_ID)
+  );
   const product = getBlank(productId);
   const sizes = product?.sizes ?? [];
   const colors = product?.colors ?? [];
 
-  // No default size (#60): the buyer must pick one before the CTA enables,
-  // so nobody checks out in a size they never chose.
-  const [size, setSize] = useState<string | null>(null);
+  // No silent size (#60): a remembered size pre-selects a *visible* chip the
+  // buyer can change; with nothing remembered the CTA stays disabled until a
+  // pick.
+  const [size, setSize] = useState<string | null>(() => {
+    const s = remembered?.size;
+    return s && (getBlank(productId)?.sizes ?? []).includes(s) ? s : null;
+  });
   // The pinned backdrop color IS defaulted (the design is displayed on it),
   // but labeled below so it's not a silent pick.
   const pinnedColorApplied =

--- a/src/app/d/[imageId]/page.tsx
+++ b/src/app/d/[imageId]/page.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import { headers } from "next/headers";
 import { notFound } from "next/navigation";
 import { getPublishedImage } from "../actions";
+import { getLastPurchaseDefaults } from "@/app/preview/actions";
 import { auth, isAnonymousUser } from "@/lib/auth";
 import { Breadcrumbs } from "@/components/breadcrumbs";
 import { breadcrumbTrail } from "@/lib/nav";
@@ -29,6 +30,10 @@ export default async function PublishedImagePage({
   // purchase point requires a real account. A guest sees "Sign in to buy".
   const isLoggedIn = Boolean(session) && !isAnonymousUser(session?.user);
   const isOwner = session?.user.id === img.designerId;
+
+  // Remembered defaults (#44, §8 Q3): last purchase seeds product + size.
+  // Null for guests/first purchase — the panel then starts unselected.
+  const remembered = await getLastPurchaseDefaults();
 
   const trail = breadcrumbTrail(`/d/${imageId}`, { from });
   const up = trail.length > 0 ? trail[trail.length - 1] : null;
@@ -95,6 +100,7 @@ export default async function PublishedImagePage({
             imageId={img.imageId}
             isLoggedIn={isLoggedIn}
             preferredColor={img.backgroundColor}
+            remembered={remembered}
           />
         </div>
       </main>

--- a/src/app/design/actions.ts
+++ b/src/app/design/actions.ts
@@ -444,7 +444,19 @@ export async function getDesign(designId: string) {
   // consume `displayImageUrl` rather than touching design_image rows
   // directly).
   const displayImageUrl = await getDesignDisplayImageUrl(designId);
-  return { ...found, displayImageUrl };
+
+  // Primary image's pinned backdrop color (#16) — /preview's color default
+  // (§3): the design was published on this color, so show it on it.
+  let backgroundColor: string | null = null;
+  if (found.primaryImageId) {
+    const primary = await db.query.designImage.findFirst({
+      where: eq(designImageTable.id, found.primaryImageId),
+      columns: { backgroundColor: true },
+    });
+    backgroundColor = primary?.backgroundColor ?? null;
+  }
+
+  return { ...found, displayImageUrl, backgroundColor };
 }
 
 /**

--- a/src/app/preview/actions.ts
+++ b/src/app/preview/actions.ts
@@ -29,6 +29,8 @@ import {
   getBackSourceGroups,
   type BackSourceGroup,
 } from "@/lib/back-sources";
+import { resolveLastPurchaseDefaults } from "@/lib/last-purchase";
+import type { PurchaseDefaults } from "@/lib/purchase-defaults";
 
 const COST_PER_GENERATION = 0.03;
 
@@ -66,6 +68,18 @@ export async function getBackDesignSources(
     userId: isAnonymousUser(session.user) ? null : session.user.id,
   });
   return { groups };
+}
+
+/**
+ * Remembered defaults (#44, §3): the signed-in user's last purchase seeds
+ * product + size on the buy surfaces (/preview, /d, /shop). Null for guests —
+ * no localStorage fallback. Values are validated against the active catalog
+ * in resolveLastPurchaseDefaults.
+ */
+export async function getLastPurchaseDefaults(): Promise<PurchaseDefaults | null> {
+  const session = await auth.api.getSession({ headers: await headers() });
+  if (!session || isAnonymousUser(session.user)) return null;
+  return resolveLastPurchaseDefaults(db, session.user);
 }
 
 export async function generateMockup(

--- a/src/app/preview/page.tsx
+++ b/src/app/preview/page.tsx
@@ -11,7 +11,13 @@ import {
   ensureMockupsPrefetched,
   isMultiPlacementEnabled,
   getBackDesignSources,
+  getLastPurchaseDefaults,
 } from "./actions";
+import {
+  resolveProductAndSize,
+  resolveDefaultColor,
+  type PurchaseDefaults,
+} from "@/lib/purchase-defaults";
 import Link from "next/link";
 import { Button } from "@/components/ui";
 import { SizePicker, ColorPicker } from "@/components/product-options";
@@ -55,9 +61,24 @@ function PreviewPageInner() {
   const searchParams = useSearchParams();
   const designId = searchParams.get("id");
   const initialProductId = searchParams.get("product") ?? DEFAULT_BLANK_ID;
+  // URL params as they were on arrival (§3 precedence: URL wins). Captured
+  // once — the replaceState sync below rewrites the URL from state, so the
+  // live params stop meaning "what the link carried".
+  const initialUrl = useRef({
+    product: searchParams.get("product"),
+    size: searchParams.get("size"),
+    color: searchParams.get("color"),
+  }).current;
 
   const [productId, setProductId] = useState(initialProductId);
   const product = getBlank(productId);
+  // Remembered defaults (#44) + the design's pinned backdrop color. Both
+  // arrive async; they only fill selections the URL didn't set and the user
+  // hasn't touched (the *Touched refs).
+  const [remembered, setRemembered] = useState<PurchaseDefaults | null>(null);
+  const [pinnedColor, setPinnedColor] = useState<string | null>(null);
+  const productTouched = useRef(false);
+  const colorTouched = useRef(false);
 
   const [renderState, setRenderState] = useState<RenderState>({ status: "idle" });
   // Bumped to re-run the placement-render effect (retry after an error).
@@ -167,6 +188,7 @@ function PreviewPageInner() {
           return;
         }
         setHasPrimary(true);
+        setPinnedColor(design.backgroundColor ?? null);
         if (design.mockupUrls) {
           for (const [key, url] of Object.entries(design.mockupUrls)) {
             mockupCache.current.set(key, url as string);
@@ -199,6 +221,55 @@ function PreviewPageInner() {
   useEffect(() => {
     isCartEnabled().then(setCartShown).catch(() => setCartShown(false));
   }, []);
+
+  // Fetch remembered defaults once (#44). Null for guests/first purchase.
+  useEffect(() => {
+    getLastPurchaseDefaults()
+      .then((d) => {
+        if (d) setRemembered(d);
+      })
+      .catch(() => {});
+  }, []);
+
+  // Apply remembered product + size when they arrive (§3): URL param >
+  // remembered > static. Remembered size pre-selects a visible chip — never
+  // a silent default (#66); anything the user already picked wins.
+  useEffect(() => {
+    if (!remembered) return;
+    const resolved = resolveProductAndSize({
+      urlProduct: initialUrl.product,
+      urlSize: initialUrl.size,
+      remembered,
+    });
+    if (!productTouched.current && resolved.productId !== productId) {
+      handleProductChange(resolved.productId);
+    }
+    // Validate the size against the product actually on screen — the user
+    // may have switched products before the fetch landed.
+    const effectiveId = productTouched.current ? productId : resolved.productId;
+    const sizes = getBlank(effectiveId)?.sizes ?? [];
+    const candidate =
+      resolved.size && sizes.includes(resolved.size) ? resolved.size : null;
+    if (candidate) setSize((s) => s ?? candidate);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [remembered]);
+
+  // Color default (§3, not remembered): URL > pinned backdrop > White >
+  // first color. Re-derives when the product changes or the pinned color
+  // loads; a user pick sticks as long as the palette still offers it.
+  useEffect(() => {
+    const palette = product?.colors ?? [];
+    if (palette.length === 0) return;
+    if (colorTouched.current && palette.some((c) => c.name === colorName)) return;
+    colorTouched.current = false;
+    const { color } = resolveDefaultColor({
+      urlColor: initialUrl.color,
+      pinnedColor,
+      palette,
+    });
+    if (color !== colorName) handleColorChange(color);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [productId, pinnedColor]);
 
   // A picked back design prices + checks out only while the flag is on — the
   // server gates it again at checkout, defense in depth.
@@ -376,10 +447,15 @@ function PreviewPageInner() {
     if (newProductId === productId) return;
     const newProduct = getBlank(newProductId);
     if (!newProduct) return;
-    const newColor = newProduct.colors[0]?.name ?? "White";
     mockupReq.invalidate();
     setProductId(newProductId);
-    setColorName(newColor);
+    // Keep the color when the new product offers it; otherwise the color-
+    // default effect re-derives (pinned backdrop > White > first).
+    setColorName((c) =>
+      newProduct.colors.some((col) => col.name === c)
+        ? c
+        : newProduct.colors[0]?.name ?? "White"
+    );
     // Keep the size only if the new product offers it; otherwise back to
     // unselected (#60 — never silently carry an unavailable size).
     setSize((s) => (s && newProduct.sizes.includes(s) ? s : null));
@@ -725,7 +801,10 @@ function PreviewPageInner() {
               {ACTIVE_BLANKS.map((p) => (
                 <button
                   key={p.id}
-                  onClick={() => handleProductChange(p.id)}
+                  onClick={() => {
+                    productTouched.current = true;
+                    handleProductChange(p.id);
+                  }}
                   className={`flex-1 px-3 py-2 rounded-lg border-2 text-left transition-colors ${
                     productId === p.id
                       ? "border-accent ring-2 ring-accent ring-offset-1 ring-offset-background"
@@ -741,7 +820,19 @@ function PreviewPageInner() {
             </div>
           </div>
 
-          <ColorPicker colors={colors} value={colorName} onChange={handleColorChange} />
+          <ColorPicker
+            colors={colors}
+            value={colorName}
+            onChange={(name) => {
+              colorTouched.current = true;
+              handleColorChange(name);
+            }}
+            note={
+              pinnedColor && colorName === pinnedColor
+                ? "Designer's pick"
+                : undefined
+            }
+          />
           <SizePicker sizes={sizes} value={size} onChange={setSize} label={sizeLabel} />
 
           {/* Pricing (§8 Q4: full breakdown here; the mobile sticky bar repeats

--- a/src/app/shop/[slug]/[productId]/page.tsx
+++ b/src/app/shop/[slug]/[productId]/page.tsx
@@ -3,6 +3,7 @@ import { headers } from "next/headers";
 import { notFound } from "next/navigation";
 import { auth, isAnonymousUser } from "@/lib/auth";
 import { getStoreProductForBuy } from "../../actions";
+import { getLastPurchaseDefaults } from "@/app/preview/actions";
 import { StoreBuyPanel } from "./store-buy-panel";
 
 type Params = Promise<{ slug: string; productId: string }>;
@@ -18,6 +19,11 @@ export default async function StoreProductPage({ params }: { params: Params }) {
   // Anonymous (guest) sessions don't count for the buy CTA — purchase needs a
   // real account, same as the published-design buy flow.
   const isLoggedIn = Boolean(session) && !isAnonymousUser(session?.user);
+
+  // Remembered size (#44, §8 Q3) — the blank is fixed here (the organizer
+  // chose it), so only the size default applies; the panel validates it
+  // against this product's sizes.
+  const remembered = await getLastPurchaseDefaults();
 
   return (
     <div className="min-h-screen flex flex-col">
@@ -50,6 +56,7 @@ export default async function StoreProductPage({ params }: { params: Params }) {
             colors={detail.colors}
             isLoggedIn={isLoggedIn}
             buyable={detail.buyable}
+            rememberedSize={remembered?.size ?? null}
           />
         </div>
       </main>

--- a/src/app/shop/[slug]/[productId]/store-buy-panel.tsx
+++ b/src/app/shop/[slug]/[productId]/store-buy-panel.tsx
@@ -23,6 +23,7 @@ export function StoreBuyPanel({
   colors,
   isLoggedIn,
   buyable,
+  rememberedSize,
 }: {
   storeSlug: string;
   productId: string;
@@ -32,19 +33,28 @@ export function StoreBuyPanel({
   colors: BlankColor[];
   isLoggedIn: boolean;
   buyable: boolean;
+  /** Last-purchase size (#44); null for guests/first purchase. */
+  rememberedSize?: string | null;
 }) {
-  const [size, setSize] = useState(sizes[1] ?? sizes[0] ?? "M");
+  // No silent size (#60): a remembered size pre-selects a visible chip; with
+  // nothing remembered the buy CTA stays disabled until a pick.
+  const [size, setSize] = useState<string | null>(() =>
+    rememberedSize && sizes.includes(rememberedSize) ? rememberedSize : null
+  );
   const [color, setColor] = useState(colors[0]?.name ?? "White");
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   const signInHref = `/sign-in?next=/shop/${storeSlug}/${productId}`;
 
-  // Organizer price is size-independent; the computed fallback varies by size.
-  const itemPrice = fixedPrice ?? computePrice(0, blankId, size).total;
+  // Organizer price is size-independent; the computed fallback varies by
+  // size — before a pick it shows the base-size price.
+  const itemPrice =
+    fixedPrice ?? computePrice(0, blankId, size ?? sizes[0] ?? "M").total;
   const { item, shipping, total } = computeOrderTotal(itemPrice);
 
   async function handleBuy() {
+    if (!size) return;
     setLoading(true);
     setError(null);
     try {
@@ -96,9 +106,19 @@ export function StoreBuyPanel({
           Not listed yet — publish the shop and list this product to sell it.
         </p>
       ) : isLoggedIn ? (
-        <Button onClick={handleBuy} disabled={loading} size="lg" className="w-full">
-          {loading ? "Redirecting…" : `Buy — $${total.toFixed(2)}`}
-        </Button>
+        <div className="space-y-1.5">
+          {!size && (
+            <p className="text-sm text-text-muted text-center">Choose a size</p>
+          )}
+          <Button
+            onClick={handleBuy}
+            disabled={loading || !size}
+            size="lg"
+            className="w-full"
+          >
+            {loading ? "Redirecting…" : `Buy — $${total.toFixed(2)}`}
+          </Button>
+        </div>
       ) : (
         <Link href={signInHref} className="block">
           <Button size="lg" className="w-full">

--- a/src/lib/__tests__/last-purchase.integration.test.ts
+++ b/src/lib/__tests__/last-purchase.integration.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Remembered purchase defaults (#44) against a real in-memory DB: order +
+ * order_item rows are real, so status filtering, ordering, and the
+ * resolveOrderLines scalar/item split are exercised end to end.
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+import { createTestDb } from "./test-db";
+import { makeUser, makeDesign } from "./factories";
+import * as schema from "@/lib/db/schema";
+import { resolveLastPurchaseDefaults } from "@/lib/last-purchase";
+
+type Db = Awaited<ReturnType<typeof createTestDb>>;
+
+const USER = { id: "buyer-1" };
+
+async function seedOrder(
+  db: Db,
+  designId: string,
+  overrides: Partial<typeof schema.order.$inferInsert> = {}
+) {
+  const [row] = await db
+    .insert(schema.order)
+    .values({
+      userId: USER.id,
+      designId,
+      productId: "bella-canvas-3001",
+      size: "M",
+      color: "Black",
+      totalPrice: 24.12,
+      status: "paid",
+      ...overrides,
+    })
+    .returning();
+  return row;
+}
+
+describe("resolveLastPurchaseDefaults", () => {
+  let db: Db;
+  let designId: string;
+
+  beforeEach(async () => {
+    db = await createTestDb();
+    await makeUser(db, USER.id);
+    designId = (await makeDesign(db, USER.id)).id;
+  });
+
+  it("returns the last order's blank + size via its order_item row", async () => {
+    const order = await seedOrder(db, designId);
+    await db.insert(schema.orderItem).values({
+      orderId: order.id,
+      designId,
+      productId: "bella-canvas-6400",
+      size: "L",
+      color: "White",
+      itemPrice: 19.43,
+    });
+
+    expect(await resolveLastPurchaseDefaults(db, USER)).toEqual({
+      blankId: "bella-canvas-6400",
+      size: "L",
+    });
+  });
+
+  it("resolves legacy scalar orders with no order_item rows", async () => {
+    await seedOrder(db, designId, { size: "XL" });
+
+    expect(await resolveLastPurchaseDefaults(db, USER)).toEqual({
+      blankId: "bella-canvas-3001",
+      size: "XL",
+    });
+  });
+
+  it("uses the first line of a multi-item order (order_item by createdAt)", async () => {
+    const order = await seedOrder(db, designId);
+    const base = { orderId: order.id, designId, color: "Black", itemPrice: 19.43 };
+    // Inserted newest-first to prove ordering comes from createdAt, not
+    // insertion order.
+    await db.insert(schema.orderItem).values({
+      ...base,
+      productId: "cotton-heritage-mc1087",
+      size: "2XL",
+      createdAt: new Date("2026-07-02T00:00:10Z"),
+    });
+    await db.insert(schema.orderItem).values({
+      ...base,
+      productId: "bella-canvas-3001",
+      size: "S",
+      createdAt: new Date("2026-07-02T00:00:00Z"),
+    });
+
+    expect(await resolveLastPurchaseDefaults(db, USER)).toEqual({
+      blankId: "bella-canvas-3001",
+      size: "S",
+    });
+  });
+
+  it("skips pending and canceled orders, even when newer", async () => {
+    await seedOrder(db, designId, {
+      size: "L",
+      createdAt: new Date("2026-07-01T00:00:00Z"),
+    });
+    await seedOrder(db, designId, {
+      size: "S",
+      status: "pending",
+      createdAt: new Date("2026-07-02T00:00:00Z"),
+    });
+    await seedOrder(db, designId, {
+      size: "2XL",
+      status: "canceled",
+      createdAt: new Date("2026-07-03T00:00:00Z"),
+    });
+
+    expect(await resolveLastPurchaseDefaults(db, USER)).toEqual({
+      blankId: "bella-canvas-3001",
+      size: "L",
+    });
+  });
+
+  it("returns null with only pending/canceled history", async () => {
+    await seedOrder(db, designId, { status: "pending" });
+    await seedOrder(db, designId, { status: "canceled" });
+
+    expect(await resolveLastPurchaseDefaults(db, USER)).toBeNull();
+  });
+
+  it("returns null when the last blank is discontinued", async () => {
+    await seedOrder(db, designId, {
+      productId: "clear-case-iphone",
+      size: "iPhone 15",
+    });
+
+    expect(await resolveLastPurchaseDefaults(db, USER)).toBeNull();
+  });
+
+  it("drops a size the blank no longer offers, keeps the blank", async () => {
+    await seedOrder(db, designId, { size: "5XL" });
+
+    expect(await resolveLastPurchaseDefaults(db, USER)).toEqual({
+      blankId: "bella-canvas-3001",
+      size: null,
+    });
+  });
+
+  it("returns null for anonymous users regardless of history", async () => {
+    await seedOrder(db, designId, { size: "L" });
+
+    expect(
+      await resolveLastPurchaseDefaults(db, { id: USER.id, isAnonymous: true })
+    ).toBeNull();
+    expect(await resolveLastPurchaseDefaults(db, null)).toBeNull();
+  });
+});

--- a/src/lib/__tests__/purchase-defaults.test.ts
+++ b/src/lib/__tests__/purchase-defaults.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect } from "vitest";
+import {
+  resolveProductAndSize,
+  resolveDefaultColor,
+} from "@/lib/purchase-defaults";
+import { DEFAULT_BLANK_ID } from "@/lib/blanks";
+
+const remembered = { blankId: "bella-canvas-6400", size: "L" };
+
+describe("resolveProductAndSize", () => {
+  it("falls back to the static default with nothing remembered", () => {
+    expect(
+      resolveProductAndSize({ urlProduct: null, urlSize: null, remembered: null })
+    ).toEqual({ productId: DEFAULT_BLANK_ID, size: null });
+  });
+
+  it("uses the remembered blank + size when the URL has neither", () => {
+    expect(
+      resolveProductAndSize({ urlProduct: null, urlSize: null, remembered })
+    ).toEqual({ productId: "bella-canvas-6400", size: "L" });
+  });
+
+  it("URL product wins over remembered", () => {
+    const r = resolveProductAndSize({
+      urlProduct: "cotton-heritage-mc1087",
+      urlSize: null,
+      remembered,
+    });
+    expect(r.productId).toBe("cotton-heritage-mc1087");
+    // Remembered size still applies when the winning product offers it.
+    expect(r.size).toBe("L");
+  });
+
+  it("URL size wins over remembered size", () => {
+    expect(
+      resolveProductAndSize({ urlProduct: null, urlSize: "M", remembered })
+    ).toEqual({ productId: "bella-canvas-6400", size: "M" });
+  });
+
+  it("drops an URL size the winning product does not offer", () => {
+    const r = resolveProductAndSize({
+      urlProduct: DEFAULT_BLANK_ID, // 3001 has no 4XL
+      urlSize: "4XL",
+      remembered: null,
+    });
+    expect(r.size).toBeNull();
+  });
+
+  it("drops a remembered size the winning product does not offer", () => {
+    const r = resolveProductAndSize({
+      urlProduct: DEFAULT_BLANK_ID, // 3001 tops out at 2XL
+      urlSize: null,
+      remembered: { blankId: "cotton-heritage-mc1087", size: "4XL" },
+    });
+    expect(r).toEqual({ productId: DEFAULT_BLANK_ID, size: null });
+  });
+
+  it("ignores a discontinued or unknown URL product", () => {
+    expect(
+      resolveProductAndSize({
+        urlProduct: "clear-case-iphone",
+        urlSize: null,
+        remembered,
+      }).productId
+    ).toBe("bella-canvas-6400");
+    expect(
+      resolveProductAndSize({
+        urlProduct: "no-such-blank",
+        urlSize: null,
+        remembered: null,
+      }).productId
+    ).toBe(DEFAULT_BLANK_ID);
+  });
+});
+
+describe("resolveDefaultColor", () => {
+  const palette = [
+    { name: "Black", value: "#000000" },
+    { name: "White", value: "#ffffff" },
+    { name: "Navy", value: "#1f2a44" },
+  ];
+
+  it("URL color wins", () => {
+    expect(
+      resolveDefaultColor({ urlColor: "Navy", pinnedColor: "Black", palette })
+    ).toEqual({ color: "Navy", pinnedApplied: false });
+  });
+
+  it("pinned backdrop applies when the URL has no valid color", () => {
+    expect(
+      resolveDefaultColor({ urlColor: "Chartreuse", pinnedColor: "Black", palette })
+    ).toEqual({ color: "Black", pinnedApplied: true });
+  });
+
+  it("ignores a pinned color the palette lacks", () => {
+    expect(
+      resolveDefaultColor({ urlColor: null, pinnedColor: "Mauve", palette })
+    ).toEqual({ color: "White", pinnedApplied: false });
+  });
+
+  it("prefers White, else the first color", () => {
+    expect(
+      resolveDefaultColor({ urlColor: null, pinnedColor: null, palette })
+    ).toEqual({ color: "White", pinnedApplied: false });
+    expect(
+      resolveDefaultColor({
+        urlColor: null,
+        pinnedColor: null,
+        palette: [{ name: "Black", value: "#000000" }, { name: "Navy", value: "#1f2a44" }],
+      })
+    ).toEqual({ color: "Black", pinnedApplied: false });
+  });
+});

--- a/src/lib/last-purchase.ts
+++ b/src/lib/last-purchase.ts
@@ -1,0 +1,60 @@
+/**
+ * Remembered purchase defaults (#44, collapse plan §3): what product + size
+ * the user bought last, for pre-selecting the buy surfaces. Deps-injected db
+ * so the real-DB harness can exercise it.
+ *
+ * Guests/anonymous users get null — no localStorage fallback (§3); the claim
+ * flow re-parents orders on sign-in, so history follows the account.
+ */
+import { and, asc, desc, eq, notInArray } from "drizzle-orm";
+import {
+  order as orderTable,
+  orderItem as orderItemTable,
+} from "@/lib/db/schema";
+import { resolveOrderLines } from "@/lib/order-lines";
+import { ACTIVE_BLANKS } from "@/lib/blanks";
+import type { db as appDb } from "@/lib/db";
+import type { PurchaseDefaults } from "@/lib/purchase-defaults";
+
+type Db = typeof appDb;
+
+export async function resolveLastPurchaseDefaults(
+  db: Db,
+  user: { id: string; isAnonymous?: boolean | null } | null | undefined
+): Promise<PurchaseDefaults | null> {
+  if (!user || user.isAnonymous) return null;
+
+  // Most recent order that actually paid: pending never did, canceled
+  // shouldn't re-seed.
+  const [last] = await db
+    .select()
+    .from(orderTable)
+    .where(
+      and(
+        eq(orderTable.userId, user.id),
+        notInArray(orderTable.status, ["pending", "canceled"])
+      )
+    )
+    .orderBy(desc(orderTable.createdAt))
+    .limit(1);
+  if (!last) return null;
+
+  const items = await db
+    .select()
+    .from(orderItemTable)
+    .where(eq(orderItemTable.orderId, last.id))
+    .orderBy(asc(orderItemTable.createdAt));
+
+  const [line] = resolveOrderLines(last, items);
+  if (!line) return null;
+
+  // A discontinued blank never comes back as a default (#44); its size is
+  // meaningless without the blank, so the whole default drops.
+  const blank = ACTIVE_BLANKS.find((b) => b.id === line.blankId);
+  if (!blank) return null;
+
+  return {
+    blankId: blank.id,
+    size: blank.sizes.includes(line.size) ? line.size : null,
+  };
+}

--- a/src/lib/purchase-defaults.ts
+++ b/src/lib/purchase-defaults.ts
@@ -1,0 +1,73 @@
+/**
+ * Pure precedence helpers for buy-surface defaults (#44, collapse plan §3).
+ *
+ * For each control: URL param (validated) > remembered default > static
+ * default. Size is never silently defaulted (#66) — a remembered size
+ * pre-selects a visible chip; with nothing remembered it stays null and the
+ * CTA is gated. Color is NOT remembered: URL > the design's pinned backdrop
+ * (when the palette has it) > White > first color.
+ *
+ * No DB access here — the remembered value comes from
+ * `resolveLastPurchaseDefaults` (src/lib/last-purchase.ts).
+ */
+import {
+  ACTIVE_BLANKS,
+  DEFAULT_BLANK_ID,
+  getBlankOrThrow,
+  type BlankColor,
+} from "@/lib/blanks";
+
+export type PurchaseDefaults = {
+  /** Blank catalog id from the last purchase; always in ACTIVE_BLANKS. */
+  blankId: string;
+  /** Size from the last purchase when the blank still offers it, else null. */
+  size: string | null;
+};
+
+function activeBlank(id: string | null | undefined) {
+  return id ? ACTIVE_BLANKS.find((b) => b.id === id) : undefined;
+}
+
+/**
+ * Product + size precedence for a buy surface. URL values are validated
+ * against the active catalog (a discontinued blank in a stale deep link falls
+ * through, same as a discontinued remembered blank). Size validates against
+ * whichever blank won.
+ */
+export function resolveProductAndSize(params: {
+  urlProduct: string | null;
+  urlSize: string | null;
+  remembered: PurchaseDefaults | null;
+}): { productId: string; size: string | null } {
+  const { urlProduct, urlSize, remembered } = params;
+  const blank =
+    activeBlank(urlProduct) ??
+    activeBlank(remembered?.blankId) ??
+    getBlankOrThrow(DEFAULT_BLANK_ID);
+  const size =
+    urlSize && blank.sizes.includes(urlSize)
+      ? urlSize
+      : remembered?.size && blank.sizes.includes(remembered.size)
+        ? remembered.size
+        : null;
+  return { productId: blank.id, size };
+}
+
+/**
+ * Color precedence (§3, not remembered): URL > pinned backdrop > White >
+ * first color. `pinnedApplied` tells the caller to label the default
+ * ("Designer's pick") so it isn't a silent pick.
+ */
+export function resolveDefaultColor(params: {
+  urlColor: string | null;
+  pinnedColor: string | null;
+  palette: BlankColor[];
+}): { color: string; pinnedApplied: boolean } {
+  const { urlColor, pinnedColor, palette } = params;
+  const has = (name: string | null | undefined): name is string =>
+    !!name && palette.some((c) => c.name === name);
+  if (has(urlColor)) return { color: urlColor, pinnedApplied: false };
+  if (has(pinnedColor)) return { color: pinnedColor, pinnedApplied: true };
+  if (has("White")) return { color: "White", pinnedApplied: false };
+  return { color: palette[0]?.name ?? "White", pinnedApplied: false };
+}


### PR DESCRIPTION
Closes #44. Slice 3 of the preview+order collapse plan (§3, §7, §8 Q3). **Stacked on #84** — base is `feat/preview-order-collapse-1`, merge that first.

## What

Signed-in users get their last purchase's product + size pre-selected on every buy surface; guests and first-time buyers see no change. Precedence everywhere: **URL param (validated) > remembered default > static default.**

- `src/lib/last-purchase.ts` — `resolveLastPurchaseDefaults(db, user)`: most recent order with `status NOT IN ('pending','canceled')`, its `order_item` rows by `createdAt` (#41 convention), first line via `resolveOrderLines`. Discontinued blank → whole default dropped; size the blank no longer offers → size dropped, blank kept. Anonymous/guest → null (no localStorage, per §3).
- `src/lib/purchase-defaults.ts` — pure precedence helpers (`resolveProductAndSize`, `resolveDefaultColor`), unit-tested.
- `getLastPurchaseDefaults()` server action (preview/actions.ts), shared by `/preview`, `/d/[imageId]`, and `/shop/[slug]/[productId]` (§8 Q3).
- `/preview`: remembered values fill only what the arrival URL didn't set and the user hasn't touched. Color default now URL > pinned backdrop (`design_image.background_color` via `getDesign`, labeled "Designer's pick") > White > first color. Product switch keeps a still-valid color pick instead of always resetting.
- `/d` BuyPanel: remembered product + size as initial state; remembered size renders as a visibly selected chip (never silent, #66).
- Shop `StoreBuyPanel`: the silent `sizes[1]` default is gone — size starts null (or remembered), buy CTA gated with the "Choose a size" hint. Blank is fixed there, so only the size default applies.

## Tests

- `last-purchase.integration.test.ts` (real-DB harness + shared factories, 8 tests): happy path via order_item, legacy scalar orders, multi-item first-line-by-createdAt, pending/canceled excluded, only-pending/canceled → null, discontinued blank → null, invalid size → size dropped, anonymous → null.
- `purchase-defaults.test.ts` (11 tests): full precedence matrix for product/size and color.

`npm run lint` (0 errors), `npm test` (574 passed), `npm run build` (CI env) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)