### PR TITLE
test: one Stripe test-mode e2e through the money path

### DIFF
--- a/docs/stripe-e2e.md
+++ b/docs/stripe-e2e.md
@@ -1,0 +1,60 @@
+# Stripe test-mode e2e
+
+One spec — `e2e/stripe-money-path.spec.ts` — that pays through real Stripe
+test mode: seed a design, `/preview`, pick size, Order, fill Stripe's hosted
+checkout (4242 test card), land on `/order/confirm`, then assert the order row
+reaches `submitted` (dry-run Printful) with `sale` + `stripe_fee` ledger rows.
+
+This is the test class that would have caught the 2026-07-19 external_id
+incident's siblings: real vendor constraints (Stripe here; Printful stays
+dry-run) that mocks can't see. Keep it at exactly one spec.
+
+## Prerequisites
+
+- Stripe CLI installed: `brew install stripe/stripe-cli/stripe`. No
+  `stripe login` needed — the script passes `--api-key` from `.env.local`.
+- `.env.local` with the dev Turso DB and a **test-mode** `STRIPE_SECRET_KEY`
+  (`sk_test_…`). The script refuses live keys.
+- Port 3100 free (the script refuses a busy port — a stale server would have
+  the wrong webhook secret baked in).
+
+## Run
+
+```
+npm run e2e:stripe
+```
+
+What the script (`scripts/e2e-stripe.sh`) does:
+
+1. Reads the CLI listener's signing secret (`stripe listen --print-secret`)
+   and exports it as `STRIPE_WEBHOOK_SECRET` — the compiled server verifies
+   the forwarded event with it (process env beats `.env.local`).
+2. Spawns `stripe listen --forward-to localhost:3100/api/webhooks/stripe`
+   (only `checkout.session.completed`), killed on exit.
+3. Exports `NEXT_PUBLIC_APP_URL=http://localhost:3100` so Stripe's
+   success/cancel redirects land back on the server under test,
+   `PRINTFUL_DRY_RUN=true` (also forced in `playwright.config.ts` — no local
+   e2e can place a real Printful order), a dummy `RESEND_API_KEY` (no real
+   order emails), and `E2E_STRIPE=1`.
+4. Runs the spec on the mobile project only — one payment per run.
+
+The spec self-cleans: its order + `order_item` + ledger rows, seeded design,
+and throwaway account are deleted from the dev DB afterward.
+
+## Gating
+
+The spec is tagged `@stripe` and skips itself unless `E2E_STRIPE=1`, so plain
+`npm run e2e` and CI never run it. It also skips when `E2E_BASE_URL` is set
+(CI runs against a Vercel preview, where Stripe redirect URLs build from
+`NEXT_PUBLIC_APP_URL` = prod and checkout would bounce off the deployment
+under test) and when `STRIPE_SECRET_KEY` isn't `sk_test_…`.
+
+## Troubleshooting
+
+- Order stuck at `paid`/`pending` in the poll: the listener isn't forwarding,
+  or the server booted with a different `STRIPE_WEBHOOK_SECRET` than the
+  listener's. Re-run the script with port 3100 free (fresh boot picks up the
+  exported secret).
+- Stripe's checkout DOM changes without notice. The spec resolves each field
+  through candidate locators (`#cardNumber`, placeholder, label); if a fill
+  fails, update the candidates in `completeStripeCheckout`.

--- a/e2e/helpers/db.ts
+++ b/e2e/helpers/db.ts
@@ -86,6 +86,67 @@ export async function cleanupDesigns(designIds: string[]): Promise<void> {
   });
 }
 
+/** Order row for a Stripe Checkout session id (the Stripe spec extracts
+ * `cs_test_…` from the hosted-checkout URL). */
+export async function orderForStripeSession(
+  sessionId: string
+): Promise<{ id: string; status: string; printfulOrderId: string | null } | null> {
+  const res = await db().execute({
+    sql: `SELECT id, status, printful_order_id FROM "order" WHERE stripe_session_id = ?`,
+    args: [sessionId],
+  });
+  const row = res.rows[0];
+  if (!row) return null;
+  return {
+    id: String(row.id),
+    status: String(row.status),
+    printfulOrderId:
+      row.printful_order_id == null ? null : String(row.printful_order_id),
+  };
+}
+
+/** Ledger entry types booked against an order (sale, stripe_fee, cogs, …). */
+export async function ledgerTypesForOrder(orderId: string): Promise<string[]> {
+  const res = await db().execute({
+    sql: "SELECT type FROM ledger_entry WHERE order_id = ?",
+    args: [orderId],
+  });
+  return res.rows.map((r) => String(r.type));
+}
+
+/**
+ * Remove the orders (+ order_item + ledger rows) a spec's checkout created
+ * against its seeded designs. Dev-DB self-cleanup of the spec's own test-mode
+ * rows — the append-only ledger rule protects real money, not e2e residue.
+ * Ledger + items first (FK to order).
+ */
+export async function cleanupOrdersForDesigns(
+  designIds: string[]
+): Promise<void> {
+  if (designIds.length === 0) return;
+  const c = db();
+  const designPh = designIds.map(() => "?").join(",");
+  const orders = await c.execute({
+    sql: `SELECT id FROM "order" WHERE design_id IN (${designPh})`,
+    args: designIds,
+  });
+  const orderIds = orders.rows.map((r) => String(r.id));
+  if (orderIds.length === 0) return;
+  const orderPh = orderIds.map(() => "?").join(",");
+  await c.execute({
+    sql: `DELETE FROM ledger_entry WHERE order_id IN (${orderPh})`,
+    args: orderIds,
+  });
+  await c.execute({
+    sql: `DELETE FROM order_item WHERE order_id IN (${orderPh})`,
+    args: orderIds,
+  });
+  await c.execute({
+    sql: `DELETE FROM "order" WHERE id IN (${orderPh})`,
+    args: orderIds,
+  });
+}
+
 /**
  * Remove the stores + products an organizer spec built through the UI.
  * Products first (FK to store + design), then stores. Scoped by owner so a

--- a/e2e/stripe-money-path.spec.ts
+++ b/e2e/stripe-money-path.spec.ts
@@ -1,0 +1,202 @@
+/**
+ * The one Stripe test-mode e2e (WP5): a real payment through Stripe's hosted
+ * checkout, the real signed webhook (Stripe CLI listener forwarding to the
+ * local server), and the dry-run Printful submission — asserted all the way
+ * to the order row and ledger.
+ *
+ * This is the test class that catches real vendor constraints invisible to
+ * mocks (e.g. the 2026-07-19 incident: Printful rejects external_id > 32
+ * chars, which no mocked or dry-run test could see). Everything between the
+ * "Order" click and the ledger rows here runs against the real Stripe API.
+ *
+ * Deliberately OFF by default — it moves real (test-mode) money and needs a
+ * `stripe listen` forwarder on :3100. Run via `npm run e2e:stripe`
+ * (docs/stripe-e2e.md); it self-skips everywhere else:
+ *   - E2E_STRIPE unset          → plain `npm run e2e` skips it
+ *   - E2E_BASE_URL set          → CI-against-preview skips it (Stripe redirect
+ *     URLs build from NEXT_PUBLIC_APP_URL, which is prod on previews — the
+ *     checkout would bounce off the deployment under test)
+ *   - STRIPE_SECRET_KEY not sk_test_ → never pays with a live key
+ */
+import { test, expect, type Page, type Locator } from "@playwright/test";
+import {
+  userIdForSessionCookie,
+  seedDesign,
+  cleanupDesigns,
+  cleanupOrdersForDesigns,
+  cleanupUser,
+  orderForStripeSession,
+  ledgerTypesForOrder,
+} from "./helpers/db";
+import { waitForSessionCookie } from "./helpers/session";
+import { signUpFreshAccount } from "./helpers/auth";
+
+const PRODUCT = "bella-canvas-3001";
+const TEST_CARD = "4242424242424242";
+
+/** Fill the first visible candidate. Stripe owns the checkout DOM and changes
+ * it without notice, so every field is resolved through a candidate list. */
+async function fillFirstVisible(
+  candidates: Locator[],
+  value: string
+): Promise<boolean> {
+  for (const candidate of candidates) {
+    const target = candidate.first();
+    if (await target.isVisible().catch(() => false)) {
+      await target.fill(value);
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Drive Stripe's hosted test checkout: email, US shipping address, 4242 test
+ * card, Pay. Optional fields (Link prompts, autocomplete) are handled when
+ * present and skipped when not.
+ */
+async function completeStripeCheckout(page: Page, email: string) {
+  // The card number field is the last thing to hydrate; once it's visible the
+  // form is interactable.
+  const cardNumber = page
+    .locator("#cardNumber")
+    .or(page.getByPlaceholder("1234 1234 1234 1234"));
+  await expect(cardNumber.first()).toBeVisible({ timeout: 60_000 });
+
+  const filledEmail = await fillFirstVisible(
+    [page.locator("#email"), page.getByRole("textbox", { name: /email/i })],
+    email
+  );
+  expect(filledEmail, "no email field on Stripe checkout").toBe(true);
+
+  // Shipping (shipping_address_collection: US). Stripe may show an address
+  // autocomplete first — switch to manual entry when the toggle exists.
+  const manualEntry = page.getByText("Enter address manually");
+  if (await manualEntry.first().isVisible().catch(() => false)) {
+    await manualEntry.first().click();
+  }
+  await fillFirstVisible(
+    [page.locator("#shippingName"), page.getByLabel(/full name/i)],
+    "E2E Stripe Buyer"
+  );
+  await fillFirstVisible(
+    [page.locator("#shippingAddressLine1"), page.getByLabel(/address/i)],
+    "100 Test Street"
+  );
+  await fillFirstVisible(
+    [page.locator("#shippingLocality"), page.getByLabel(/city/i)],
+    "Seattle"
+  );
+  await fillFirstVisible(
+    [page.locator("#shippingPostalCode"), page.getByLabel(/zip/i)],
+    "98101"
+  );
+  const stateSelect = page.locator("select#shippingAdministrativeArea");
+  if (await stateSelect.isVisible().catch(() => false)) {
+    await stateSelect.selectOption("WA");
+  }
+
+  // Card details. The 4242 test card never triggers 3DS.
+  await cardNumber.first().fill(TEST_CARD);
+  await fillFirstVisible(
+    [page.locator("#cardExpiry"), page.getByPlaceholder("MM / YY")],
+    "12 / 34"
+  );
+  await fillFirstVisible(
+    [page.locator("#cardCvc"), page.getByPlaceholder("CVC")],
+    "123"
+  );
+  await fillFirstVisible(
+    [page.locator("#billingName"), page.getByLabel(/name on card/i)],
+    "E2E Stripe Buyer"
+  );
+
+  const payButton = page
+    .getByTestId("hosted-payment-submit-button")
+    .or(page.getByRole("button", { name: /^Pay/ }));
+  await payButton.first().click({ timeout: 30_000 });
+}
+
+test.describe("stripe money path", { tag: "@stripe" }, () => {
+  const stripeKey = process.env.STRIPE_SECRET_KEY ?? "";
+  test.skip(
+    process.env.E2E_STRIPE !== "1",
+    "opt-in only — run via `npm run e2e:stripe`"
+  );
+  test.skip(
+    Boolean(process.env.E2E_BASE_URL),
+    "local-only: on previews the Stripe success/cancel URLs point at prod (NEXT_PUBLIC_APP_URL)"
+  );
+  test.skip(
+    !stripeKey.startsWith("sk_test_"),
+    "needs a test-mode STRIPE_SECRET_KEY (sk_test_…) in .env.local"
+  );
+
+  test("hosted checkout → signed webhook → submitted order + sale/fee ledger", async ({
+    page,
+  }, testInfo) => {
+    // Stripe page load + payment settle + webhook forward all add up.
+    test.setTimeout(300_000);
+    const key = `${Date.now()}-${testInfo.project.name}`;
+    const seeded: string[] = [];
+    let userId = "";
+
+    try {
+      // Checkout is the funnel's auth gate, so pay as a fresh real account
+      // (a guest would be bounced to sign-in instead of Stripe).
+      await signUpFreshAccount(page, key);
+      const cookie = await waitForSessionCookie(page);
+      userId = await userIdForSessionCookie(cookie);
+      seeded.push(await seedDesign(userId, `${key}-pay`));
+
+      // URL params pre-select product/color/size; buy is gated on size only.
+      await page.goto(
+        `/preview?id=${seeded[0]}&product=${PRODUCT}&color=Black&size=M`
+      );
+      // The CTA label includes the total only once pricing has loaded, so
+      // matching on "Order — $" also waits for the page to be fully wired.
+      await page
+        .getByRole("button", { name: /^Order — \$/ })
+        .filter({ visible: true })
+        .first()
+        .click({ timeout: 30_000 });
+
+      await page.waitForURL(/checkout\.stripe\.com/, { timeout: 60_000 });
+      const sessionId = page.url().match(/cs_test_[A-Za-z0-9]+/)?.[0];
+      expect(sessionId, `no cs_test_… in checkout URL: ${page.url()}`).toBeTruthy();
+
+      await completeStripeCheckout(page, `e2e-buyer-${key}@prntd.test`);
+
+      // Stripe settles the payment and redirects to success_url.
+      await page.waitForURL(/\/order\/confirm/, { timeout: 120_000 });
+
+      // The CLI listener forwards the signed checkout.session.completed to the
+      // local webhook: pending → paid (sale + stripe_fee ledger) → dry-run
+      // Printful submission → submitted.
+      await expect
+        .poll(
+          async () =>
+            (await orderForStripeSession(sessionId!))?.status ?? "missing",
+          {
+            timeout: 90_000,
+            message:
+              "order never reached submitted — is `stripe listen` forwarding to :3100 with the secret the server booted with?",
+          }
+        )
+        .toBe("submitted");
+
+      const order = await orderForStripeSession(sessionId!);
+      // Dry-run Printful: fake id, no real shirt, costs 0.00 → no COGS row.
+      expect(order!.printfulOrderId).toMatch(/^dry-run-/);
+      const types = await ledgerTypesForOrder(order!.id);
+      expect(types).toContain("sale");
+      expect(types).toContain("stripe_fee");
+      expect(types).not.toContain("cogs");
+    } finally {
+      // Orders first (FK to design + user), then designs, then the account.
+      await cleanupOrdersForDesigns(seeded);
+      await cleanupDesigns(seeded);
+      await cleanupUser(userId);
+    }
+  });
+});

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
-    "e2e": "playwright test"
+    "e2e": "playwright test",
+    "e2e:stripe": "bash scripts/e2e-stripe.sh"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.80.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -62,6 +62,11 @@ export default defineConfig({
           // localhost; let Better-Auth trust the localhost origin so the
           // sign-up/sign-in flow (origin-checked) works. Never set in real prod.
           E2E_TRUST_LOCALHOST: "true",
+          // The Stripe money-path spec (e2e:stripe) completes a real test-mode
+          // payment, which drives the webhook into Printful submission — force
+          // dry-run so a local e2e can never place a real Printful order,
+          // whatever .env.local says.
+          PRINTFUL_DRY_RUN: "true",
         },
       },
 });

--- a/scripts/e2e-stripe.sh
+++ b/scripts/e2e-stripe.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Run the one Stripe test-mode e2e (e2e/stripe-money-path.spec.ts).
+#
+# Spawns a `stripe listen` forwarder so the real, signed
+# checkout.session.completed event reaches the local webhook, exports the
+# listener's signing secret for the server, and runs the tagged spec against
+# the compiled build on :3100. See docs/stripe-e2e.md.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+if ! command -v stripe >/dev/null 2>&1; then
+  echo "stripe CLI not found. Install: brew install stripe/stripe-cli/stripe" >&2
+  exit 1
+fi
+
+if [ ! -f .env.local ]; then
+  echo ".env.local not found — the spec needs the dev DB + test-mode Stripe key" >&2
+  exit 1
+fi
+
+# A stale server on :3100 would be reused (reuseExistingServer) with the wrong
+# webhook secret / NEXT_PUBLIC_APP_URL — refuse instead of debugging that.
+if lsof -nP -iTCP:3100 -sTCP:LISTEN >/dev/null 2>&1; then
+  echo "Port 3100 is busy. Kill whatever is listening there and re-run." >&2
+  exit 1
+fi
+
+set -a
+. ./.env.local
+set +a
+
+case "${STRIPE_SECRET_KEY:-}" in
+  sk_test_*) ;;
+  *)
+    echo "STRIPE_SECRET_KEY in .env.local is missing or not test-mode (sk_test_…). Refusing to pay." >&2
+    exit 1
+    ;;
+esac
+
+# The server must verify events with the CLI listener's signing secret, not
+# the dashboard endpoint's. Exported before Playwright boots the webServer;
+# process env beats .env.local in Next's env loading.
+STRIPE_WEBHOOK_SECRET="$(stripe listen --api-key "$STRIPE_SECRET_KEY" --print-secret)"
+export STRIPE_WEBHOOK_SECRET
+
+stripe listen --api-key "$STRIPE_SECRET_KEY" \
+  --events checkout.session.completed \
+  --forward-to localhost:3100/api/webhooks/stripe &
+LISTENER_PID=$!
+trap 'kill "$LISTENER_PID" 2>/dev/null || true' EXIT
+
+# Stripe's success/cancel URLs build from NEXT_PUBLIC_APP_URL — point them at
+# the server under test so the post-payment redirect lands back on :3100.
+export NEXT_PUBLIC_APP_URL="http://localhost:3100"
+# Belt over the playwright.config suspenders: never submit a real Printful order.
+export PRINTFUL_DRY_RUN=true
+# Suppress real order emails (invalid key; the send helper swallows failures).
+export RESEND_API_KEY="re_dummy_e2e"
+# Opt the tagged spec in (it self-skips without this).
+export E2E_STRIPE=1
+
+# One project only — phone-first, and one payment per run is enough.
+npx playwright test e2e/stripe-money-path.spec.ts --project=mobile


### PR DESCRIPTION
The WP5 candidate flagged after the 2026-07-19 Printful external_id incident: exactly ONE e2e that pays through real Stripe test mode, so real-vendor constraints invisible to mocks get exercised. Not expanded beyond one spec, per prior guidance.

## What it does

`e2e/stripe-money-path.spec.ts` (tag `@stripe`): fresh sign-up (checkout is the auth gate) → seed design via the anon-safe db helper → `/preview?…&size=M` → click `Order — $…` → fill Stripe's hosted test checkout (4242 card, US shipping, candidate-locator fills since Stripe's DOM shifts) → land on `/order/confirm` → poll the dev DB until the order is `submitted` with a `dry-run-…` Printful id → assert `sale` + `stripe_fee` ledger rows and no `cogs` (dry-run reports 0.00). Self-cleans order/items/ledger/design/account.

## Webhook design: Stripe CLI listener (not signed replay)

Stripe can't reach :3100, so `scripts/e2e-stripe.sh` (→ `npm run e2e:stripe`) spawns the forwarder *outside* Playwright — sturdier than spawning inside the test runner, and the signed-replay fallback wasn't needed:

1. `stripe listen --print-secret` → exported as `STRIPE_WEBHOOK_SECRET` before Playwright boots the webServer (process env beats the env file in Next's env loading; the webhook route reads it at request time).
2. `stripe listen --api-key … --events checkout.session.completed --forward-to localhost:3100/api/webhooks/stripe`, killed on exit. No `stripe login` needed.
3. Exports `NEXT_PUBLIC_APP_URL=http://localhost:3100` (success/cancel URLs must land back on the server under test), dummy `RESEND_API_KEY` (no real emails; send helper swallows failures), `E2E_STRIPE=1`, and runs `--project=mobile` only (one payment per run).
4. Guards: refuses a non-`sk_test_` key, a missing local env file, and a busy :3100 (a stale reused server would have the wrong secret baked in).

## Gating

- Plain `npm run e2e`: spec skips (`E2E_STRIPE` unset).
- CI against preview: skips (`E2E_BASE_URL` set — Stripe redirects there build from prod `NEXT_PUBLIC_APP_URL` and would bounce off the deployment under test).
- Live key: skips/refuses at both spec and script level.
- Safety net for everything else: `playwright.config.ts` webServer now always sets `PRINTFUL_DRY_RUN=true`, so no local e2e can ever place a real Printful order.

## Not run live

I could not execute the spec (secrets hook blocks the local env file; no Stripe key available to this session). Lint (0 errors, warnings unchanged from main), typecheck, 625 vitest tests, and a CI-dummy-env production build all pass; `playwright --list` registers the spec. The Stripe-page selector set is the untested surface — first run may need a candidate-locator tweak in `completeStripeCheckout`.

Run it locally:

```
npm run e2e:stripe
```

Docs: `docs/stripe-e2e.md`. Note: the spec deletes its own test-mode order + ledger rows from the dev DB afterward — append-only applies to real money, not e2e residue; flag if you'd rather keep them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016r36fkFu4LKU1jtBKAt2xR
