### PR TITLE
fix: thumbnail strip replaces numbered gallery FAB on /design mobile

### DIFF
--- a/src/app/design/chat-panel.tsx
+++ b/src/app/design/chat-panel.tsx
@@ -32,6 +32,7 @@ export function ChatPanel({
   options,
   onUploadImage,
   isEmpty,
+  mobileGalleryStrip,
 }: {
   messages: ChatMessage[];
   images: DesignImage[];
@@ -43,6 +44,9 @@ export function ChatPanel({
   options: ChatOption[];
   onUploadImage: (base64: string, fileName: string) => void;
   isEmpty: boolean;
+  // Mobile-only thumbnail strip, docked directly above the composer so it
+  // reserves layout space instead of floating over content.
+  mobileGalleryStrip?: React.ReactNode;
 }) {
   const urlByImageId = useMemo(
     () => new Map(images.map((img) => [img.id, img.url])),
@@ -285,6 +289,8 @@ export function ChatPanel({
           Add more detail, or tap Generate.
         </div>
       )}
+
+      {mobileGalleryStrip}
 
       {/* Composer — phone-first: input on its own row, actions wrap below,
           every control ≥44px. */}

--- a/src/app/design/mobile-gallery-strip.tsx
+++ b/src/app/design/mobile-gallery-strip.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import type { DesignImage, ProductVersionGroup } from "@/lib/design-images";
+
+// Mobile-only strip docked above the composer: real thumbnails of the
+// generated previews (newest first, selected one highlighted), horizontally
+// scrollable. Tapping a thumbnail opens the lightbox; the "All" tile opens
+// the full gallery drawer (product versions + Make Products live there).
+// Replaces the numbered FAB, which floated over content and didn't read as
+// "your previews".
+export function MobileGalleryStrip({
+  images,
+  productGroups,
+  selectedImage,
+  generating,
+  onClickImage,
+  onOpenDrawer,
+}: {
+  images: DesignImage[];
+  productGroups: ProductVersionGroup[];
+  selectedImage: string | null;
+  generating: boolean;
+  onClickImage: (index: number) => void;
+  onOpenDrawer: () => void;
+}) {
+  if (images.length === 0 && productGroups.length === 0 && !generating) {
+    return null;
+  }
+
+  // Newest first so the latest render is in view without scrolling.
+  const ordered = images.map((img, index) => ({ img, index })).reverse();
+
+  return (
+    <div
+      className="md:hidden border-t border-border"
+      data-testid="mobile-gallery-strip"
+    >
+      <div className="flex items-center gap-2 overflow-x-auto px-3 py-2">
+        {generating && (
+          <div
+            className="shrink-0 w-14 h-14 rounded-md border-2 border-border bg-surface animate-pulse"
+            aria-label="Generating"
+          />
+        )}
+        {ordered.map(({ img, index }) => (
+          <button
+            key={img.id ?? img.number}
+            type="button"
+            onClick={() => onClickImage(index)}
+            aria-label={`Preview #${img.number}`}
+            className={`shrink-0 w-14 h-14 rounded-md overflow-hidden border-2 bg-gray-900 transition-colors ${
+              selectedImage === img.url ? "border-accent" : "border-border"
+            }`}
+          >
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              src={img.url}
+              alt={`Preview #${img.number}`}
+              className="w-full h-full object-contain"
+            />
+          </button>
+        ))}
+        <button
+          type="button"
+          onClick={onOpenDrawer}
+          data-testid="mobile-gallery-all"
+          className="shrink-0 min-w-[56px] h-14 px-2 rounded-md border-2 border-border text-xs text-text-muted hover:text-foreground hover:border-border-hover transition-colors"
+        >
+          All
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/app/design/page.tsx
+++ b/src/app/design/page.tsx
@@ -20,6 +20,7 @@ import { ChatPanel } from "./chat-panel";
 import { ImageGallery } from "./image-gallery";
 import { ImageLightbox } from "./image-lightbox";
 import { MobileGalleryDrawer } from "./mobile-gallery-drawer";
+import { MobileGalleryStrip } from "./mobile-gallery-strip";
 import { Breadcrumbs } from "@/components/breadcrumbs";
 import { breadcrumbTrail } from "@/lib/nav";
 import { isDesignEmpty } from "@/lib/design-view";
@@ -164,13 +165,11 @@ function DesignPageInner() {
       setOptions("options" in result ? (result.options ?? []) : []);
       // Claude may answer with a clarifying question instead of an image
       // (no imageUrl) — just show the message, no gallery/drawer changes.
+      // The new render lands inline in chat and leads the mobile thumbnail
+      // strip — no drawer auto-open needed.
       if (result.imageUrl) {
         setSelectedImage(result.imageUrl);
         await refreshGallery();
-        // Auto-open gallery drawer on mobile
-        if (window.matchMedia("(max-width: 767px)").matches) {
-          setDrawerOpen(true);
-        }
       }
     } catch {
       setMessages((prev) => [
@@ -294,6 +293,16 @@ function DesignPageInner() {
           options={options}
           onUploadImage={handleUploadImage}
           isEmpty={empty}
+          mobileGalleryStrip={
+            <MobileGalleryStrip
+              images={images}
+              productGroups={productGroups}
+              selectedImage={selectedImage}
+              generating={generating}
+              onClickImage={(i) => setLightboxIndex(i)}
+              onOpenDrawer={() => setDrawerOpen(true)}
+            />
+          }
         />
         {!empty && (
           <ImageGallery
@@ -307,16 +316,6 @@ function DesignPageInner() {
           />
         )}
       </div>
-
-      {/* Mobile gallery toggle */}
-      {(images.length > 0 || productGroups.length > 0) && (
-        <button
-          onClick={() => setDrawerOpen(true)}
-          className="fixed bottom-20 right-4 z-30 md:hidden w-12 h-12 rounded-full bg-accent text-accent-fg shadow-lg flex items-center justify-center"
-        >
-          <span className="text-sm font-bold">{images.length}</span>
-        </button>
-      )}
 
       {/* Mobile gallery drawer */}
       <MobileGalleryDrawer


### PR DESCRIPTION
From Nico's iPhone smoke: the round FAB showing only an image count was the sole path to generated previews on mobile — it read as nothing and floated over content.

## What changed

- New `src/app/design/mobile-gallery-strip.tsx` — mobile-only (`md:hidden`) horizontal strip docked directly above the composer, rendered via a `mobileGalleryStrip` slot prop on `ChatPanel` so it reserves layout space (covers no chat, composer, or Generate button).
  - Real 56px thumbnails, newest first, horizontally scrollable; selected image gets the accent border.
  - Tap a thumbnail → existing lightbox (`onClickImage`, original index preserved).
  - "All" tail tile → opens `MobileGalleryDrawer` (full gallery + product versions + Make Products, unchanged).
  - Shimmer placeholder tile leads the strip while a generation is in flight.
  - Touch targets 56px (≥44px); semantic tokens throughout.
- Removed the FAB from `page.tsx`.
- Removed the drawer auto-open after a successful generation — the new render appears inline in chat and leads the strip, so hijacking the screen with the drawer is no longer needed.

Desktop `ImageGallery` column untouched. No e2e specs referenced the old FAB.

## Testing

- `npm run lint` — 0 errors (16 pre-existing warnings)
- `npm test` — 578 passed
- `npm run build` — clean (CI dummy env)

🤖 Generated with [Claude Code](https://claude.com/claude-code)