### PR TITLE
feat: cancel in-flight generation; composer stays usable (#59)

### DIFF
--- a/src/app/design/__tests__/chat-panel.test.tsx
+++ b/src/app/design/__tests__/chat-panel.test.tsx
@@ -29,6 +29,7 @@ const baseProps = {
   generating: false,
   onSend: () => {},
   onGenerate: () => {},
+  onCancelGenerate: () => {},
   readyToGenerate: true,
   options: [],
   onUploadImage: () => {},
@@ -67,11 +68,26 @@ describe("ChatPanel quick-reply placement", () => {
     expect(onSend).toHaveBeenCalledWith("A pun caption over the frog");
   });
 
-  it("hides chips while a turn is in flight", () => {
+  it("hides chips while a chat turn is in flight", () => {
     render(
-      <ChatPanel {...baseProps} generating messages={thread} options={options} />
+      <ChatPanel {...baseProps} loading messages={thread} options={options} />
     );
     expect(screen.queryByTestId("chat-options")).toBeNull();
+  });
+
+  it("keeps chips tappable while a generation runs (#59)", () => {
+    const onSend = vi.fn();
+    render(
+      <ChatPanel
+        {...baseProps}
+        generating
+        onSend={onSend}
+        messages={thread}
+        options={options}
+      />
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Pun caption" }));
+    expect(onSend).toHaveBeenCalledWith("A pun caption over the frog");
   });
 });
 
@@ -83,5 +99,79 @@ describe("ChatPanel generating status", () => {
     expect(screen.getByTestId("drawing-status")).toHaveTextContent(
       "Generating…"
     );
+  });
+
+  it("offers Cancel while generating and reports the tap (#59)", () => {
+    const onCancelGenerate = vi.fn();
+    render(
+      <ChatPanel
+        {...baseProps}
+        generating
+        onCancelGenerate={onCancelGenerate}
+        messages={[thread[0]]}
+      />
+    );
+    fireEvent.click(screen.getByTestId("cancel-generation"));
+    expect(onCancelGenerate).toHaveBeenCalledOnce();
+  });
+
+  it("shows no Cancel when nothing is generating", () => {
+    render(<ChatPanel {...baseProps} messages={thread} />);
+    expect(screen.queryByTestId("cancel-generation")).toBeNull();
+  });
+});
+
+describe("ChatPanel composer during generation (#59)", () => {
+  it("leaves the input and Send usable while generating", () => {
+    const onSend = vi.fn();
+    render(
+      <ChatPanel {...baseProps} generating onSend={onSend} messages={thread} />
+    );
+    const input = screen.getByPlaceholderText(
+      "Describe a design or drop an image"
+    );
+    expect(input).not.toBeDisabled();
+    fireEvent.change(input, { target: { value: "make the frog green" } });
+    fireEvent.click(screen.getByRole("button", { name: "Send" }));
+    expect(onSend).toHaveBeenCalledWith("make the frog green");
+  });
+
+  it("disables Generate and shows the in-flight label while generating", () => {
+    render(<ChatPanel {...baseProps} generating messages={thread} />);
+    // Button label + the chat status row both read "Generating…".
+    const generateBtn = screen
+      .getAllByRole("button", { name: "Generating…" })
+      .find((el) => el.tagName === "BUTTON");
+    expect(generateBtn).toBeDisabled();
+  });
+
+  it("routes generate-trigger text to chat while a generation runs", () => {
+    // One generation at a time: "make it blue" typed mid-generation becomes a
+    // chat turn instead of a refused second generation.
+    const onSend = vi.fn();
+    const onGenerate = vi.fn();
+    render(
+      <ChatPanel
+        {...baseProps}
+        generating
+        onSend={onSend}
+        onGenerate={onGenerate}
+        messages={thread}
+      />
+    );
+    const input = screen.getByPlaceholderText(
+      "Describe a design or drop an image"
+    );
+    fireEvent.change(input, { target: { value: "make it blue" } });
+    fireEvent.click(screen.getByRole("button", { name: "Send" }));
+    expect(onGenerate).not.toHaveBeenCalled();
+    expect(onSend).toHaveBeenCalledWith("make it blue");
+  });
+
+  it("locks the composer during a chat turn (unchanged)", () => {
+    render(<ChatPanel {...baseProps} loading messages={thread} />);
+    expect(
+      screen.getByPlaceholderText("Describe a design or drop an image")
+    ).toBeDisabled();
   });
 });

--- a/src/app/design/chat-panel.tsx
+++ b/src/app/design/chat-panel.tsx
@@ -28,6 +28,7 @@ export function ChatPanel({
   generating,
   onSend,
   onGenerate,
+  onCancelGenerate,
   readyToGenerate,
   options,
   onUploadImage,
@@ -40,6 +41,7 @@ export function ChatPanel({
   generating: boolean;
   onSend: (message: string) => void;
   onGenerate: (message?: string) => void;
+  onCancelGenerate: () => void;
   readyToGenerate: boolean;
   options: ChatOption[];
   onUploadImage: (base64: string, fileName: string) => void;
@@ -95,9 +97,10 @@ export function ChatPanel({
     messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
   }, [messages, loading, generating]);
 
-  // Auto-focus input on mount and after actions complete
+  // Auto-focus input on mount and after actions complete. A running
+  // generation doesn't lock the composer (#59), so focus stays available.
   useEffect(() => {
-    if (!loading && !generating) inputRef.current?.focus();
+    if (!loading) inputRef.current?.focus();
   }, [loading, generating]);
 
   // "draw it"/"draw" kept for muscle memory from the old button label; typing
@@ -105,12 +108,15 @@ export function ChatPanel({
   const GENERATE_TRIGGERS = /^(yes|yeah|yep|do it|go|generate|draw it|draw|let'?s do it|go ahead|make it|yes please|sure|ok generate)/i;
 
   // Shared submit path for both the composer and a tapped quick-reply chip, so
-  // generate-intent detection and input clearing behave identically.
+  // generate-intent detection and input clearing behave identically. The
+  // composer stays open while a generation runs (#59) — only a chat turn in
+  // flight blocks; generate-intent text during a generation routes to chat
+  // (one generation at a time).
   function submitTurn(text: string) {
     const msg = text.trim();
-    if (!msg || loading || generating) return;
+    if (!msg || loading) return;
     setInput("");
-    if (GENERATE_TRIGGERS.test(msg) && messages.length > 0) {
+    if (!generating && GENERATE_TRIGGERS.test(msg) && messages.length > 0) {
       onGenerate(msg);
       return;
     }
@@ -128,8 +134,6 @@ export function ChatPanel({
     if (msg) setInput("");
     onGenerate(msg);
   }
-
-  const busy = loading || generating;
   // Soft nudge: until Claude judges the subject concrete, Generate sits as a
   // secondary button and a hint shows — it pops to primary when ready. Always
   // clickable; the fast thin-check catches a too-thin click in ~1s rather
@@ -260,11 +264,12 @@ export function ChatPanel({
             message flow, directly under the question they answer (options
             state only ever holds the latest turn's chips, so older messages
             never re-show theirs). Tap answers the question, no "type a
-            number" needed. Hidden while a turn is in flight. */}
-        {!busy && options.length > 0 && (
+            number" needed. Hidden while a chat turn is in flight; a running
+            generation doesn't hide them (#59) — the composer stays usable. */}
+        {!loading && options.length > 0 && (
           <div className="flex justify-start" data-testid="chat-options">
             <div className="max-w-[80%] px-4">
-              <QuickReply options={options} onSelect={submitTurn} disabled={busy} />
+              <QuickReply options={options} onSelect={submitTurn} disabled={loading} />
             </div>
           </div>
         )}
@@ -276,8 +281,17 @@ export function ChatPanel({
           </div>
         )}
         {generating && (
-          <div className="flex justify-start">
+          <div className="flex justify-start items-center gap-2">
             <DrawingStatus />
+            <Button
+              type="button"
+              variant="secondary"
+              className="min-h-[44px]"
+              onClick={onCancelGenerate}
+              data-testid="cancel-generation"
+            >
+              Cancel
+            </Button>
           </div>
         )}
         <div ref={messagesEndRef} />
@@ -299,7 +313,7 @@ export function ChatPanel({
           <button
             type="button"
             onClick={() => fileInputRef.current?.click()}
-            disabled={busy}
+            disabled={loading}
             className="flex items-center justify-center min-h-[44px] min-w-[44px] border border-border rounded-md text-text-muted hover:text-white hover:border-border-hover transition-colors disabled:opacity-50"
             title="Upload image"
           >
@@ -315,7 +329,7 @@ export function ChatPanel({
             onChange={(e) => setInput(e.target.value)}
             placeholder="Describe a design or drop an image"
             className="flex-1 min-h-[44px] px-3 py-2 bg-surface border border-border rounded-md text-white placeholder:text-text-faint focus:border-border-hover focus:outline-none"
-            disabled={busy}
+            disabled={loading}
           />
         </div>
         <div className="flex flex-wrap gap-2">
@@ -323,7 +337,7 @@ export function ChatPanel({
             type="submit"
             variant="secondary"
             className="min-h-[44px] flex-1"
-            disabled={busy || !input.trim()}
+            disabled={loading || !input.trim()}
           >
             Send
           </Button>
@@ -332,10 +346,12 @@ export function ChatPanel({
             variant={readyToGenerate ? "primary" : "secondary"}
             className="min-h-[44px] flex-1"
             onClick={handleGenerate}
-            disabled={busy || (messages.length === 0 && !input.trim())}
+            disabled={
+              loading || generating || (messages.length === 0 && !input.trim())
+            }
             title={readyToGenerate ? undefined : notReadyTitle}
           >
-            Generate
+            {generating ? "Generating…" : "Generate"}
           </Button>
         </div>
       </form>

--- a/src/app/design/page.tsx
+++ b/src/app/design/page.tsx
@@ -24,6 +24,7 @@ import { MobileGalleryStrip } from "./mobile-gallery-strip";
 import { Breadcrumbs } from "@/components/breadcrumbs";
 import { breadcrumbTrail } from "@/lib/nav";
 import { isDesignEmpty } from "@/lib/design-view";
+import { createTurnTracker } from "@/lib/turn-tracker";
 import { ensureGuestSession } from "@/lib/ensure-guest-session";
 
 export default function DesignPage() {
@@ -54,6 +55,14 @@ function DesignPageInner() {
   // Tappable quick-replies attached to the most recent assistant turn. Cleared
   // at the start of every new turn so chips never outlive the question.
   const [options, setOptions] = useState<ChatOption[]>([]);
+  // #59: chat and generation turns register here. A settling action applies
+  // its full effects (options/readiness/selection) only while it is still the
+  // latest, un-cancelled turn — a cancelled generation's late completion may
+  // append its image/message but never clobbers newer composer state.
+  const turns = useRef(createTurnTracker());
+  // Token of the in-flight generation (one at a time; handleGenerate refuses
+  // re-entry). Null once it settles or the user cancels.
+  const activeGeneration = useRef<number | null>(null);
 
   const refreshGallery = useCallback(async () => {
     const { sources, productGroups } = await getDesignGallery(designId.current);
@@ -123,6 +132,7 @@ function DesignPageInner() {
   }
 
   async function handleSend(userMessage: string) {
+    const token = turns.current.start();
     setLoading(true);
     setOptions([]);
     setMessages((prev) => [...prev, makeOptimisticMessage("user", userMessage)]);
@@ -134,8 +144,10 @@ function DesignPageInner() {
         ...prev,
         makeOptimisticMessage("assistant", result.message),
       ]);
-      setReadyToGenerate(result.readyToGenerate);
-      setOptions(result.options);
+      if (turns.current.isCurrent(token)) {
+        setReadyToGenerate(result.readyToGenerate);
+        setOptions(result.options);
+      }
     } catch {
       setMessages((prev) => [
         ...prev,
@@ -147,6 +159,13 @@ function DesignPageInner() {
   }
 
   async function handleGenerate(userMessage?: string) {
+    // One generation at a time: a second Generate while one is in flight is
+    // refused (the button shows the in-flight state). #40 made server-side
+    // numbering/quota concurrency-safe, but serializing here keeps quota burn
+    // and the strip predictable.
+    if (activeGeneration.current !== null) return;
+    const token = turns.current.start();
+    activeGeneration.current = token;
     setGenerating(true);
     setOptions([]);
     if (userMessage) {
@@ -156,29 +175,56 @@ function DesignPageInner() {
     try {
       await ensureGuestSession();
       const result = await generateDesign(designId.current, userMessage);
+      // The result always lands in chat + gallery — even after a client-side
+      // cancel the server render completed (and the quota unit was spent), so
+      // show the image honestly rather than hiding paid work.
       setMessages((prev) => [
         ...prev,
         makeOptimisticMessage("assistant", result.message, result.imageId),
       ]);
-      setReadyToGenerate(result.readyToGenerate);
-      // A clarifying question (no image) may carry tappable style options.
-      setOptions("options" in result ? (result.options ?? []) : []);
       // Claude may answer with a clarifying question instead of an image
       // (no imageUrl) — just show the message, no gallery/drawer changes.
       // The new render lands inline in chat and leads the mobile thumbnail
       // strip — no drawer auto-open needed.
       if (result.imageUrl) {
-        setSelectedImage(result.imageUrl);
         await refreshGallery();
       }
+      // Composer-adjacent state belongs to the latest turn only: a cancelled
+      // or superseded generation must not reset options, readiness, or the
+      // user's current selection.
+      if (turns.current.isCurrent(token)) {
+        setReadyToGenerate(result.readyToGenerate);
+        // A clarifying question (no image) may carry tappable style options.
+        setOptions("options" in result ? (result.options ?? []) : []);
+        if (result.imageUrl) setSelectedImage(result.imageUrl);
+      }
     } catch {
-      setMessages((prev) => [
-        ...prev,
-        makeOptimisticMessage("assistant", "Generation failed. Try again."),
-      ]);
+      // After a cancel, a failure message is noise — the user moved on.
+      if (!turns.current.isCancelled(token)) {
+        setMessages((prev) => [
+          ...prev,
+          makeOptimisticMessage("assistant", "Generation failed. Try again."),
+        ]);
+      }
     } finally {
-      setGenerating(false);
+      if (activeGeneration.current === token) {
+        activeGeneration.current = null;
+        setGenerating(false);
+      }
     }
+  }
+
+  // #59 client-side cancel: stop waiting on the action and free the composer.
+  // The server action still runs to completion — its image appears in the
+  // strip when it lands (append-only), and the quota unit stays spent because
+  // the render actually ran. True server-side Replicate cancel would need a
+  // predictions.create/cancel refactor — possible follow-up.
+  function handleCancelGenerate() {
+    const token = activeGeneration.current;
+    if (token === null) return;
+    turns.current.cancel(token);
+    activeGeneration.current = null;
+    setGenerating(false);
   }
 
   async function handleDeleteImage(imageId: string) {
@@ -289,6 +335,7 @@ function DesignPageInner() {
           generating={generating}
           onSend={handleSend}
           onGenerate={handleGenerate}
+          onCancelGenerate={handleCancelGenerate}
           readyToGenerate={readyToGenerate}
           options={options}
           onUploadImage={handleUploadImage}

--- a/src/lib/__tests__/turn-tracker.test.ts
+++ b/src/lib/__tests__/turn-tracker.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "vitest";
+import { createTurnTracker } from "../turn-tracker";
+
+describe("createTurnTracker", () => {
+  it("issues increasing tokens", () => {
+    const t = createTurnTracker();
+    const a = t.start();
+    const b = t.start();
+    expect(b).toBeGreaterThan(a);
+  });
+
+  it("only the latest turn is current", () => {
+    const t = createTurnTracker();
+    const a = t.start();
+    expect(t.isCurrent(a)).toBe(true);
+    const b = t.start();
+    expect(t.isCurrent(a)).toBe(false);
+    expect(t.isCurrent(b)).toBe(true);
+  });
+
+  it("a cancelled turn is never current, even while latest", () => {
+    const t = createTurnTracker();
+    const a = t.start();
+    t.cancel(a);
+    expect(t.isCancelled(a)).toBe(true);
+    expect(t.isCurrent(a)).toBe(false);
+  });
+
+  it("cancelling an old turn does not affect a newer one", () => {
+    const t = createTurnTracker();
+    const a = t.start();
+    const b = t.start();
+    t.cancel(a);
+    expect(t.isCancelled(a)).toBe(true);
+    expect(t.isCancelled(b)).toBe(false);
+    expect(t.isCurrent(b)).toBe(true);
+  });
+
+  it("a completion after cancel-then-new-turn is both cancelled and stale", () => {
+    // The #59 scenario: user cancels a generation, keeps chatting, then the
+    // abandoned server action settles — it must see itself as non-current.
+    const t = createTurnTracker();
+    const gen = t.start();
+    t.cancel(gen);
+    const chat = t.start();
+    expect(t.isCurrent(gen)).toBe(false);
+    expect(t.isCancelled(gen)).toBe(true);
+    expect(t.isCurrent(chat)).toBe(true);
+  });
+});

--- a/src/lib/turn-tracker.ts
+++ b/src/lib/turn-tracker.ts
@@ -1,0 +1,40 @@
+/**
+ * Client-side turn tracker for the /design page (#59).
+ *
+ * Chat sends and generations both register as "turns". A settling server
+ * action applies its full UI effects (options, readiness, selection) only
+ * when it is still the latest turn and wasn't cancelled — a stale or
+ * cancelled completion may still append its content (chat message, gallery
+ * image) but must never reset composer-adjacent state a newer turn owns.
+ *
+ * Pure and framework-free so the guard is unit-testable; the page holds one
+ * instance in a ref.
+ */
+export interface TurnTracker {
+  /** Register a new turn; returns its token. Later tokens supersede earlier ones. */
+  start(): number;
+  /** Mark a turn cancelled (client-side abandon — the server action still runs). */
+  cancel(token: number): void;
+  isCancelled(token: number): boolean;
+  /** True when this token is the latest started turn and not cancelled. */
+  isCurrent(token: number): boolean;
+}
+
+export function createTurnTracker(): TurnTracker {
+  let latest = 0;
+  const cancelled = new Set<number>();
+  return {
+    start() {
+      return ++latest;
+    },
+    cancel(token) {
+      cancelled.add(token);
+    },
+    isCancelled(token) {
+      return cancelled.has(token);
+    },
+    isCurrent(token) {
+      return token === latest && !cancelled.has(token);
+    },
+  };
+}


### PR DESCRIPTION
Closes #59

Client-side abandon (the issue's suggested MVP). No server-side Replicate cancel — that needs a `predictions.create`/`predictions.cancel` refactor in `replicate.ts`; noted as a possible follow-up.

## What changed

- **Composer unlocked during generation.** Input, Send, quick-reply chips, and upload only lock during a chat turn (`loading`), not while a render runs. User can keep refining instructions mid-generation.
- **Cancel** button (Clean Label, one word, ≥44px) next to the "Generating…" status line. Clears the generating UI immediately and frees the flow.
- **Turn tracker** (`src/lib/turn-tracker.ts`, pure + unit-tested): chat sends and generations register as turns; a settling server action applies composer-adjacent effects (options, readiness, selected image) only if it's still the latest, un-cancelled turn.

## Decisions

- **Concurrency: one generation at a time.** A second Generate while one is in flight is refused — the button disables and shows "Generating…". #40 made server-side numbering/quota concurrency-safe, so allowing parallel generations would be safe, but serializing keeps quota burn and the strip predictable. Typed generate-triggers ("make it…", "yes") during a generation route to chat instead.
- **Quota: no refund on client-side cancel.** The server action keeps running and the render actually happens, so the unit stays spent. The existing failed-generation refund path (#40) is untouched.
- **Cancelled-then-completed generations still land.** The image and assistant message append to chat/gallery/strip when the action settles — cheap and honest, the user sees paid work appear labeled normally. What a stale completion can NOT do: reset options, readiness, or the user's current selection (turn-tracker guard). A failure after cancel is silent — the user moved on.

## Tests

- 5 unit tests for the turn tracker (incl. the cancel-then-keep-chatting scenario).
- 6 new ChatPanel component tests: Cancel visible + wired while generating, composer/Send/chips usable mid-generation, Generate disabled with in-flight label, trigger-text routes to chat, chat-turn lock unchanged.
- Full suite 637 passed; lint 0 errors; build green under CI env.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016r36fkFu4LKU1jtBKAt2xR