### PR TITLE
fix: Printful external_id capped at 32 chars — strip UUID dashes

### DIFF
--- a/src/lib/__tests__/printful.test.ts
+++ b/src/lib/__tests__/printful.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect, beforeEach, afterEach, vi, type MockInstance } from "vitest";
-import { createOrder, createMockupTask, pollMockupTask } from "../printful";
+import {
+  createOrder,
+  createMockupTask,
+  pollMockupTask,
+  toPrintfulExternalId,
+} from "../printful";
 
 const params = {
   designImageUrl: "https://example.com/img.png",
@@ -61,6 +66,35 @@ describe("createOrder PRINTFUL_DRY_RUN", () => {
     );
     await createOrder(params);
     expect(fetchSpy).toHaveBeenCalledOnce();
+  });
+
+  it("sends external_id stripped of dashes (Printful 32-char cap)", async () => {
+    delete process.env.PRINTFUL_DRY_RUN;
+    fetchSpy.mockResolvedValue(
+      new Response(JSON.stringify({ result: { id: 1, costs: { total: "5.00" } } }), {
+        status: 200,
+      })
+    );
+    await createOrder({
+      ...params,
+      externalId: "854ab0f1-d2e2-44c3-b328-5944fc675c1f",
+    });
+    const body = JSON.parse(fetchSpy.mock.calls[0][1].body as string);
+    expect(body.external_id).toBe("854ab0f1d2e244c3b3285944fc675c1f");
+    expect(body.external_id.length).toBeLessThanOrEqual(32);
+  });
+});
+
+describe("toPrintfulExternalId", () => {
+  it("strips dashes from a UUID down to 32 chars", () => {
+    const id = "854ab0f1-d2e2-44c3-b328-5944fc675c1f";
+    expect(id.length).toBe(36);
+    expect(toPrintfulExternalId(id)).toBe("854ab0f1d2e244c3b3285944fc675c1f");
+    expect(toPrintfulExternalId(id).length).toBe(32);
+  });
+
+  it("leaves an already-short id unchanged", () => {
+    expect(toPrintfulExternalId("abc123")).toBe("abc123");
   });
 });
 

--- a/src/lib/__tests__/printful.test.ts
+++ b/src/lib/__tests__/printful.test.ts
@@ -79,7 +79,8 @@ describe("createOrder PRINTFUL_DRY_RUN", () => {
       ...params,
       externalId: "854ab0f1-d2e2-44c3-b328-5944fc675c1f",
     });
-    const body = JSON.parse(fetchSpy.mock.calls[0][1].body as string);
+    const init = fetchSpy.mock.calls[0]?.[1] as RequestInit;
+    const body = JSON.parse(String(init.body));
     expect(body.external_id).toBe("854ab0f1d2e244c3b3285944fc675c1f");
     expect(body.external_id.length).toBeLessThanOrEqual(32);
   });

--- a/src/lib/printful.ts
+++ b/src/lib/printful.ts
@@ -97,7 +97,9 @@ export async function createOrder(params: {
   const data = await printfulFetch(`/orders${confirm ? "?confirm=true" : ""}`, {
     method: "POST",
     body: JSON.stringify({
-      ...(params.externalId ? { external_id: params.externalId } : {}),
+      ...(params.externalId
+        ? { external_id: toPrintfulExternalId(params.externalId) }
+        : {}),
       recipient: {
         name: params.recipientName,
         address1: params.address1,
@@ -127,6 +129,18 @@ export async function getOrderStatus(orderId: string) {
 }
 
 /**
+ * Printful caps external_id at 32 characters; a dashed UUID is 36 and gets a
+ * 400 "Invalid External ID specified" (bit both real orders on 2026-07-19 —
+ * the first live submissions since #37 added external_id). Stripping dashes
+ * yields exactly 32 hex chars. Applied at this boundary on both the send
+ * (createOrder) and lookup (getOrderByExternalId) sides so callers keep
+ * passing the raw order id.
+ */
+export function toPrintfulExternalId(orderId: string): string {
+  return orderId.replace(/-/g, "");
+}
+
+/**
  * Fetch an order by OUR id (sent as external_id on createOrder). Printful's
  * `@`-prefix on the id path selects by external_id instead of Printful's own
  * numeric id. Used to recover a stranded submission: a prior fulfillment
@@ -136,7 +150,9 @@ export async function getOrderStatus(orderId: string) {
  */
 export async function getOrderByExternalId(externalId: string) {
   try {
-    const data = await printfulFetch(`/orders/@${encodeURIComponent(externalId)}`);
+    const data = await printfulFetch(
+      `/orders/@${encodeURIComponent(toPrintfulExternalId(externalId))}`
+    );
     return data.result as { id: string | number; costs?: { total?: string } | null };
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);


### PR DESCRIPTION
Prod incident 2026-07-19: both real orders (854ab0f1, f1b2f15b) charged on Stripe but failed Printful submission with `400 Invalid External ID specified`. Root cause: #37 (PR #48) sends the order UUID as Printful `external_id`, which caps at 32 chars — a dashed UUID is 36. These were the first live submissions since that shipped; dry-run and mocked tests never exercised the real constraint.

Fix: `toPrintfulExternalId()` strips dashes (exactly 32 hex chars), applied at the printful.ts boundary on both send (`createOrder`) and recovery lookup (`getOrderByExternalId`) so the WP1 stranded-order probe stays consistent. Callers unchanged.

Tests: body assertion on createOrder + unit tests for the encoder; printful + order-fulfillment suites 27/27.

After merge + deploy: admin Retry on both stuck orders submits them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)