### PR TITLE
fix: menu polish — build date, sign-out contrast, outside-click, admin entry

### DIFF
--- a/src/app/admin/actions.ts
+++ b/src/app/admin/actions.ts
@@ -35,6 +35,7 @@ import {
   getDesignImageById,
 } from "@/lib/design-images";
 import { designerAttribution } from "@/lib/order-attribution";
+import { isAdminEmail } from "@/lib/admin";
 
 // Second user join (the design's owner) needs an alias to coexist with the
 // buyer join on the same query.
@@ -43,6 +44,15 @@ const designerUser = alias(userTable, "designer_user");
 const ADMIN_EMAIL = process.env.ADMIN_EMAIL;
 if (!ADMIN_EMAIL) {
   throw new Error("ADMIN_EMAIL env var is required");
+}
+
+/**
+ * Whether the current session belongs to the admin. Client-readable (drives
+ * the nav's Admin entry) — returns only a boolean, never the admin email.
+ */
+export async function isAdminUser(): Promise<boolean> {
+  const session = await auth.api.getSession({ headers: await headers() });
+  return isAdminEmail(session?.user?.email, ADMIN_EMAIL);
 }
 
 export async function getOrders() {

--- a/src/components/site-header.tsx
+++ b/src/components/site-header.tsx
@@ -1,11 +1,12 @@
 "use client";
 
 import Link from "next/link";
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { usePathname } from "next/navigation";
 import { authClient } from "@/lib/auth-client";
 import { getCartCount, isCartEnabled } from "@/app/cart/actions";
 import { isStoresEnabled } from "@/app/dashboard/actions";
+import { isAdminUser } from "@/app/admin/actions";
 import { FeedbackPanel } from "@/components/feedback-launcher";
 import { FEEDBACK_PROJECT_ID } from "@/lib/feedback/project-id";
 
@@ -41,6 +42,46 @@ export function SiteHeader() {
     isStoresEnabled().then(setShowDashboard).catch(() => setShowDashboard(false));
   }, []);
 
+  // Admin nav entry — server action returns only a boolean (never the admin
+  // email), so ADMIN_EMAIL stays out of the client bundle. Re-checked when the
+  // session user changes (sign-in/out).
+  const [isAdmin, setIsAdmin] = useState(false);
+  useEffect(() => {
+    isAdminUser().then(setIsAdmin).catch(() => setIsAdmin(false));
+  }, [session?.user?.id]);
+
+  // Outside-click + Escape dismissal for the mobile dropdown. pointerdown so
+  // the menu closes before the tap's click lands elsewhere; the hamburger is
+  // excluded or its toggle would re-open the menu it just closed. Escape
+  // preventDefaults so page-level Escape-to-go-up (Breadcrumbs) skips it.
+  const menuRef = useRef<HTMLDivElement>(null);
+  const menuButtonRef = useRef<HTMLButtonElement>(null);
+  useEffect(() => {
+    if (!menuOpen) return;
+    function onPointerDown(e: PointerEvent) {
+      const target = e.target as Node;
+      if (
+        menuRef.current?.contains(target) ||
+        menuButtonRef.current?.contains(target)
+      ) {
+        return;
+      }
+      setMenuOpen(false);
+    }
+    function onKeyDown(e: KeyboardEvent) {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        setMenuOpen(false);
+      }
+    }
+    document.addEventListener("pointerdown", onPointerDown);
+    document.addEventListener("keydown", onKeyDown);
+    return () => {
+      document.removeEventListener("pointerdown", onPointerDown);
+      document.removeEventListener("keydown", onKeyDown);
+    };
+  }, [menuOpen]);
+
   // Guest-funnel (#26) anonymous sessions don't count as signed-in for the nav:
   // a guest sees the signed-out nav ("Sign in"), not "Sign out" + the gated
   // personal links (/designs, /orders still redirect anon to sign-in).
@@ -58,6 +99,7 @@ export function SiteHeader() {
         ...(showDashboard ? [{ href: "/dashboard", label: "Dashboard" }] : []),
         { href: "/designs", label: "My Designs" },
         { href: "/orders", label: "Orders" },
+        ...(isAdmin ? [{ href: "/admin", label: "Admin" }] : []),
       ]
     : [{ href: "/prints", label: "Shop" }];
 
@@ -119,6 +161,7 @@ export function SiteHeader() {
 
         {/* Mobile: hamburger */}
         <button
+          ref={menuButtonRef}
           onClick={() => setMenuOpen((o) => !o)}
           aria-label="Menu"
           aria-expanded={menuOpen}
@@ -133,7 +176,10 @@ export function SiteHeader() {
       {/* Mobile dropdown — anchored to the right edge under the hamburger,
           solid raised panel so it reads over page content. */}
       {menuOpen && (
-        <div className="sm:hidden absolute right-2 top-full z-50 mt-1 w-64 max-w-[calc(100vw-1rem)] flex flex-col rounded-md border border-border bg-surface-raised py-1 shadow-lg shadow-black/60">
+        <div
+          ref={menuRef}
+          className="sm:hidden absolute right-2 top-full z-50 mt-1 w-64 max-w-[calc(100vw-1rem)] flex flex-col rounded-md border border-border bg-surface-raised py-1 shadow-lg shadow-black/60"
+        >
           {links.map((l) => (
             <Link
               key={l.href}
@@ -165,7 +211,7 @@ export function SiteHeader() {
           {isAuthed ? (
             <button
               onClick={signOut}
-              className="flex min-h-11 items-center justify-end px-4 text-lg text-text-muted hover:text-foreground hover:bg-surface transition-colors"
+              className="flex min-h-11 items-center justify-end px-4 text-lg text-foreground hover:bg-surface transition-colors"
             >
               Sign out
             </button>
@@ -178,6 +224,9 @@ export function SiteHeader() {
               Sign in
             </Link>
           )}
+          <span className="px-4 pt-2 pb-1 text-right text-[10px] leading-none text-text-faint font-mono">
+            {buildDate}
+          </span>
         </div>
       )}
 

--- a/src/lib/__tests__/admin.test.ts
+++ b/src/lib/__tests__/admin.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+import { isAdminEmail } from "@/lib/admin";
+
+describe("isAdminEmail", () => {
+  it("matches when both emails are equal", () => {
+    expect(isAdminEmail("admin@example.com", "admin@example.com")).toBe(true);
+  });
+
+  it("rejects a different email", () => {
+    expect(isAdminEmail("user@example.com", "admin@example.com")).toBe(false);
+  });
+
+  it("rejects when the session has no email", () => {
+    expect(isAdminEmail(undefined, "admin@example.com")).toBe(false);
+    expect(isAdminEmail(null, "admin@example.com")).toBe(false);
+  });
+
+  it("matches nothing when the admin email is unset", () => {
+    expect(isAdminEmail("admin@example.com", undefined)).toBe(false);
+    expect(isAdminEmail("admin@example.com", "")).toBe(false);
+    // Both missing must not match either.
+    expect(isAdminEmail(undefined, undefined)).toBe(false);
+  });
+
+  it("is case-sensitive (exact match, same as the /admin gate)", () => {
+    expect(isAdminEmail("Admin@example.com", "admin@example.com")).toBe(false);
+  });
+});

--- a/src/lib/admin.ts
+++ b/src/lib/admin.ts
@@ -1,0 +1,11 @@
+/**
+ * True when a session email matches the configured admin email. Pure so the
+ * comparison is testable; callers pass process.env.ADMIN_EMAIL server-side.
+ * An unset admin email matches nothing.
+ */
+export function isAdminEmail(
+  email: string | null | undefined,
+  adminEmail: string | null | undefined
+): boolean {
+  return Boolean(adminEmail) && email === adminEmail;
+}


### PR DESCRIPTION
Four fixes from Nico's iPhone smoke of prod, all in the site header.

## Changes

- **Build date in the menu.** `NEXT_PUBLIC_BUILD_DATE` renders as a tiny muted mono line at the bottom of the mobile dropdown panel. Desktop keeps its existing header placement (the dropdown only exists under `sm`).
- **Sign out contrast.** Dropdown Sign out was `text-text-muted` (read as disabled); now `text-foreground` like the other items. Desktop hierarchy untouched.
- **Outside-click dismissal.** `pointerdown` listener closes the open dropdown on any tap outside the panel; the hamburger is excluded so its toggle doesn't re-open a just-closed menu. Escape also closes, with `preventDefault` so page-level Escape-to-go-up (Breadcrumbs) skips the keystroke. Close-on-item-tap unchanged.
- **Admin menu entry.** New `isAdminUser()` server action in `src/app/admin/actions.ts` compares the session email to `ADMIN_EMAIL` server-side via a pure `isAdminEmail` helper (`src/lib/admin.ts`, unit-tested) and returns only a boolean — `ADMIN_EMAIL` never reaches the client bundle. The header fetches it in a `useEffect` keyed on the session user (same pattern as `isCartEnabled`/`isStoresEnabled`) and appends an "Admin" link to `/admin` in both desktop nav and mobile dropdown. Guests, anon, and regular users never see it.

## Checks

- `npm run lint` — 0 errors
- `npm run typecheck` — clean
- `npm test` — 597 tests pass (includes 5 new `isAdminEmail` tests)
- `npm run build` — clean (CI dummy env)

🤖 Generated with [Claude Code](https://claude.com/claude-code)