### PR TITLE
feat: back design on the published-design buy page

### DIFF
--- a/src/app/d/[imageId]/__tests__/buy-panel.test.tsx
+++ b/src/app/d/[imageId]/__tests__/buy-panel.test.tsx
@@ -5,6 +5,15 @@ import { BuyPanel } from "../buy-panel";
 
 vi.mock("../../actions", () => ({
   buyPublishedDesign: vi.fn().mockResolvedValue({ url: null, needsAuth: false }),
+  getBuyPageBackSources: vi.fn().mockResolvedValue({
+    groups: [
+      {
+        id: "my-designs",
+        label: "My designs",
+        images: [{ id: "back-1", imageUrl: "https://img.example/back-1.png" }],
+      },
+    ],
+  }),
 }));
 
 import { buyPublishedDesign } from "../../actions";
@@ -111,5 +120,56 @@ describe("BuyPanel color palette derives from the selected product", () => {
     fireEvent.click(screen.getByTitle("Black"));
     fireEvent.click(screen.getByRole("button", { name: "Box Tee" }));
     expect(screen.getByText("Color — Black")).toBeInTheDocument();
+  });
+});
+
+describe("BuyPanel back design (#25 on /d)", () => {
+  it("hides the affordance without backEnabled", () => {
+    render(<BuyPanel imageId="img-1" isLoggedIn />);
+    expect(screen.queryByText(/Add a back design/)).not.toBeInTheDocument();
+  });
+
+  async function pickBack() {
+    fireEvent.click(screen.getByText(/Add a back design/));
+    fireEvent.click(
+      await screen.findByRole("button", { name: "My designs option" })
+    );
+  }
+
+  it("picking a source adds the +$8 line and updates the total", async () => {
+    render(<BuyPanel imageId="img-1" isLoggedIn backEnabled />);
+    await pickBack();
+
+    // Both the picked row and the price line label it.
+    expect(screen.getAllByText("Back design").length).toBeGreaterThan(0);
+    expect(screen.getByText("+$8.00")).toBeInTheDocument();
+    // $19.43 front + $8.00 back + $4.69 shipping.
+    fireEvent.click(screen.getByRole("button", { name: "M" }));
+    expect(
+      screen.getAllByRole("button", { name: "Order — $32.12" }).length
+    ).toBeGreaterThan(0);
+  });
+
+  it("passes the picked back image to buyPublishedDesign", async () => {
+    render(<BuyPanel imageId="img-1" isLoggedIn backEnabled />);
+    await pickBack();
+    fireEvent.click(screen.getByRole("button", { name: "M" }));
+    fireEvent.click(buyButton());
+    expect(buyPublishedDesign).toHaveBeenCalledWith(
+      expect.objectContaining({ backImageId: "back-1" })
+    );
+  });
+
+  it("the remove affordance clears the back and the upcharge", async () => {
+    render(<BuyPanel imageId="img-1" isLoggedIn backEnabled />);
+    await pickBack();
+    fireEvent.click(
+      screen.getByRole("button", { name: "Remove back design" })
+    );
+    expect(screen.queryByText("+$8.00")).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "M" }));
+    expect(
+      screen.getAllByRole("button", { name: "Order — $24.12" }).length
+    ).toBeGreaterThan(0);
   });
 });

--- a/src/app/d/[imageId]/buy-panel.tsx
+++ b/src/app/d/[imageId]/buy-panel.tsx
@@ -5,12 +5,17 @@ import Link from "next/link";
 import { Button } from "@/components/ui";
 import { SizePicker, ColorPicker } from "@/components/product-options";
 import { ACTIVE_BLANKS, DEFAULT_BLANK_ID, getBlank } from "@/lib/blanks";
-import { computePrice, computeOrderTotal } from "@/lib/pricing";
+import {
+  computePrice,
+  computeOrderTotal,
+  BACK_PLACEMENT_UPCHARGE,
+} from "@/lib/pricing";
 import {
   resolveDefaultColor,
   type PurchaseDefaults,
 } from "@/lib/purchase-defaults";
-import { buyPublishedDesign } from "../actions";
+import type { BackSourceGroup } from "@/lib/back-sources";
+import { buyPublishedDesign, getBuyPageBackSources } from "../actions";
 
 /**
  * Buy-existing UI on `/d/[imageId]`. Logged-in users pick product/size/color
@@ -25,6 +30,7 @@ export function BuyPanel({
   isLoggedIn,
   preferredColor,
   remembered,
+  backEnabled = false,
 }: {
   imageId: string;
   isLoggedIn: boolean;
@@ -32,6 +38,9 @@ export function BuyPanel({
   preferredColor?: string | null;
   /** Last-purchase defaults (#44); null for guests/first purchase. */
   remembered?: PurchaseDefaults | null;
+  /** Multi-placement flag && signed-in (#25/#72 on /d). The server action
+   * re-checks both — this only controls the affordance. */
+  backEnabled?: boolean;
 }) {
   // Remembered product wins over the static default (#44). No URL params on
   // this surface, so precedence is remembered > static.
@@ -63,6 +72,22 @@ export function BuyPanel({
   );
   const [loading, setLoading] = useState(false);
 
+  // Back design (#25 on /d): picked source image, the picker's open state,
+  // and its groups (null until first fetched — one fetch per page view).
+  const [back, setBack] = useState<{ id: string; imageUrl: string } | null>(
+    null
+  );
+  const [backPickerOpen, setBackPickerOpen] = useState(false);
+  const [backGroups, setBackGroups] = useState<BackSourceGroup[] | null>(null);
+
+  function openBackPicker() {
+    setBackPickerOpen(true);
+    if (backGroups !== null) return;
+    getBuyPageBackSources(imageId)
+      .then(({ groups }) => setBackGroups(groups))
+      .catch(() => setBackGroups([]));
+  }
+
   // Switching product can invalidate the current size/color. Size resets to
   // unselected (never silently re-picked); an invalidated color resets per
   // the §3 precedence — pinned backdrop when the new palette has it, else
@@ -84,16 +109,25 @@ export function BuyPanel({
   }
 
   // Price display before a size is picked uses the base size — S–XL share a
-  // price; a 2XL pick updates it live.
-  const { item, shipping, total } = computeOrderTotal(
-    computePrice(0, productId, size ?? sizes[0] ?? "M").total
+  // price; a 2XL pick updates it live. The Design line stays the front-only
+  // price; a picked back design adds its own +$8 line.
+  const sizeForPrice = size ?? sizes[0] ?? "M";
+  const frontPrice = computePrice(0, productId, sizeForPrice).total;
+  const { shipping, total } = computeOrderTotal(
+    computePrice(0, productId, sizeForPrice, { back: !!back }).total
   );
 
   async function handleBuy() {
     if (!size) return;
     setLoading(true);
     try {
-      const { url, needsAuth } = await buyPublishedDesign({ imageId, productId, size, color });
+      const { url, needsAuth } = await buyPublishedDesign({
+        imageId,
+        productId,
+        size,
+        color,
+        backImageId: back?.id,
+      });
       if (needsAuth) {
         window.location.href = `/sign-in?next=/d/${imageId}`;
         return;
@@ -166,11 +200,112 @@ export function BuyPanel({
         }
       />
 
+      {backEnabled && (
+        <div>
+          {back ? (
+            <div className="flex items-center gap-3">
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img
+                src={back.imageUrl}
+                alt="Back design"
+                className="w-11 h-11 rounded-md border border-border bg-checkerboard object-contain"
+              />
+              <div className="flex-1 text-sm">
+                <p>Back design</p>
+                <button
+                  onClick={openBackPicker}
+                  className="text-text-muted underline"
+                >
+                  Change
+                </button>
+              </div>
+              <button
+                onClick={() => {
+                  setBack(null);
+                  setBackPickerOpen(false);
+                }}
+                aria-label="Remove back design"
+                className="w-11 h-11 flex items-center justify-center rounded-md border border-border text-text-muted hover:border-border-hover"
+              >
+                ×
+              </button>
+            </div>
+          ) : (
+            !backPickerOpen && (
+              <button
+                onClick={openBackPicker}
+                className="min-h-11 text-sm underline text-text-muted hover:text-foreground"
+              >
+                Add a back design (+${BACK_PLACEMENT_UPCHARGE.toFixed(2)})
+              </button>
+            )
+          )}
+
+          {backPickerOpen && (
+            <div className="mt-3 space-y-3 max-h-[50vh] overflow-y-auto border border-border rounded-md p-3">
+              <div className="flex items-center justify-between">
+                <p className="text-sm text-text-muted">
+                  Pick an image to print on the back.
+                </p>
+                <button
+                  onClick={() => setBackPickerOpen(false)}
+                  className="text-sm text-text-muted underline"
+                >
+                  Cancel
+                </button>
+              </div>
+              {backGroups === null ? (
+                <div className="w-8 h-8 mx-auto border-2 border-accent border-t-transparent rounded-full animate-spin" />
+              ) : backGroups.length === 0 ? (
+                <p className="text-sm text-text-faint">No images available.</p>
+              ) : (
+                backGroups.map((group) => (
+                  <div key={group.id}>
+                    <h3 className="text-xs font-medium uppercase tracking-wide text-text-muted mb-1.5">
+                      {group.label}
+                    </h3>
+                    <div className="grid grid-cols-3 sm:grid-cols-4 gap-2">
+                      {group.images.map((s) => (
+                        <button
+                          key={s.id}
+                          onClick={() => {
+                            setBack({ id: s.id, imageUrl: s.imageUrl });
+                            setBackPickerOpen(false);
+                          }}
+                          className={`aspect-square min-h-11 rounded-md overflow-hidden border-2 bg-checkerboard ${
+                            s.id === back?.id
+                              ? "border-accent"
+                              : "border-border hover:border-accent"
+                          }`}
+                        >
+                          {/* eslint-disable-next-line @next/next/no-img-element */}
+                          <img
+                            src={s.imageUrl}
+                            alt={`${group.label} option`}
+                            className="w-full h-full object-contain"
+                          />
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+                ))
+              )}
+            </div>
+          )}
+        </div>
+      )}
+
       <div className="space-y-2 text-sm border-t border-border pt-4">
         <div className="flex justify-between">
           <span className="text-text-muted">Design</span>
-          <span>${item.toFixed(2)}</span>
+          <span>${frontPrice.toFixed(2)}</span>
         </div>
+        {back && (
+          <div className="flex justify-between">
+            <span className="text-text-muted">Back design</span>
+            <span>+${BACK_PLACEMENT_UPCHARGE.toFixed(2)}</span>
+          </div>
+        )}
         <div className="flex justify-between">
           <span className="text-text-muted">Shipping</span>
           <span>${shipping.toFixed(2)}</span>

--- a/src/app/d/[imageId]/page.tsx
+++ b/src/app/d/[imageId]/page.tsx
@@ -4,6 +4,7 @@ import { notFound } from "next/navigation";
 import { getPublishedImage } from "../actions";
 import { getLastPurchaseDefaults } from "@/app/preview/actions";
 import { auth, isAnonymousUser } from "@/lib/auth";
+import { multiPlacementEnabled } from "@/lib/blanks";
 import { Breadcrumbs } from "@/components/breadcrumbs";
 import { breadcrumbTrail } from "@/lib/nav";
 import { EditableNaming } from "./editable-naming";
@@ -101,6 +102,10 @@ export default async function PublishedImagePage({
             isLoggedIn={isLoggedIn}
             preferredColor={img.backgroundColor}
             remembered={remembered}
+            // Back affordance is signed-in only (back selection would be lost
+            // through the sign-in redirect anyway) and flag-gated; the server
+            // action re-checks both.
+            backEnabled={isLoggedIn && multiPlacementEnabled()}
           />
         </div>
       </main>

--- a/src/app/d/__tests__/buy-published-design.integration.test.ts
+++ b/src/app/d/__tests__/buy-published-design.integration.test.ts
@@ -1,0 +1,257 @@
+/**
+ * buyPublishedDesign with a back design (#25 on /d), against a real
+ * in-memory libSQL (the #28 pattern). Proves the order + order_item rows
+ * carry both placements and the +$8 upcharge, that the flag gates the back
+ * entirely, and that a cross-owner buyer can't forge a private image id from
+ * the seller's thread (the canUseAsPlacementSource tightening).
+ *
+ * The db singleton, auth session, and Stripe client are mocked; the database
+ * is real (FKs enforced, schema-derived).
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { eq as schemaEq } from "drizzle-orm";
+import { createTestDb } from "@/lib/__tests__/test-db";
+import * as schema from "@/lib/db/schema";
+import { makeUser } from "@/lib/__tests__/factories";
+
+const h = vi.hoisted(() => ({
+  db: null as unknown,
+  session: null as unknown,
+}));
+
+vi.mock("@/lib/db", () => ({
+  get db() {
+    return h.db;
+  },
+}));
+
+vi.mock("@/lib/auth", () => ({
+  auth: { api: { getSession: async () => h.session } },
+  isAnonymousUser: (u: { isAnonymous?: boolean } | undefined) =>
+    Boolean(u?.isAnonymous),
+}));
+
+vi.mock("next/headers", () => ({ headers: async () => new Headers() }));
+
+vi.mock("@/lib/stripe", () => ({
+  stripe: {
+    checkout: {
+      sessions: {
+        create: vi.fn(async () => ({
+          id: "cs_test_back",
+          url: "https://checkout.stripe.example/cs_test_back",
+        })),
+      },
+    },
+  },
+}));
+
+import { buyPublishedDesign } from "@/app/d/actions";
+
+type Db = Awaited<ReturnType<typeof createTestDb>>;
+
+async function seed(db: Db) {
+  await makeUser(db, "seller");
+  await makeUser(db, "buyer");
+
+  // The seller's design being bought: a published image (the listing) and a
+  // private sibling in the same thread.
+  const [sold] = await db
+    .insert(schema.design)
+    .values({ userId: "seller" })
+    .returning();
+  const [listing] = await db
+    .insert(schema.designImage)
+    .values({
+      designId: sold.id,
+      aspectRatio: "1:1",
+      imageUrl: "https://img.example/listing.png",
+      publishedAt: new Date(),
+    })
+    .returning();
+  const [sellerPrivate] = await db
+    .insert(schema.designImage)
+    .values({
+      designId: sold.id,
+      aspectRatio: "1:1",
+      imageUrl: "https://img.example/seller-private.png",
+    })
+    .returning();
+
+  // The buyer's own design → a legitimate back source.
+  const [mine] = await db
+    .insert(schema.design)
+    .values({ userId: "buyer" })
+    .returning();
+  const [myBack] = await db
+    .insert(schema.designImage)
+    .values({
+      designId: mine.id,
+      aspectRatio: "1:1",
+      imageUrl: "https://img.example/my-back.png",
+    })
+    .returning();
+  // My Designs lists primaries only.
+  await db
+    .update(schema.design)
+    .set({ primaryImageId: myBack.id })
+    .where(schemaEq(schema.design.id, mine.id));
+
+  return {
+    soldDesignId: sold.id,
+    listingId: listing.id,
+    sellerPrivateId: sellerPrivate.id,
+    myBackId: myBack.id,
+  };
+}
+
+beforeEach(async () => {
+  h.db = await createTestDb();
+  h.session = { user: { id: "buyer", isAnonymous: false } };
+  vi.stubEnv("MULTI_PLACEMENT_ENABLED", "true");
+  vi.stubEnv("NEXT_PUBLIC_APP_URL", "http://localhost:3000");
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("buyPublishedDesign with a back design", () => {
+  it("writes both placements and the +$8 price to the order and its line", async () => {
+    const db = h.db as Db;
+    const ids = await seed(db);
+
+    const { url } = await buyPublishedDesign({
+      imageId: ids.listingId,
+      productId: "bella-canvas-3001",
+      size: "M",
+      color: "Black",
+      backImageId: ids.myBackId,
+    });
+    expect(url).toBe("https://checkout.stripe.example/cs_test_back");
+
+    const [order] = await db.select().from(schema.order);
+    expect(order.designId).toBe(ids.soldDesignId);
+    expect(order.placements).toEqual({
+      front: ids.listingId,
+      back: ids.myBackId,
+    });
+    // $19.43 front + $8 back upcharge; shipping rides on top.
+    expect(order.itemPrice).toBe(27.43);
+    expect(order.shippingPrice).toBe(4.69);
+    expect(order.totalPrice).toBe(32.12);
+
+    const [line] = await db.select().from(schema.orderItem);
+    expect(line.orderId).toBe(order.id);
+    expect(line.placements).toEqual({
+      front: ids.listingId,
+      back: ids.myBackId,
+    });
+    expect(line.itemPrice).toBe(27.43);
+  });
+
+  it("rejects a forged private image id from the seller's thread and writes no order", async () => {
+    const db = h.db as Db;
+    const ids = await seed(db);
+
+    await expect(
+      buyPublishedDesign({
+        imageId: ids.listingId,
+        productId: "bella-canvas-3001",
+        size: "M",
+        color: "Black",
+        backImageId: ids.sellerPrivateId,
+      })
+    ).rejects.toThrow("Back image is not available");
+
+    expect(await db.select().from(schema.order)).toHaveLength(0);
+    expect(await db.select().from(schema.orderItem)).toHaveLength(0);
+  });
+
+  it("allows the seller's PUBLISHED image itself as the back (Shop path)", async () => {
+    const db = h.db as Db;
+    const ids = await seed(db);
+
+    await buyPublishedDesign({
+      imageId: ids.listingId,
+      productId: "bella-canvas-3001",
+      size: "M",
+      color: "Black",
+      backImageId: ids.listingId,
+    });
+
+    const [order] = await db.select().from(schema.order);
+    expect(order.placements).toEqual({
+      front: ids.listingId,
+      back: ids.listingId,
+    });
+    expect(order.itemPrice).toBe(27.43);
+  });
+
+  it("ignores the back entirely when the flag is off", async () => {
+    vi.stubEnv("MULTI_PLACEMENT_ENABLED", "false");
+    const db = h.db as Db;
+    const ids = await seed(db);
+
+    await buyPublishedDesign({
+      imageId: ids.listingId,
+      productId: "bella-canvas-3001",
+      size: "M",
+      color: "Black",
+      backImageId: ids.myBackId,
+    });
+
+    const [order] = await db.select().from(schema.order);
+    expect(order.placements).toEqual({ front: ids.listingId });
+    expect(order.itemPrice).toBe(19.43);
+    expect(order.totalPrice).toBe(24.12);
+  });
+
+  it("keeps the front-only path unchanged when no back is passed", async () => {
+    const db = h.db as Db;
+    const ids = await seed(db);
+
+    await buyPublishedDesign({
+      imageId: ids.listingId,
+      productId: "bella-canvas-3001",
+      size: "M",
+      color: "Black",
+    });
+
+    const [order] = await db.select().from(schema.order);
+    expect(order.placements).toEqual({ front: ids.listingId });
+    expect(order.itemPrice).toBe(19.43);
+  });
+});
+
+describe("getBuyPageBackSources gating", () => {
+  it("returns no groups for an anonymous session", async () => {
+    const db = h.db as Db;
+    const ids = await seed(db);
+    h.session = { user: { id: "anon-1", isAnonymous: true } };
+
+    const { getBuyPageBackSources } = await import("@/app/d/actions");
+    expect(await getBuyPageBackSources(ids.listingId)).toEqual({ groups: [] });
+  });
+
+  it("returns no groups when the flag is off", async () => {
+    vi.stubEnv("MULTI_PLACEMENT_ENABLED", "false");
+    const db = h.db as Db;
+    const ids = await seed(db);
+
+    const { getBuyPageBackSources } = await import("@/app/d/actions");
+    expect(await getBuyPageBackSources(ids.listingId)).toEqual({ groups: [] });
+  });
+
+  it("returns the buyer-scoped groups when enabled", async () => {
+    const db = h.db as Db;
+    const ids = await seed(db);
+
+    const { getBuyPageBackSources } = await import("@/app/d/actions");
+    const { groups } = await getBuyPageBackSources(ids.listingId);
+    const groupIds = groups.map((g) => g.id);
+    expect(groupIds).not.toContain("this-design");
+    expect(groupIds).toContain("my-designs");
+    expect(groupIds).toContain("shop");
+  });
+});

--- a/src/app/d/actions.ts
+++ b/src/app/d/actions.ts
@@ -10,9 +10,14 @@ import {
 } from "@/lib/db/schema";
 import { eq } from "drizzle-orm";
 import { computePrice } from "@/lib/pricing";
-import { DEFAULT_BLANK_ID } from "@/lib/blanks";
+import { DEFAULT_BLANK_ID, multiPlacementEnabled } from "@/lib/blanks";
 import { createStripeCheckoutForOrder } from "@/app/order/actions";
 import { getPublishedFeed } from "@/lib/discover-feed";
+import {
+  assertUsableBackImage,
+  getBuyPageBackSourceGroups,
+  type BackSourceGroup,
+} from "@/lib/back-sources";
 import {
   canBuyPublishedImage,
   buildForkChain,
@@ -159,6 +164,34 @@ export async function getPublishedImage(
 }
 
 /**
+ * Source groups for the /d back-design picker. Same shape as /preview's
+ * getBackDesignSources, scoped for a buyer who usually doesn't own the
+ * image's source design: My Designs + Shop, with This design only for the
+ * owner (getBuyPageBackSourceGroups). Empty when the flag is off or the
+ * viewer isn't a signed-in, non-anonymous user — the buy page hides the
+ * back affordance for both, this is the server backstop.
+ */
+export async function getBuyPageBackSources(
+  imageId: string
+): Promise<{ groups: BackSourceGroup[] }> {
+  if (!multiPlacementEnabled()) return { groups: [] };
+
+  const session = await auth.api.getSession({ headers: await headers() });
+  if (!session || isAnonymousUser(session.user)) return { groups: [] };
+
+  const image = await db.query.designImage.findFirst({
+    where: eq(designImageTable.id, imageId),
+  });
+  if (!image || !canBuyPublishedImage(image)) return { groups: [] };
+
+  const groups = await getBuyPageBackSourceGroups({
+    designId: image.designId,
+    viewerId: session.user.id,
+  });
+  return { groups };
+}
+
+/**
  * Buy-existing path: a logged-in user purchases a published image from
  * `/d/[imageId]` without designing one. Account-gated by decision (orders
  * must tie to an account so they're trackable in /orders) — the auth check
@@ -177,6 +210,9 @@ export async function buyPublishedDesign(params: {
   productId?: string;
   size: string;
   color: string;
+  /** Source design_image id to print on the back (#25). Honored only when
+   * MULTI_PLACEMENT_ENABLED; ignored otherwise (defense in depth). */
+  backImageId?: string;
 }): Promise<{ url: string | null; needsAuth?: boolean }> {
   const session = await auth.api.getSession({ headers: await headers() });
   // Purchase point — guests (anonymous-plugin sessions) and the sessionless
@@ -195,8 +231,21 @@ export async function buyPublishedDesign(params: {
     throw new Error("Image is not available to buy");
   }
 
+  // Note the order's designId is the SELLER's design here, so the guard's
+  // thread argument gives a cross-owner buyer no extra reach (see
+  // canUseAsPlacementSource) — the back image must be the buyer's own or
+  // published.
+  const backImageId = multiPlacementEnabled()
+    ? params.backImageId ?? null
+    : null;
+  if (backImageId) {
+    await assertUsableBackImage(backImageId, image.designId, session.user.id);
+  }
+
   const resolvedProductId = params.productId ?? DEFAULT_BLANK_ID;
-  const pricing = computePrice(0, resolvedProductId, params.size);
+  const pricing = computePrice(0, resolvedProductId, params.size, {
+    back: !!backImageId,
+  });
 
   return createStripeCheckoutForOrder({
     userId: session.user.id,
@@ -205,7 +254,10 @@ export async function buyPublishedDesign(params: {
     size: params.size,
     color: params.color,
     itemPrice: pricing.total,
-    placements: { front: params.imageId },
+    placements: {
+      front: params.imageId,
+      ...(backImageId ? { back: backImageId } : {}),
+    },
     checkoutImageUrl: image.imageUrl,
     cancelUrl: `${process.env.NEXT_PUBLIC_APP_URL}/d/${params.imageId}`,
   });

--- a/src/lib/__tests__/back-sources.integration.test.ts
+++ b/src/lib/__tests__/back-sources.integration.test.ts
@@ -21,9 +21,11 @@ vi.mock("@/lib/db", () => ({
   },
 }));
 
-const { getBackSourceGroups, assertUsableBackImage } = await import(
-  "@/lib/back-sources"
-);
+const {
+  getBackSourceGroups,
+  getBuyPageBackSourceGroups,
+  assertUsableBackImage,
+} = await import("@/lib/back-sources");
 const { getDesignImageById } = await import("@/lib/design-images");
 
 async function makeDesignWithImage(
@@ -193,6 +195,24 @@ describe("getBackSourceGroups / assertUsableBackImage (#72)", () => {
     ).resolves.toBeUndefined();
   });
 
+  it("rejects a forged private image id from the SELLER's thread for a cross-owner buyer", async () => {
+    // The /d buy case: the order's designId is the seller's design (d1 is
+    // nico's). The stranger, buying nico's published s2, must not be able to
+    // print nico's private s1 by forging its id — thread membership alone
+    // grants nothing (canUseAsPlacementSource tightening).
+    const ids = await seed();
+    await expect(
+      assertUsableBackImage(ids.s1, ids.d1, "stranger")
+    ).rejects.toThrow("Back image is not available");
+  });
+
+  it("allows the seller's PUBLISHED thread image for a cross-owner buyer", async () => {
+    const ids = await seed();
+    await expect(
+      assertUsableBackImage(ids.s2, ids.d1, "stranger")
+    ).resolves.toBeUndefined();
+  });
+
   it("the webhook's id resolver finds a cross-design back image", async () => {
     // Fulfillment resolves placements.back purely by design_image id
     // (getDesignImageById via resolveImageUrlById) with no design scoping, so
@@ -202,5 +222,120 @@ describe("getBackSourceGroups / assertUsableBackImage (#72)", () => {
     const row = await getDesignImageById(ids.pub.imageId);
     expect(row?.imageUrl).toBe(`https://img.example/${ids.pub.designId}.png`);
     expect(row?.designId).not.toBe(ids.d1);
+  });
+});
+
+describe("getBuyPageBackSourceGroups (/d back picker)", () => {
+  beforeEach(async () => {
+    testDb = await createTestDb();
+  });
+
+  async function seedBuyPage() {
+    await makeUser(testDb, "seller");
+    await makeUser(testDb, "buyer");
+
+    // Seller's design being bought: one private + one published image.
+    const [sold] = await testDb
+      .insert(schema.design)
+      .values({ userId: "seller" })
+      .returning();
+    const [privImg] = await testDb
+      .insert(schema.designImage)
+      .values({
+        designId: sold.id,
+        aspectRatio: "1:1",
+        imageUrl: "https://img.example/priv.png",
+      })
+      .returning();
+    const [pubImg] = await testDb
+      .insert(schema.designImage)
+      .values({
+        designId: sold.id,
+        aspectRatio: "1:1",
+        imageUrl: "https://img.example/pub.png",
+        publishedAt: new Date(),
+      })
+      .returning();
+
+    // Buyer's own design with a primary → My Designs.
+    const [mine] = await testDb
+      .insert(schema.design)
+      .values({ userId: "buyer" })
+      .returning();
+    const [mineImg] = await testDb
+      .insert(schema.designImage)
+      .values({
+        designId: mine.id,
+        aspectRatio: "1:1",
+        imageUrl: "https://img.example/mine.png",
+      })
+      .returning();
+    await testDb
+      .update(schema.design)
+      .set({ primaryImageId: mineImg.id })
+      .where(eq(schema.design.id, mine.id));
+
+    return {
+      soldDesignId: sold.id,
+      privImgId: privImg.id,
+      pubImgId: pubImg.id,
+      mineImgId: mineImg.id,
+    };
+  }
+
+  it("a cross-owner buyer gets My Designs + Shop, never the seller's thread", async () => {
+    const ids = await seedBuyPage();
+    const groups = await getBuyPageBackSourceGroups({
+      designId: ids.soldDesignId,
+      viewerId: "buyer",
+    });
+
+    expect(groups.map((g) => g.id)).not.toContain("this-design");
+
+    const byId = new Map(groups.map((g) => [g.id, g]));
+    expect(byId.get("my-designs")?.images.map((i) => i.id)).toEqual([
+      ids.mineImgId,
+    ]);
+    // Shop keeps the sold design's PUBLISHED image (no This-design group to
+    // carry it) and never leaks the private one.
+    expect(byId.get("shop")?.images.map((i) => i.id)).toEqual([ids.pubImgId]);
+    const all = groups.flatMap((g) => g.images.map((i) => i.id));
+    expect(all).not.toContain(ids.privImgId);
+  });
+
+  it("the owner viewing their own listing gets the /preview groups incl. This design", async () => {
+    const ids = await seedBuyPage();
+    const groups = await getBuyPageBackSourceGroups({
+      designId: ids.soldDesignId,
+      viewerId: "seller",
+    });
+    const byId = new Map(groups.map((g) => [g.id, g]));
+    expect(byId.get("this-design")?.images.map((i) => i.id).sort()).toEqual(
+      [ids.privImgId, ids.pubImgId].sort()
+    );
+  });
+
+  it("everything the buy-page groups return passes the checkout guard for that buyer", async () => {
+    const ids = await seedBuyPage();
+    const groups = await getBuyPageBackSourceGroups({
+      designId: ids.soldDesignId,
+      viewerId: "buyer",
+    });
+    for (const g of groups) {
+      for (const img of g.images) {
+        await expect(
+          assertUsableBackImage(img.id, ids.soldDesignId, "buyer")
+        ).resolves.toBeUndefined();
+      }
+    }
+  });
+
+  it("returns no groups for an unknown design", async () => {
+    await seedBuyPage();
+    const groups = await getBuyPageBackSourceGroups({
+      designId: "no-such-design",
+      viewerId: "buyer",
+    });
+    expect(groups).toEqual([]);
   });
 });

--- a/src/lib/__tests__/design-publish.test.ts
+++ b/src/lib/__tests__/design-publish.test.ts
@@ -240,13 +240,25 @@ describe("canUseAsPlacementSource (#72)", () => {
   const base = { designId: "d-other", publishedAt: null, isHidden: false };
   const ctx = { imageOwnerId: "owner", orderDesignId: "d-order", userId: "buyer" };
 
-  it("allows an image from the order's own design, even unpublished", () => {
+  it("allows an unpublished image from the order's design when the user owns it (This design on /preview)", () => {
+    expect(
+      canUseAsPlacementSource({
+        image: { ...base, designId: "d-order" },
+        ...ctx,
+        imageOwnerId: "buyer",
+      })
+    ).toBe(true);
+  });
+
+  it("rejects a private image from the order's design thread when the user does NOT own it", () => {
+    // The /d cross-owner case: orderDesignId is the SELLER's design, so a
+    // forged id from that thread must not print the seller's private work.
     expect(
       canUseAsPlacementSource({
         image: { ...base, designId: "d-order" },
         ...ctx,
       })
-    ).toBe(true);
+    ).toBe(false);
   });
 
   it("allows an image whose design the user owns (My Designs)", () => {

--- a/src/lib/back-sources.ts
+++ b/src/lib/back-sources.ts
@@ -1,5 +1,6 @@
 /**
- * Back-design source groups for the /preview picker (#72).
+ * Back-design source groups for the /preview picker (#72) and the /d buy
+ * page (getBuyPageBackSourceGroups).
  *
  * The back of a shirt can print any of three image origins:
  *  - This design: the current thread's source images (the original picker).
@@ -27,11 +28,14 @@ import {
 
 /**
  * Validate a back-placement image id before it can reach an order (#72).
- * Allowed origins mirror the picker groups below: the order's own design
- * thread, a design the buyer owns, or a published + not-hidden Shop image.
+ * Allowed origins mirror the picker groups below: a design the buyer owns
+ * (which covers the order's own thread on /preview and /order, where design
+ * ownership is checked first) or a published + not-hidden Shop image.
  * Throws on anything else — called at the checkout choke points
- * (createCheckoutSession, addToCart) so a forged id can't get a private
- * image printed.
+ * (createCheckoutSession, addToCart, buyPublishedDesign) so a forged id
+ * can't get a private image printed. On a /d buy `designId` is the SELLER's
+ * design; the guard deliberately gives that no weight (see
+ * canUseAsPlacementSource).
  */
 export async function assertUsableBackImage(
   backImageId: string,
@@ -100,6 +104,55 @@ export async function getBackSourceGroups(params: {
 }
 
 /**
+ * Picker groups for the published-design buy page (/d/[imageId]). The buyer
+ * usually does NOT own the image's source design, so the groups differ from
+ * /preview's:
+ *
+ *  - This design appears only when the viewer owns the source design — a
+ *    cross-owner buyer must never see the seller's private thread images.
+ *  - My Designs: the viewer's own designs' primary images.
+ *  - Shop: published, not-hidden images. For a non-owner the source design
+ *    is NOT excluded here — its published images (including the one being
+ *    bought) are legitimate back choices and This design won't list them.
+ *
+ * `viewerId` is a signed-in, non-anonymous user (the /d purchase gate);
+ * the action returns no groups for anyone else.
+ */
+export async function getBuyPageBackSourceGroups(params: {
+  /** The published image's source design. */
+  designId: string;
+  viewerId: string;
+}): Promise<BackSourceGroup[]> {
+  const [design] = await db
+    .select({ userId: designTable.userId })
+    .from(designTable)
+    .where(eq(designTable.id, params.designId))
+    .limit(1);
+  if (!design) return [];
+
+  if (design.userId === params.viewerId) {
+    return getBackSourceGroups({
+      designId: params.designId,
+      userId: params.viewerId,
+    });
+  }
+
+  const [myDesigns, shop] = await Promise.all([
+    getOtherDesignPrimaries(params.viewerId, params.designId),
+    getShopImages(null),
+  ]);
+
+  const groups: BackSourceGroup[] = [];
+  if (myDesigns.length > 0) {
+    groups.push({ id: "my-designs", label: "My designs", images: myDesigns });
+  }
+  if (shop.length > 0) {
+    groups.push({ id: "shop", label: "Shop", images: shop });
+  }
+  return groups;
+}
+
+/**
  * Display images of the user's other designs: each design's primary image,
  * most recently touched design first. Designs without a primary (never
  * produced a source image) are skipped.
@@ -146,12 +199,14 @@ async function getOtherDesignPrimaries(
 
 /**
  * Published, not-hidden images — the getDiscoverFeed surface, collapsed to
- * one card per design (dedupeFeedByDesign), newest published first. The
- * current design's own published images are excluded: they already appear
- * under This design.
+ * one card per design (dedupeFeedByDesign), newest published first. Pass
+ * `excludeDesignId` when the caller renders a This-design group (those
+ * published images already appear there); null keeps every design in — the
+ * /d cross-owner case, where the source design's published images are only
+ * reachable through Shop.
  */
 async function getShopImages(
-  excludeDesignId: string
+  excludeDesignId: string | null
 ): Promise<BackSourceImage[]> {
   const rows = await db
     .select({
@@ -165,7 +220,9 @@ async function getShopImages(
       and(
         isNotNull(designImageTable.publishedAt),
         eq(designImageTable.isHidden, false),
-        ne(designImageTable.designId, excludeDesignId)
+        ...(excludeDesignId
+          ? [ne(designImageTable.designId, excludeDesignId)]
+          : [])
       )
     )
     .orderBy(desc(designImageTable.publishedAt))

--- a/src/lib/design-publish.ts
+++ b/src/lib/design-publish.ts
@@ -69,14 +69,20 @@ export function canBuyPublishedImage(image: {
  * shirt) on an order for `orderDesignId` (#72). Three allowed origins,
  * matching the /preview picker's groups:
  *
- *  - This design: the image belongs to the order's own design thread.
+ *  - This design: the image belongs to the order's own design thread AND
+ *    the requesting user owns that design. Thread membership alone is not
+ *    enough: on a /d buy (and an unchecked addToCart), orderDesignId is the
+ *    SELLER's design, so an unqualified thread allowance would let a
+ *    cross-owner buyer print the seller's private, unpublished generations
+ *    by forging an image id from that thread.
  *  - My Designs: the requesting user owns the image's design.
  *  - Shop: the image is published and not admin-hidden (the buy-existing
  *    surface — same visibility rule as canBuyPublishedImage).
  *
- * Checked at the checkout choke points (createCheckoutSession / addToCart)
- * so a forged image id can't get a private image printed, and at the
- * preview render/mockup actions so the picker's reach and the guard agree.
+ * Checked at the checkout choke points (createCheckoutSession / addToCart /
+ * buyPublishedDesign) so a forged image id can't get a private image
+ * printed, and at the preview render/mockup actions so the picker's reach
+ * and the guard agree.
  */
 export function canUseAsPlacementSource(params: {
   image: {
@@ -86,12 +92,17 @@ export function canUseAsPlacementSource(params: {
   };
   /** Owner of the image's design. */
   imageOwnerId: string;
-  /** The design the order/preview is for. */
+  /** The design the order/preview is for. No longer grants access on its
+   * own (the cross-owner leak above); kept so call sites keep stating which
+   * order the check is for. */
   orderDesignId: string;
   /** The requesting user. */
   userId: string;
 }): boolean {
-  if (params.image.designId === params.orderDesignId) return true;
+  // Ownership covers the This-design origin too: on /preview and /order the
+  // order's design is verified as the caller's before this guard runs, so its
+  // thread images are the caller's own. There is deliberately NO standalone
+  // `image.designId === orderDesignId` grant — see the docstring.
   if (params.imageOwnerId === params.userId) return true;
   return params.image.publishedAt !== null && !params.image.isHidden;
 }


### PR DESCRIPTION
Nico's ask (2026-07-19): "you can always do a 2-sided shirt, not just the one special way." `/d/[imageId]` now offers the same add-a-back-design (+$8) that `/preview` has, reusing the #25/#72 machinery — nothing below the action changed (`createStripeCheckoutForOrder`'s `placements` already flows back → Printful `back` file type).

## Security check: canUseAsPlacementSource — NOT safe, tightened

The requested audit found the leak. The guard's thread allowance (`image.designId === orderDesignId → true`) held regardless of ownership or publish state. On a `/d` buy, `order.designId` is the **seller's** design, so a cross-owner buyer passing a forged `backImageId` from the seller's thread would get the seller's private, unpublished generations printed. The same hole was already reachable today through `addToCart`, which never verifies the caller owns `params.designId` (the known open item from #26).

Fix: the thread allowance now requires the user to own that design (published images still pass via the Shop rule). `/preview` and `/order` are unaffected — both verify design ownership before the guard runs, so their thread images were always the caller's own. Locked by:
- unit test: forged private image from the order's thread rejected for a non-owner (`design-publish.test.ts`)
- real-DB test: `assertUsableBackImage` rejects the seller's private thread image for a cross-owner buyer; still allows the seller's published one (`back-sources.integration.test.ts`)
- action-level test: `buyPublishedDesign` with the forged id throws and writes no order row

## What's in the PR

**Server**
- `getBuyPageBackSourceGroups` (back-sources.ts): buyer on /d gets **My Designs** + **Shop**; **This design** only when the viewer owns the source design. For a non-owner, Shop keeps the source design's published images (This design isn't there to carry them), so "same image on the back" works.
- `getBuyPageBackSources` action (d/actions.ts): flag-gated, signed-in non-anonymous only.
- `buyPublishedDesign` gains optional `backImageId`: honored only when `MULTI_PLACEMENT_ENABLED` (double-gate), validated via `assertUsableBackImage`, priced `computePrice(0, …, {back: true})`, `placements.back` set.

**UI (BuyPanel, phone-first)**
- "Add a back design (+$8.00)" below the color picker (only when flag on + signed in; hidden for signed-out — sign-in redirect would lose the selection anyway).
- Grouped thumbnail picker (≥44px targets, same layout as /preview's), picked state shows a small thumbnail with Change and a × remove, price area gains a "Back design +$8.00" line, total + "Order — $NN.NN" CTA update live.

**Tests** (622 passing)
- `buy-published-design.integration.test.ts` (real-DB harness + factories): order **and** order_item rows carry `{front, back}` and the $27.43 item price ($32.12 total); forged-id rejection writes no order; flag-off ignores the back entirely; front-only path unchanged; group-action gating.
- `back-sources.integration.test.ts`: buy-page group scoping (owner vs cross-owner), picker-reach ⊆ guard invariant for the buyer.
- `buy-panel.test.tsx`: affordance gating, +$8 line + total math, `backImageId` passed through, remove resets.

## Checks

- `npm run lint` — 0 errors (17 pre-existing warnings)
- `npm test` — 58 files, 622 tests passing
- `npm run build` — green (CI dummy env)

Out of scope per the brief: /shop store-product pages, cart on /d, /preview changes. `addToCart`'s missing design-ownership check is now mitigated at the guard level but the ownership check itself is still the open #26 item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)