### PR TITLE
fix: color palette derives from selected product (regression from #86)

### DIFF
--- a/src/app/d/[imageId]/__tests__/buy-panel.test.tsx
+++ b/src/app/d/[imageId]/__tests__/buy-panel.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
+import { getBlankOrThrow } from "@/lib/blanks";
 import { BuyPanel } from "../buy-panel";
 
 vi.mock("../../actions", () => ({
@@ -38,5 +39,77 @@ describe("BuyPanel size gate (#60)", () => {
   it("shows no designer's-pick note without a pinned color", () => {
     render(<BuyPanel imageId="img-1" isLoggedIn />);
     expect(screen.queryByText(/designer's pick/)).not.toBeInTheDocument();
+  });
+});
+
+// Regression guards for the #86 fallout: the swatch row must always be
+// exactly the selected product's palette, and a selection invalidated by a
+// product switch resets per the §3 precedence (pinned backdrop > White >
+// first) instead of an ad-hoc first-color pick.
+const CLASSIC = "bella-canvas-3001";
+const BOX = "cotton-heritage-mc1087";
+const classicColors = getBlankOrThrow(CLASSIC).colors.map((c) => c.name);
+const boxColors = getBlankOrThrow(BOX).colors.map((c) => c.name);
+
+/** Color swatches are the only buttons carrying a title attribute. */
+function swatchNames() {
+  return screen
+    .getAllByRole("button")
+    .filter((b) => b.hasAttribute("title"))
+    .map((b) => b.getAttribute("title"));
+}
+
+describe("BuyPanel color palette derives from the selected product", () => {
+  it("renders exactly the default product's colors", () => {
+    render(<BuyPanel imageId="img-1" isLoggedIn />);
+    expect(swatchNames()).toEqual(classicColors);
+  });
+
+  it("a remembered product seeds its own palette, not the default's", () => {
+    render(
+      <BuyPanel
+        imageId="img-1"
+        isLoggedIn
+        remembered={{ blankId: BOX, size: null }}
+      />
+    );
+    expect(swatchNames()).toEqual(boxColors);
+  });
+
+  it("switching product replaces the palette entirely", () => {
+    render(<BuyPanel imageId="img-1" isLoggedIn />);
+    fireEvent.click(screen.getByRole("button", { name: "Box Tee" }));
+    // Exact equality: every Box Tee color, nothing carried over.
+    expect(swatchNames()).toEqual(boxColors);
+    expect(screen.queryByTitle("Sage")).not.toBeInTheDocument();
+    // And back: the full Classic palette returns.
+    fireEvent.click(screen.getByRole("button", { name: "Classic Tee" }));
+    expect(swatchNames()).toEqual(classicColors);
+  });
+
+  it("re-applies the pinned backdrop when a switch invalidates the pick", () => {
+    // Pinned Black is valid on both products. The user's Sage pick dies with
+    // the switch to Box Tee, so the reset goes back to the designer's pick —
+    // not to whatever color happens to be first in the new palette.
+    render(<BuyPanel imageId="img-1" isLoggedIn preferredColor="Black" />);
+    fireEvent.click(screen.getByTitle("Sage"));
+    expect(screen.getByText("Color — Sage")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Box Tee" }));
+    expect(screen.getByText("Color — Black")).toBeInTheDocument();
+  });
+
+  it("falls back to White when the pinned backdrop is invalid too", () => {
+    // Tan exists on the Classic Tee only.
+    render(<BuyPanel imageId="img-1" isLoggedIn preferredColor="Tan" />);
+    fireEvent.click(screen.getByTitle("Sage"));
+    fireEvent.click(screen.getByRole("button", { name: "Box Tee" }));
+    expect(screen.getByText("Color — White")).toBeInTheDocument();
+  });
+
+  it("keeps a still-valid pick across a product switch", () => {
+    render(<BuyPanel imageId="img-1" isLoggedIn />);
+    fireEvent.click(screen.getByTitle("Black"));
+    fireEvent.click(screen.getByRole("button", { name: "Box Tee" }));
+    expect(screen.getByText("Color — Black")).toBeInTheDocument();
   });
 });

--- a/src/app/d/[imageId]/buy-panel.tsx
+++ b/src/app/d/[imageId]/buy-panel.tsx
@@ -6,7 +6,10 @@ import { Button } from "@/components/ui";
 import { SizePicker, ColorPicker } from "@/components/product-options";
 import { ACTIVE_BLANKS, DEFAULT_BLANK_ID, getBlank } from "@/lib/blanks";
 import { computePrice, computeOrderTotal } from "@/lib/pricing";
-import type { PurchaseDefaults } from "@/lib/purchase-defaults";
+import {
+  resolveDefaultColor,
+  type PurchaseDefaults,
+} from "@/lib/purchase-defaults";
 import { buyPublishedDesign } from "../actions";
 
 /**
@@ -51,21 +54,32 @@ export function BuyPanel({
   const pinnedColorApplied =
     !!preferredColor && colors.some((c) => c.name === preferredColor);
   const [color, setColor] = useState<string>(
-    pinnedColorApplied && preferredColor
-      ? preferredColor
-      : colors[0]?.name ?? "White"
+    () =>
+      resolveDefaultColor({
+        urlColor: null,
+        pinnedColor: preferredColor ?? null,
+        palette: colors,
+      }).color
   );
   const [loading, setLoading] = useState(false);
 
   // Switching product can invalidate the current size/color. Size resets to
-  // unselected (never silently re-picked); color clamps to the new options.
+  // unselected (never silently re-picked); an invalidated color resets per
+  // the §3 precedence — pinned backdrop when the new palette has it, else
+  // White, else first — never a carryover from the old palette.
   function handleProduct(id: string) {
     const next = getBlank(id);
     if (!next) return;
     setProductId(id);
     if (size && !next.sizes.includes(size)) setSize(null);
     if (!next.colors.some((c) => c.name === color)) {
-      setColor(next.colors[0]?.name ?? "White");
+      setColor(
+        resolveDefaultColor({
+          urlColor: null,
+          pinnedColor: preferredColor ?? null,
+          palette: next.colors,
+        }).color
+      );
     }
   }
 

--- a/src/app/preview/page.tsx
+++ b/src/app/preview/page.tsx
@@ -452,12 +452,18 @@ function PreviewPageInner() {
     if (!newProduct) return;
     mockupReq.invalidate();
     setProductId(newProductId);
-    // Keep the color when the new product offers it; otherwise the color-
-    // default effect re-derives (pinned backdrop > White > first).
+    // Keep the color when the new product offers it; otherwise reset per the
+    // §3 precedence (URL > pinned backdrop > White > first) right here — not
+    // colors[0] — so the swatch selection and the mockup fetch never spend a
+    // frame on a color the precedence wouldn't pick.
     setColorName((c) =>
       newProduct.colors.some((col) => col.name === c)
         ? c
-        : newProduct.colors[0]?.name ?? "White"
+        : resolveDefaultColor({
+            urlColor: initialUrl.color,
+            pinnedColor,
+            palette: newProduct.colors,
+          }).color
     );
     // Keep the size only if the new product offers it; otherwise back to
     // unselected (#60 — never silently carry an unavailable size).


### PR DESCRIPTION
## Report

Prod screenshot: /d/[imageId] with Box Tee selected showed 5 swatches (white / dark / navy / dark gray / cream) that looked wrong — "colors are by product, we lost that."

## What reproduction found

Reproduced the flow live on prntd.org before changing code: the swatch row DOES re-derive per product on all three panels — with Box Tee selected the 5 swatches are exactly Box Tee's catalog palette (White, Black, Navy Blazer, Vintage Black, Vintage White — the last two render as dark-gray/cream placeholder hexes in `blanks.ts`). No other product's colors leak into the list. Two things changed with #86 that produce the reported experience:

1. **Remembered-product seeding** now lands you on your last-purchased blank (e.g. Box Tee) instead of the Classic Tee, so the color row shows an unfamiliar 5-color palette while the design above still displays on its pinned Classic-Tee backdrop.
2. **Real defect:** when a product switch invalidates the current color, `BuyPanel` reset to `next.colors[0]` — the §3 precedence (pinned backdrop > White > first) was implemented on /preview but not here, so the designer's pick was never re-applied even when the new palette offers it. /preview had the same `colors[0]` pick for one frame (and fired a mockup fetch for it) before its color-default effect corrected it.

## Fix

- `src/app/d/[imageId]/buy-panel.tsx`: initial color and switch-reset go through `resolveDefaultColor` (pinned > White > first).
- `src/app/preview/page.tsx`: `handleProductChange`'s clamp uses `resolveDefaultColor` (URL > pinned > White > first) directly — no wrong-color frame/fetch.
- `/shop/[slug]/[productId]` store panel: blank is fixed (no product switch), palette is a server prop from that blank — no change needed.

## Tests (written first, TDD)

New suite in `src/app/d/[imageId]/__tests__/buy-panel.test.tsx`:
- swatch list is exactly the selected product's `colors` (Classic vs Box Tee)
- a remembered product seeds its own palette, not the default's
- switching product replaces the palette entirely — no carryover, and back again
- an invalidated pick resets to the pinned backdrop when the new palette has it — **failed against the old code** (`Color — White` instead of `Color — Black`), passes after
- pinned invalid too → White; a still-valid pick survives the switch

598 tests, lint (0 errors), and the CI-env build all pass.

## Note for review

If the underlying complaint is the remembered product switching the panel away from the design's pinned presentation at all (Box Tee can never show a Tan pinned color), that's a §3 precedence product call — flagging rather than deciding it here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)