### PR TITLE
test: WP5 route-level coverage (webhooks, cron auth, emails, financial summary)

### DIFF
--- a/src/app/admin/__tests__/financial-summary.integration.test.ts
+++ b/src/app/admin/__tests__/financial-summary.integration.test.ts
@@ -1,0 +1,222 @@
+// @vitest-environment node
+/**
+ * Real-DB integration test for getFinancialSummary (WP5): seeds orders +
+ * ledger rows across classifications and asserts the grouped-sum →
+ * summarizeLedger math the admin dashboard shows. Asserts CURRENT behavior,
+ * including two quirks worth knowing about (documented inline): archived
+ * orders drop out of orderCount but their ledger rows still count, and
+ * unfiltered summaries include test-classified orders' money.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { eq } from "drizzle-orm";
+import * as schema from "@/lib/db/schema";
+import { createTestDb } from "@/lib/__tests__/test-db";
+
+const state = vi.hoisted(() => {
+  // actions.ts throws at module load without ADMIN_EMAIL; set it before the
+  // static import below evaluates.
+  process.env.ADMIN_EMAIL = "admin@example.com";
+  return {
+    db: null as unknown,
+    sessionEmail: "admin@example.com" as string | null,
+  };
+});
+
+vi.mock("@/lib/db", () => ({
+  get db() {
+    return state.db;
+  },
+}));
+vi.mock("@/lib/auth", () => ({
+  auth: {
+    api: {
+      getSession: vi.fn(async () =>
+        state.sessionEmail ? { user: { email: state.sessionEmail } } : null
+      ),
+    },
+  },
+}));
+vi.mock("next/headers", () => ({ headers: vi.fn(async () => new Headers()) }));
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
+vi.mock("@/lib/stripe", () => ({ stripe: {} }));
+vi.mock("@/lib/printful", () => ({
+  createOrder: vi.fn(),
+  getOrderByExternalId: vi.fn(),
+}));
+vi.mock("@/lib/ai", () => ({ generateOrderName: vi.fn() }));
+vi.mock("@/lib/email", () => ({
+  sendOrderConfirmation: vi.fn(),
+  sendOwnerOrderAlert: vi.fn(),
+}));
+
+import { getFinancialSummary, archiveOrder } from "../actions";
+
+type Db = Awaited<ReturnType<typeof createTestDb>>;
+
+function db(): Db {
+  return state.db as Db;
+}
+
+async function seedOrder(opts: {
+  id: string;
+  classification: string | null;
+  archived?: boolean;
+  ledger?: { type: string; amount: number }[];
+}) {
+  const [design] = await db()
+    .insert(schema.design)
+    .values({ userId: "u1" })
+    .returning();
+  await db()
+    .insert(schema.order)
+    .values({
+      id: opts.id,
+      userId: "u1",
+      designId: design.id,
+      productId: "bella-canvas-3001",
+      size: "M",
+      color: "Black",
+      totalPrice: 24.12,
+      status: "submitted",
+      classification: opts.classification,
+      archivedAt: opts.archived ? new Date() : null,
+    });
+  if (opts.ledger?.length) {
+    await db()
+      .insert(schema.ledgerEntry)
+      .values(
+        opts.ledger.map((l) => ({
+          orderId: opts.id,
+          type: l.type,
+          amount: l.amount,
+          description: `${l.type} for ${opts.id}`,
+        }))
+      );
+  }
+}
+
+beforeEach(async () => {
+  state.db = await createTestDb();
+  state.sessionEmail = "admin@example.com";
+  await db()
+    .insert(schema.user)
+    .values({ id: "u1", email: "buyer@example.com", name: "Buyer" });
+});
+
+describe("getFinancialSummary", () => {
+  beforeEach(async () => {
+    await seedOrder({
+      id: "o-customer",
+      classification: "customer",
+      ledger: [
+        { type: "sale", amount: 24.12 },
+        { type: "stripe_fee", amount: -1.0 },
+        { type: "cogs", amount: -12.5 },
+      ],
+    });
+    await seedOrder({
+      id: "o-test",
+      classification: "test",
+      ledger: [
+        { type: "sale", amount: 10.0 },
+        { type: "stripe_fee", amount: -0.59 },
+      ],
+    });
+    await seedOrder({
+      id: "o-archived",
+      classification: "customer",
+      archived: true,
+      ledger: [{ type: "sale", amount: 5.0 }],
+    });
+    await seedOrder({ id: "o-unclassified", classification: null });
+  });
+
+  it("unfiltered: sums EVERY ledger row — including test-classified orders — and counts non-archived orders", async () => {
+    const summary = await getFinancialSummary();
+
+    // Current behavior: no default exclusion of `test` orders (the
+    // docs/test-orders-and-accounting.md proposal would change this), and the
+    // archived order's sale still counts even though the order itself doesn't.
+    expect(summary.revenue).toBeCloseTo(24.12 + 10.0 + 5.0, 5);
+    expect(summary.stripeFees).toBeCloseTo(-1.59, 5);
+    expect(summary.cogs).toBeCloseTo(12.5, 5);
+    expect(summary.grossProfit).toBeCloseTo(39.12 - 1.59 - 12.5, 5);
+    expect(summary.orderCount).toBe(3); // o-archived excluded, o-unclassified included
+  });
+
+  it('"all" behaves the same as no filter', async () => {
+    const summary = await getFinancialSummary("all");
+    expect(summary.revenue).toBeCloseTo(39.12, 5);
+    expect(summary.orderCount).toBe(3);
+  });
+
+  it("customer filter: joins ledger through order classification; archived customer money still counts", async () => {
+    const summary = await getFinancialSummary("customer");
+
+    expect(summary.revenue).toBeCloseTo(24.12 + 5.0, 5); // o-customer + archived o-archived
+    expect(summary.stripeFees).toBeCloseTo(-1.0, 5);
+    expect(summary.cogs).toBeCloseTo(12.5, 5);
+    expect(summary.grossProfit).toBeCloseTo(29.12 - 1.0 - 12.5, 5);
+    expect(summary.orderCount).toBe(1); // only the non-archived customer order
+  });
+
+  it("test filter: isolates test-order money", async () => {
+    const summary = await getFinancialSummary("test");
+    expect(summary.revenue).toBeCloseTo(10.0, 5);
+    expect(summary.stripeFees).toBeCloseTo(-0.59, 5);
+    expect(summary.cogs).toBe(0);
+    expect(summary.grossProfit).toBeCloseTo(9.41, 5);
+    expect(summary.orderCount).toBe(1);
+  });
+
+  it("counts a refund_cogs_reversal as a COGS correction in gross profit (WP1)", async () => {
+    await seedOrder({
+      id: "o-canceled",
+      classification: "customer",
+      ledger: [
+        { type: "sale", amount: 24.12 },
+        { type: "stripe_fee", amount: -1.0 },
+        { type: "cogs", amount: -12.5 },
+        { type: "refund_cogs_reversal", amount: 12.5 },
+      ],
+    });
+
+    const summary = await getFinancialSummary("customer");
+    // The reversal nets the canceled order's COGS to zero: only o-customer's
+    // 12.50 remains, and gross profit reflects both orders' sale − fee.
+    expect(summary.cogs).toBeCloseTo(12.5, 5);
+    expect(summary.grossProfit).toBeCloseTo(
+      (24.12 - 1.0 - 12.5) + (5.0) + (24.12 - 1.0),
+      5
+    );
+  });
+
+  it("rejects a non-admin session", async () => {
+    state.sessionEmail = "someone-else@example.com";
+    await expect(getFinancialSummary()).rejects.toThrow("Unauthorized");
+  });
+});
+
+describe("archiveOrder (uses canArchiveOrder)", () => {
+  it("archives a pre-fulfillment order and refuses a submitted one", async () => {
+    await seedOrder({ id: "o-pending", classification: null });
+    await db()
+      .update(schema.order)
+      .set({ status: "pending" })
+      .where(eq(schema.order.id, "o-pending"));
+    await archiveOrder("o-pending");
+    const archived = await db().query.order.findFirst({
+      where: eq(schema.order.id, "o-pending"),
+    });
+    expect(archived?.archivedAt).not.toBeNull();
+
+    await seedOrder({ id: "o-submitted", classification: "customer" });
+    await db()
+      .update(schema.order)
+      .set({ printfulOrderId: "9999" })
+      .where(eq(schema.order.id, "o-submitted"));
+    await expect(archiveOrder("o-submitted")).rejects.toThrow(
+      "Cannot archive orders submitted to Printful"
+    );
+  });
+});

--- a/src/app/admin/actions.ts
+++ b/src/app/admin/actions.ts
@@ -16,7 +16,7 @@ import { alias } from "drizzle-orm/sqlite-core";
 import { revalidatePath } from "next/cache";
 import { createOrder, getOrderByExternalId } from "@/lib/printful";
 import { generateOrderName } from "@/lib/ai";
-import { assertTransition } from "@/lib/order-state";
+import { assertTransition, canArchiveOrder } from "@/lib/order-state";
 import { summarizeLedger } from "@/lib/ledger";
 import { ORDER_CLASSIFICATIONS, type OrderClassification } from "@/lib/order-classification";
 import { stripe } from "@/lib/stripe";
@@ -261,7 +261,7 @@ export async function archiveOrder(orderId: string) {
     where: eq(orderTable.id, orderId),
   });
   if (!found) throw new Error("Order not found");
-  if (found.status === "shipped" || found.status === "delivered" || found.trackingNumber || found.printfulOrderId) {
+  if (!canArchiveOrder(found)) {
     throw new Error("Cannot archive orders submitted to Printful");
   }
 

--- a/src/app/api/cron/retry-fulfillment/__tests__/route.test.ts
+++ b/src/app/api/cron/retry-fulfillment/__tests__/route.test.ts
@@ -1,0 +1,104 @@
+// @vitest-environment node
+/**
+ * Auth-gate tests for the retry-fulfillment cron route (WP5). The sweep core
+ * (retryStuckFulfillments) is real-DB tested in
+ * src/lib/__tests__/retry-fulfillment.integration.test.ts; here it's mocked so
+ * these tests exercise only the route's Bearer contract.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("@/lib/db", () => ({ db: {} }));
+vi.mock("@/lib/printful", () => ({
+  createOrder: vi.fn(),
+  getOrderByExternalId: vi.fn(),
+}));
+vi.mock("@/lib/ai", () => ({ generateOrderName: vi.fn() }));
+vi.mock("@/lib/design-images", () => ({
+  getDesignDisplayImageUrl: vi.fn(),
+  getDesignImageById: vi.fn(),
+}));
+vi.mock("@/lib/retry-fulfillment", () => ({
+  retryStuckFulfillments: vi.fn(),
+}));
+
+import { GET } from "../route";
+import { retryStuckFulfillments } from "@/lib/retry-fulfillment";
+
+const coreMock = vi.mocked(retryStuckFulfillments);
+const originalSecret = process.env.CRON_SECRET;
+
+function request(authorization?: string) {
+  return new NextRequest("http://localhost/api/cron/retry-fulfillment", {
+    method: "GET",
+    headers: authorization ? { authorization } : {},
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  process.env.CRON_SECRET = "cron-secret-wp5";
+  coreMock.mockResolvedValue({ scanned: 0, results: [] });
+});
+
+afterEach(() => {
+  if (originalSecret === undefined) delete process.env.CRON_SECRET;
+  else process.env.CRON_SECRET = originalSecret;
+});
+
+describe("cron retry-fulfillment route — auth gate", () => {
+  it("500s when CRON_SECRET is not configured (misconfiguration, not an open door)", async () => {
+    delete process.env.CRON_SECRET;
+    const res = await GET(request("Bearer anything"));
+    expect(res.status).toBe(500);
+    expect(await res.json()).toEqual({ error: "Not configured" });
+    expect(coreMock).not.toHaveBeenCalled();
+  });
+
+  it("401s with no Authorization header", async () => {
+    const res = await GET(request());
+    expect(res.status).toBe(401);
+    expect(await res.json()).toEqual({ error: "Unauthorized" });
+    expect(coreMock).not.toHaveBeenCalled();
+  });
+
+  it("401s on a wrong bearer token", async () => {
+    const res = await GET(request("Bearer wrong-secret"));
+    expect(res.status).toBe(401);
+    expect(coreMock).not.toHaveBeenCalled();
+  });
+
+  it("401s when the secret is sent without the Bearer prefix", async () => {
+    const res = await GET(request("cron-secret-wp5"));
+    expect(res.status).toBe(401);
+    expect(coreMock).not.toHaveBeenCalled();
+  });
+
+  it("runs the sweep and returns its result on the correct Bearer secret", async () => {
+    coreMock.mockResolvedValue({
+      scanned: 2,
+      results: [
+        { orderId: "o1", action: "submitted" },
+        { orderId: "o2", action: "error" },
+      ],
+    });
+
+    const res = await GET(request("Bearer cron-secret-wp5"));
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      scanned: 2,
+      results: [
+        { orderId: "o1", action: "submitted" },
+        { orderId: "o2", action: "error" },
+      ],
+    });
+    expect(coreMock).toHaveBeenCalledTimes(1);
+    // The route wires the shared fulfillment deps (db + Printful + naming +
+    // image resolution) into the core.
+    const deps = coreMock.mock.calls[0][0];
+    expect(deps).toHaveProperty("db");
+    expect(deps).toHaveProperty("createPrintfulOrder");
+    expect(deps).toHaveProperty("getPrintfulOrderByExternalId");
+  });
+});

--- a/src/app/api/webhooks/printful/__tests__/route.test.ts
+++ b/src/app/api/webhooks/printful/__tests__/route.test.ts
@@ -1,0 +1,275 @@
+// @vitest-environment node
+/**
+ * Route-level tests for the Printful webhook (WP5), run against a real
+ * in-memory DB (createTestDb) so the route's own joins and the shipping-email
+ * hero resolution (resolveHeroImages → design-images → email-images) execute
+ * for real. Only the outbound email sender is mocked.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { eq } from "drizzle-orm";
+import { NextRequest } from "next/server";
+import * as schema from "@/lib/db/schema";
+import { getColorHex } from "@/lib/blanks";
+import { createTestDb } from "@/lib/__tests__/test-db";
+
+const state = vi.hoisted(() => ({
+  db: null as unknown,
+}));
+
+// The route (and design-images, transitively) import the app db; route every
+// access to the per-test in-memory DB.
+vi.mock("@/lib/db", () => ({
+  get db() {
+    return state.db;
+  },
+}));
+vi.mock("@/lib/email", () => ({
+  sendShippingNotification: vi.fn().mockResolvedValue(undefined),
+  sendOrderConfirmation: vi.fn(),
+  sendOwnerOrderAlert: vi.fn(),
+}));
+
+import { POST } from "../route";
+import { sendShippingNotification } from "@/lib/email";
+
+type Db = Awaited<ReturnType<typeof createTestDb>>;
+const shippingEmailMock = vi.mocked(sendShippingNotification);
+
+function db(): Db {
+  return state.db as Db;
+}
+
+function request(payload: unknown) {
+  return new NextRequest("http://localhost/api/webhooks/printful", {
+    method: "POST",
+    body: typeof payload === "string" ? payload : JSON.stringify(payload),
+    headers: { "content-type": "application/json" },
+  });
+}
+
+async function seed(opts: {
+  orderOverrides?: Partial<typeof schema.order.$inferInsert>;
+  designOverrides?: Partial<typeof schema.design.$inferInsert>;
+} = {}) {
+  const userId = "pf-user";
+  await db()
+    .insert(schema.user)
+    .values({ id: userId, email: "customer@example.com", name: "Customer" });
+  const [design] = await db()
+    .insert(schema.design)
+    .values({ userId, ...opts.designOverrides })
+    .returning();
+  const [order] = await db()
+    .insert(schema.order)
+    .values({
+      userId,
+      designId: design.id,
+      productId: "bella-canvas-3001",
+      size: "M",
+      color: "Black",
+      totalPrice: 24.12,
+      status: "submitted",
+      printfulOrderId: "9999",
+      displayName: "Test Shirt",
+      ...opts.orderOverrides,
+    })
+    .returning();
+  return { userId, design, order };
+}
+
+beforeEach(async () => {
+  vi.clearAllMocks();
+  state.db = await createTestDb();
+});
+
+describe("Printful webhook route — malformed input", () => {
+  it("400s on a non-JSON body", async () => {
+    const res = await POST(request("not json {"));
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "Invalid JSON" });
+  });
+
+  it("404s when no order matches the Printful id", async () => {
+    const res = await POST(
+      request({ type: "package_shipped", data: { order: { id: 424242 } } })
+    );
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.error).toMatch(/No order found/);
+  });
+
+  it("400s on a missing Printful order id", async () => {
+    const res = await POST(request({ type: "package_shipped", data: {} }));
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("Printful webhook route — package_shipped", () => {
+  it("marks the order shipped and sends the shipping email with the cached mockup hero", async () => {
+    const mockupUrl = "https://mock.example/front-mockup.png";
+    const { order } = await seed({
+      designOverrides: {
+        // Same key shape /preview caches: product:placement:color:scale.
+        mockupUrls: { "bella-canvas-3001:front:Black:200": mockupUrl },
+      },
+    });
+
+    const res = await POST(
+      request({
+        type: "package_shipped",
+        data: {
+          order: { id: 9999 },
+          shipment: {
+            tracking_number: "1Z999",
+            tracking_url: "https://track.example/1Z999",
+          },
+        },
+      })
+    );
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ received: true });
+
+    const updated = await db().query.order.findFirst({
+      where: eq(schema.order.id, order.id),
+    });
+    expect(updated?.status).toBe("shipped");
+    expect(updated?.trackingNumber).toBe("1Z999");
+    expect(updated?.trackingUrl).toBe("https://track.example/1Z999");
+
+    // Hero resolution preferred the cached Printful mockup (no backdrop).
+    expect(shippingEmailMock).toHaveBeenCalledTimes(1);
+    expect(shippingEmailMock).toHaveBeenCalledWith({
+      to: "customer@example.com",
+      orderId: order.id,
+      trackingNumber: "1Z999",
+      trackingUrl: "https://track.example/1Z999",
+      displayName: "Test Shirt",
+      images: [{ label: "Front", url: mockupUrl, backdrop: null }],
+    });
+  });
+
+  it("falls back to the design artwork on a shirt-color backdrop when no mockup is cached", async () => {
+    const { design } = await seed();
+    const [image] = await db()
+      .insert(schema.designImage)
+      .values({
+        designId: design.id,
+        aspectRatio: "1:1",
+        imageUrl: "https://img.example/artwork.png",
+      })
+      .returning();
+    await db()
+      .update(schema.design)
+      .set({ primaryImageId: image.id })
+      .where(eq(schema.design.id, design.id));
+
+    const res = await POST(
+      request({
+        type: "package_shipped",
+        data: { order: { id: 9999 }, shipment: { tracking_number: "T2" } },
+      })
+    );
+
+    expect(res.status).toBe(200);
+    expect(shippingEmailMock).toHaveBeenCalledTimes(1);
+    const call = shippingEmailMock.mock.calls[0][0];
+    expect(call.images).toEqual([
+      {
+        label: "Front",
+        url: "https://img.example/artwork.png",
+        backdrop: getColorHex("bella-canvas-3001", "Black"),
+      },
+    ]);
+    expect(call.trackingUrl).toBeNull();
+  });
+
+  it("redelivery at shipped returns 200 and does not re-send the email", async () => {
+    const { order } = await seed({
+      orderOverrides: { status: "shipped", trackingNumber: "1Z999" },
+    });
+
+    const res = await POST(
+      request({
+        type: "package_shipped",
+        data: { order: { id: 9999 }, shipment: { tracking_number: "1Z999" } },
+      })
+    );
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ received: true });
+    expect(shippingEmailMock).not.toHaveBeenCalled();
+    const updated = await db().query.order.findFirst({
+      where: eq(schema.order.id, order.id),
+    });
+    expect(updated?.status).toBe("shipped");
+  });
+});
+
+describe("Printful webhook route — order_canceled", () => {
+  it("cancels the order, reverses booked COGS, and books no refund", async () => {
+    const { order } = await seed({ orderOverrides: { printfulCost: 12.5 } });
+    await db().insert(schema.ledgerEntry).values({
+      orderId: order.id,
+      type: "cogs",
+      amount: -12.5,
+      description: "Printful fulfillment PF:9999",
+    });
+
+    const res = await POST(
+      request({ type: "order_canceled", data: { order: { id: 9999 } } })
+    );
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ received: true });
+
+    const updated = await db().query.order.findFirst({
+      where: eq(schema.order.id, order.id),
+    });
+    expect(updated?.status).toBe("canceled");
+    expect(updated?.printfulCost).toBe(0);
+
+    const entries = await db().query.ledgerEntry.findMany({
+      where: eq(schema.ledgerEntry.orderId, order.id),
+      orderBy: (entry, { asc }) => [asc(entry.createdAt)],
+    });
+    const types = entries.map((e) => e.type);
+    expect(types).toContain("refund_cogs_reversal");
+    expect(types).not.toContain("refund");
+    expect(shippingEmailMock).not.toHaveBeenCalled();
+  });
+
+  it("redelivery at canceled returns 200 without a second reversal row", async () => {
+    const { order } = await seed({
+      orderOverrides: { status: "canceled", printfulCost: 0 },
+    });
+
+    const res = await POST(
+      request({ type: "order_canceled", data: { order: { id: 9999 } } })
+    );
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ received: true });
+    const entries = await db().query.ledgerEntry.findMany({
+      where: eq(schema.ledgerEntry.orderId, order.id),
+    });
+    expect(entries).toHaveLength(0);
+  });
+});
+
+describe("Printful webhook route — other events", () => {
+  it("acknowledges order_failed without changing the order", async () => {
+    const { order } = await seed();
+    const res = await POST(
+      request({
+        type: "order_failed",
+        data: { order: { id: 9999 }, reason: "Out of stock" },
+      })
+    );
+    expect(res.status).toBe(200);
+    const updated = await db().query.order.findFirst({
+      where: eq(schema.order.id, order.id),
+    });
+    expect(updated?.status).toBe("submitted");
+  });
+});

--- a/src/app/api/webhooks/stripe/__tests__/route.test.ts
+++ b/src/app/api/webhooks/stripe/__tests__/route.test.ts
@@ -1,0 +1,249 @@
+// @vitest-environment node
+/**
+ * Route-level tests for the Stripe webhook (WP5). The handler's money logic is
+ * covered by money-path.integration.test.ts against a real DB; this file locks
+ * the ROUTE contract on top of it:
+ *   - signature verification (real `stripe.webhooks.constructEvent` against a
+ *     header minted with `generateTestHeaderString` — no crypto mocked)
+ *   - event-type routing (only checkout.session.completed does work)
+ *   - error mapping: a handler THROW → 400 (Stripe redelivers; per WP1 the
+ *     handler itself only throws before the paid-claim), while post-claim
+ *     failures surface as resolved actions (paid / paid_printful_failed) that
+ *     must return 200 so Stripe does NOT redeliver
+ *   - the email branch: sendPostOrderEmails fires on submitted / paid /
+ *     paid_printful_failed, and not on skipped
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type Stripe from "stripe";
+import { NextRequest } from "next/server";
+
+vi.mock("@/lib/db", () => ({ db: {} }));
+vi.mock("@/lib/printful", () => ({
+  createOrder: vi.fn(),
+  getOrderByExternalId: vi.fn(),
+}));
+vi.mock("@/lib/ai", () => ({ generateOrderName: vi.fn() }));
+vi.mock("@/lib/design-images", () => ({
+  getDesignDisplayImageUrl: vi.fn(),
+  getDesignImageById: vi.fn(),
+}));
+vi.mock("@/lib/email", () => ({
+  sendOrderConfirmation: vi.fn(),
+  sendOwnerOrderAlert: vi.fn(),
+}));
+vi.mock("@/lib/order-emails", () => ({
+  sendPostOrderEmails: vi.fn().mockResolvedValue(undefined),
+  createDefaultOrderEmailDeps: vi.fn(() => ({})),
+}));
+vi.mock("@/lib/webhook-handlers", () => ({
+  handleStripeCheckoutCompleted: vi.fn(),
+}));
+// Real Stripe SDK instance (dummy key): webhooks.constructEvent and
+// generateTestHeaderString are pure crypto, no network. checkout.sessions is
+// spied per-test.
+vi.mock("@/lib/stripe", async () => {
+  const { default: StripeSdk } = await import("stripe");
+  return { stripe: new StripeSdk("sk_test_dummy") };
+});
+
+import { POST } from "../route";
+import { stripe } from "@/lib/stripe";
+import { handleStripeCheckoutCompleted } from "@/lib/webhook-handlers";
+import { sendPostOrderEmails } from "@/lib/order-emails";
+
+const WEBHOOK_SECRET = "whsec_test_wp5";
+process.env.STRIPE_WEBHOOK_SECRET = WEBHOOK_SECRET;
+
+const handlerMock = vi.mocked(handleStripeCheckoutCompleted);
+const emailsMock = vi.mocked(sendPostOrderEmails);
+
+function eventBody(type: string, object: Record<string, unknown> = { id: "cs_123" }) {
+  return JSON.stringify({
+    id: "evt_test_1",
+    object: "event",
+    type,
+    data: { object },
+  });
+}
+
+function signedRequest(body: string, secret = WEBHOOK_SECRET) {
+  const signature = stripe.webhooks.generateTestHeaderString({
+    payload: body,
+    secret,
+  });
+  return new NextRequest("http://localhost/api/webhooks/stripe", {
+    method: "POST",
+    body,
+    headers: { "stripe-signature": signature },
+  });
+}
+
+/** Minimal retrieved-session shape accepted by toStripeSessionData. */
+function fakeFullSession(
+  overrides: Partial<Record<string, unknown>> = {}
+): Stripe.Checkout.Session {
+  return {
+    id: "cs_123",
+    metadata: { orderId: "order-1", designId: "design-1" },
+    payment_intent: "pi_1",
+    amount_total: 2412,
+    amount_subtotal: 1943,
+    total_details: { amount_shipping: 469 },
+    collected_information: {
+      shipping_details: {
+        name: "Jane Doe",
+        address: {
+          line1: "1 Main St",
+          city: "Town",
+          state: "CA",
+          postal_code: "90001",
+          country: "US",
+        },
+      },
+    },
+    ...overrides,
+  } as unknown as Stripe.Checkout.Session;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.restoreAllMocks();
+});
+
+describe("Stripe webhook route — signature verification", () => {
+  it("400s when the stripe-signature header is missing", async () => {
+    const res = await POST(
+      new NextRequest("http://localhost/api/webhooks/stripe", {
+        method: "POST",
+        body: eventBody("checkout.session.completed"),
+      })
+    );
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "Missing signature" });
+    expect(handlerMock).not.toHaveBeenCalled();
+  });
+
+  it("400s on a signature minted with the wrong secret", async () => {
+    const res = await POST(
+      signedRequest(eventBody("checkout.session.completed"), "whsec_wrong")
+    );
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "Invalid signature" });
+    expect(handlerMock).not.toHaveBeenCalled();
+  });
+
+  it("400s when the body was tampered with after signing", async () => {
+    const body = eventBody("checkout.session.completed");
+    const signature = stripe.webhooks.generateTestHeaderString({
+      payload: body,
+      secret: WEBHOOK_SECRET,
+    });
+    const res = await POST(
+      new NextRequest("http://localhost/api/webhooks/stripe", {
+        method: "POST",
+        body: body.replace("cs_123", "cs_evil"),
+        headers: { "stripe-signature": signature },
+      })
+    );
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "Invalid signature" });
+  });
+});
+
+describe("Stripe webhook route — event routing", () => {
+  it("acknowledges unrelated event types without doing any work", async () => {
+    const retrieve = vi.spyOn(stripe.checkout.sessions, "retrieve");
+    const res = await POST(signedRequest(eventBody("payment_intent.succeeded")));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ received: true });
+    expect(retrieve).not.toHaveBeenCalled();
+    expect(handlerMock).not.toHaveBeenCalled();
+    expect(emailsMock).not.toHaveBeenCalled();
+  });
+
+  it("runs the handler with the translated session data on checkout.session.completed", async () => {
+    vi.spyOn(stripe.checkout.sessions, "retrieve").mockResolvedValue(
+      fakeFullSession() as never
+    );
+    handlerMock.mockResolvedValue({ action: "submitted" });
+
+    const res = await POST(signedRequest(eventBody("checkout.session.completed")));
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ received: true });
+    expect(handlerMock).toHaveBeenCalledTimes(1);
+    const [sessionData] = handlerMock.mock.calls[0];
+    expect(sessionData).toMatchObject({
+      id: "cs_123",
+      metadata: { orderId: "order-1", designId: "design-1" },
+      paymentIntentId: "pi_1",
+      amountTotal: 2412,
+      amountShipping: 469,
+      discount: null,
+      shipping: expect.objectContaining({ city: "Town", zip: "90001" }),
+    });
+  });
+
+  it("400s when the retrieved session is missing orderId/designId metadata", async () => {
+    vi.spyOn(stripe.checkout.sessions, "retrieve").mockResolvedValue(
+      fakeFullSession({ metadata: {} }) as never
+    );
+    const res = await POST(signedRequest(eventBody("checkout.session.completed")));
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "Missing metadata" });
+    expect(handlerMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("Stripe webhook route — error mapping (WP1 contract)", () => {
+  beforeEach(() => {
+    vi.spyOn(stripe.checkout.sessions, "retrieve").mockResolvedValue(
+      fakeFullSession() as never
+    );
+  });
+
+  it("returns 400 when the handler throws (pre-paid-claim failure → Stripe redelivers)", async () => {
+    handlerMock.mockRejectedValue(new Error("Order order-1 not found"));
+    const res = await POST(signedRequest(eventBody("checkout.session.completed")));
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "Processing failed" });
+    expect(emailsMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 200 (never 400) when fulfillment failed after the paid-claim", async () => {
+    // Per WP1, a Printful failure after the money moved resolves to
+    // paid_printful_failed instead of throwing — a 400 here would make Stripe
+    // redeliver an event that can only be skipped, stranding fulfillment on
+    // the daily cron.
+    handlerMock.mockResolvedValue({ action: "paid_printful_failed" });
+    const res = await POST(signedRequest(eventBody("checkout.session.completed")));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ received: true });
+  });
+});
+
+describe("Stripe webhook route — email branch", () => {
+  beforeEach(() => {
+    vi.spyOn(stripe.checkout.sessions, "retrieve").mockResolvedValue(
+      fakeFullSession() as never
+    );
+  });
+
+  it.each(["submitted", "paid", "paid_printful_failed"] as const)(
+    "sends post-order emails when the handler resolves %s",
+    async (action) => {
+      handlerMock.mockResolvedValue({ action });
+      const res = await POST(signedRequest(eventBody("checkout.session.completed")));
+      expect(res.status).toBe(200);
+      expect(emailsMock).toHaveBeenCalledTimes(1);
+      expect(emailsMock).toHaveBeenCalledWith("order-1", expect.anything());
+    }
+  );
+
+  it("does not send emails on a skipped redelivery", async () => {
+    handlerMock.mockResolvedValue({ action: "skipped" });
+    const res = await POST(signedRequest(eventBody("checkout.session.completed")));
+    expect(res.status).toBe(200);
+    expect(emailsMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/__tests__/__snapshots__/email-templates.test.ts.snap
+++ b/src/lib/__tests__/__snapshots__/email-templates.test.ts.snap
@@ -1,0 +1,378 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`emailLayout > omits optional sections cleanly when absent 1`] = `
+"
+    <body style="margin: 0; padding: 0; background: #fafafa;">
+      
+      <table role="presentation" cellpadding="0" cellspacing="0" width="100%" style="background: #fafafa; padding: 32px 16px;">
+        <tr>
+          <td align="center">
+            <table role="presentation" cellpadding="0" cellspacing="0" width="600" style="max-width: 600px; width: 100%; background: #ffffff; border: 1px solid #e4e4e7; border-radius: 16px; overflow: hidden; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;">
+              <tr>
+                <td style="background: #18181b; padding: 18px 28px;">
+                  <span style="color: #ffffff; font-size: 18px; font-weight: 700; letter-spacing: 0.18em;">PRNTD</span>
+                </td>
+              </tr>
+              <tr>
+                <td style="padding: 32px 28px 36px;">
+                  
+                  <h1 style="color: #18181b; font-size: 21px; font-weight: 700; margin: 0 0 12px; text-align: center;">Bare</h1>
+                  
+                  
+                  
+                </td>
+              </tr>
+              <tr>
+                <td style="border-top: 1px solid #e4e4e7; padding: 20px 28px; text-align: center;">
+                  <p style="color: #71717a; font-size: 12px; margin: 0;">PRNTD · <a href="https://prntd.org" style="color: #71717a; text-decoration: none;">prntd.org</a> · <a href="mailto:hello@prntd.org" style="color: #71717a; text-decoration: none;">hello@prntd.org</a></p>
+                </td>
+              </tr>
+            </table>
+          </td>
+        </tr>
+      </table>
+    </body>"
+`;
+
+exports[`emailLayout > renders the shared wrapper (header, card, footer, CTA, hero) stably 1`] = `
+"
+    <body style="margin: 0; padding: 0; background: #fafafa;">
+      <span style="display:none!important;opacity:0;color:transparent;height:0;width:0;overflow:hidden;">Preheader text</span>
+      <table role="presentation" cellpadding="0" cellspacing="0" width="100%" style="background: #fafafa; padding: 32px 16px;">
+        <tr>
+          <td align="center">
+            <table role="presentation" cellpadding="0" cellspacing="0" width="600" style="max-width: 600px; width: 100%; background: #ffffff; border: 1px solid #e4e4e7; border-radius: 16px; overflow: hidden; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;">
+              <tr>
+                <td style="background: #18181b; padding: 18px 28px;">
+                  <span style="color: #ffffff; font-size: 18px; font-weight: 700; letter-spacing: 0.18em;">PRNTD</span>
+                </td>
+              </tr>
+              <tr>
+                <td style="padding: 32px 28px 36px;">
+                  
+    <table role="presentation" cellpadding="0" cellspacing="0" align="center" style="margin: 0 auto 28px;">
+      <tr>
+        <td align="center" valign="top" style="padding: 0 8px;">
+          <div style="background: #f4f4f5; border-radius: 12px; padding: 14px; line-height: 0;">
+            <img src="https://mock.example/front-mockup.png" width="200" alt="Front design" style="display: block; width: 200px; max-width: 100%; height: auto; border-radius: 6px;" />
+          </div>
+          <div style="color: #71717a; font-size: 11px; letter-spacing: 0.08em; text-transform: uppercase; margin-top: 8px;">Front</div>
+        </td>
+        <td align="center" valign="top" style="padding: 0 8px;">
+          <div style="background: #0c0c0c; border-radius: 12px; padding: 14px; line-height: 0;">
+            <img src="https://img.example/back-artwork.png" width="200" alt="Back design" style="display: block; width: 200px; max-width: 100%; height: auto; border-radius: 6px;" />
+          </div>
+          <div style="color: #71717a; font-size: 11px; letter-spacing: 0.08em; text-transform: uppercase; margin-top: 8px;">Back</div>
+        </td></tr>
+    </table>
+                  <h1 style="color: #18181b; font-size: 21px; font-weight: 700; margin: 0 0 12px; text-align: center;">A heading</h1>
+                  <p style="color: #52525b; font-size: 15px; line-height: 1.5; margin: 0 0 24px;">An intro paragraph.</p>
+                  <p>Body</p>
+                  <p style="margin: 4px 0 0;"><a href="https://prntd.org/thing" style="display: inline-block; padding: 11px 22px; background: #18181b; color: #fff; text-decoration: none; border-radius: 8px; font-size: 14px; font-weight: 600;">Do the thing</a></p>
+                </td>
+              </tr>
+              <tr>
+                <td style="border-top: 1px solid #e4e4e7; padding: 20px 28px; text-align: center;">
+                  <p style="color: #71717a; font-size: 12px; margin: 0;">PRNTD · <a href="https://prntd.org" style="color: #71717a; text-decoration: none;">prntd.org</a> · <a href="mailto:hello@prntd.org" style="color: #71717a; text-decoration: none;">hello@prntd.org</a></p>
+                </td>
+              </tr>
+            </table>
+          </td>
+        </tr>
+      </table>
+    </body>"
+`;
+
+exports[`sendOrderConfirmation > multi-line cart order without display name > html 1`] = `
+"
+    <body style="margin: 0; padding: 0; background: #fafafa;">
+      <span style="display:none!important;opacity:0;color:transparent;height:0;width:0;overflow:hidden;">Your Classic Tee and 1 more is being printed.</span>
+      <table role="presentation" cellpadding="0" cellspacing="0" width="100%" style="background: #fafafa; padding: 32px 16px;">
+        <tr>
+          <td align="center">
+            <table role="presentation" cellpadding="0" cellspacing="0" width="600" style="max-width: 600px; width: 100%; background: #ffffff; border: 1px solid #e4e4e7; border-radius: 16px; overflow: hidden; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;">
+              <tr>
+                <td style="background: #18181b; padding: 18px 28px;">
+                  <span style="color: #ffffff; font-size: 18px; font-weight: 700; letter-spacing: 0.18em;">PRNTD</span>
+                </td>
+              </tr>
+              <tr>
+                <td style="padding: 32px 28px 36px;">
+                  
+                  <h1 style="color: #18181b; font-size: 21px; font-weight: 700; margin: 0 0 12px; text-align: center;">Your order is confirmed</h1>
+                  <p style="color: #52525b; font-size: 15px; line-height: 1.5; margin: 0 0 24px;">Your Classic Tee and 1 more is being printed. You'll get another email with tracking when it ships.</p>
+                  <table role="presentation" cellpadding="0" cellspacing="0" width="100%" style="border-collapse: collapse; margin: 0 0 24px;"><tr>
+    <td style="padding: 9px 0; color: #71717a; font-size: 14px; ">Order</td>
+    <td style="padding: 9px 0; text-align: right; font-size: 14px; color: #18181b;  font-family: ui-monospace, SFMono-Regular, Menlo, monospace; ">abcd1234</td>
+  </tr><tr>
+    <td style="padding: 9px 0; color: #71717a; font-size: 14px; ">Classic Tee</td>
+    <td style="padding: 9px 0; text-align: right; font-size: 14px; color: #18181b;   ">Black / M</td>
+  </tr><tr>
+    <td style="padding: 9px 0; color: #71717a; font-size: 14px; ">Box Tee ×2</td>
+    <td style="padding: 9px 0; text-align: right; font-size: 14px; color: #18181b;   ">White / L</td>
+  </tr><tr>
+    <td style="padding: 9px 0; color: #71717a; font-size: 14px; border-top: 1px solid #e4e4e7;">Total</td>
+    <td style="padding: 9px 0; text-align: right; font-size: 14px; color: #18181b; font-weight: 600;  border-top: 1px solid #e4e4e7;">$43.55</td>
+  </tr></table>
+                  <p style="margin: 4px 0 0;"><a href="https://prntd.org/orders" style="display: inline-block; padding: 11px 22px; background: #18181b; color: #fff; text-decoration: none; border-radius: 8px; font-size: 14px; font-weight: 600;">View your orders</a></p>
+                </td>
+              </tr>
+              <tr>
+                <td style="border-top: 1px solid #e4e4e7; padding: 20px 28px; text-align: center;">
+                  <p style="color: #71717a; font-size: 12px; margin: 0;">PRNTD · <a href="https://prntd.org" style="color: #71717a; text-decoration: none;">prntd.org</a> · <a href="mailto:hello@prntd.org" style="color: #71717a; text-decoration: none;">hello@prntd.org</a></p>
+                </td>
+              </tr>
+            </table>
+          </td>
+        </tr>
+      </table>
+    </body>"
+`;
+
+exports[`sendOrderConfirmation > multi-line cart order without display name > subject 1`] = `"Order confirmed — abcd1234 (Black M +1 more)"`;
+
+exports[`sendOrderConfirmation > single-line order with display name > html 1`] = `
+"
+    <body style="margin: 0; padding: 0; background: #fafafa;">
+      <span style="display:none!important;opacity:0;color:transparent;height:0;width:0;overflow:hidden;">Your Classic Tee is being printed.</span>
+      <table role="presentation" cellpadding="0" cellspacing="0" width="100%" style="background: #fafafa; padding: 32px 16px;">
+        <tr>
+          <td align="center">
+            <table role="presentation" cellpadding="0" cellspacing="0" width="600" style="max-width: 600px; width: 100%; background: #ffffff; border: 1px solid #e4e4e7; border-radius: 16px; overflow: hidden; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;">
+              <tr>
+                <td style="background: #18181b; padding: 18px 28px;">
+                  <span style="color: #ffffff; font-size: 18px; font-weight: 700; letter-spacing: 0.18em;">PRNTD</span>
+                </td>
+              </tr>
+              <tr>
+                <td style="padding: 32px 28px 36px;">
+                  
+    <table role="presentation" cellpadding="0" cellspacing="0" align="center" style="margin: 0 auto 28px;">
+      <tr>
+        <td align="center" valign="top" style="padding: 0 8px;">
+          <div style="background: #f4f4f5; border-radius: 12px; padding: 14px; line-height: 0;">
+            <img src="https://mock.example/front-mockup.png" width="280" alt="Front design" style="display: block; width: 280px; max-width: 100%; height: auto; border-radius: 6px;" />
+          </div>
+          
+        </td></tr>
+    </table>
+                  <h1 style="color: #18181b; font-size: 21px; font-weight: 700; margin: 0 0 12px; text-align: center;">Your order is confirmed</h1>
+                  <p style="color: #52525b; font-size: 15px; line-height: 1.5; margin: 0 0 24px;">Your Classic Tee is being printed. You'll get another email with tracking when it ships.</p>
+                  <table role="presentation" cellpadding="0" cellspacing="0" width="100%" style="border-collapse: collapse; margin: 0 0 24px;"><tr>
+    <td style="padding: 9px 0; color: #71717a; font-size: 14px; ">Design</td>
+    <td style="padding: 9px 0; text-align: right; font-size: 14px; color: #18181b;   ">Midnight Fox</td>
+  </tr><tr>
+    <td style="padding: 9px 0; color: #71717a; font-size: 14px; ">Order</td>
+    <td style="padding: 9px 0; text-align: right; font-size: 14px; color: #18181b;  font-family: ui-monospace, SFMono-Regular, Menlo, monospace; ">abcd1234</td>
+  </tr><tr>
+    <td style="padding: 9px 0; color: #71717a; font-size: 14px; ">Classic Tee</td>
+    <td style="padding: 9px 0; text-align: right; font-size: 14px; color: #18181b;   ">Black / M</td>
+  </tr><tr>
+    <td style="padding: 9px 0; color: #71717a; font-size: 14px; border-top: 1px solid #e4e4e7;">Total</td>
+    <td style="padding: 9px 0; text-align: right; font-size: 14px; color: #18181b; font-weight: 600;  border-top: 1px solid #e4e4e7;">$24.12</td>
+  </tr></table>
+                  <p style="margin: 4px 0 0;"><a href="https://prntd.org/orders" style="display: inline-block; padding: 11px 22px; background: #18181b; color: #fff; text-decoration: none; border-radius: 8px; font-size: 14px; font-weight: 600;">View your orders</a></p>
+                </td>
+              </tr>
+              <tr>
+                <td style="border-top: 1px solid #e4e4e7; padding: 20px 28px; text-align: center;">
+                  <p style="color: #71717a; font-size: 12px; margin: 0;">PRNTD · <a href="https://prntd.org" style="color: #71717a; text-decoration: none;">prntd.org</a> · <a href="mailto:hello@prntd.org" style="color: #71717a; text-decoration: none;">hello@prntd.org</a></p>
+                </td>
+              </tr>
+            </table>
+          </td>
+        </tr>
+      </table>
+    </body>"
+`;
+
+exports[`sendOrderConfirmation > single-line order with display name > subject 1`] = `"Order confirmed — Midnight Fox (Black M)"`;
+
+exports[`sendOwnerOrderAlert > renders the admin alert with discount and design rows > html 1`] = `
+"
+    <body style="margin: 0; padding: 0; background: #fafafa;">
+      
+      <table role="presentation" cellpadding="0" cellspacing="0" width="100%" style="background: #fafafa; padding: 32px 16px;">
+        <tr>
+          <td align="center">
+            <table role="presentation" cellpadding="0" cellspacing="0" width="600" style="max-width: 600px; width: 100%; background: #ffffff; border: 1px solid #e4e4e7; border-radius: 16px; overflow: hidden; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;">
+              <tr>
+                <td style="background: #18181b; padding: 18px 28px;">
+                  <span style="color: #ffffff; font-size: 18px; font-weight: 700; letter-spacing: 0.18em;">PRNTD</span>
+                </td>
+              </tr>
+              <tr>
+                <td style="padding: 32px 28px 36px;">
+                  
+    <table role="presentation" cellpadding="0" cellspacing="0" align="center" style="margin: 0 auto 28px;">
+      <tr>
+        <td align="center" valign="top" style="padding: 0 8px;">
+          <div style="background: #f4f4f5; border-radius: 12px; padding: 14px; line-height: 0;">
+            <img src="https://mock.example/front-mockup.png" width="280" alt="Front design" style="display: block; width: 280px; max-width: 100%; height: auto; border-radius: 6px;" />
+          </div>
+          
+        </td></tr>
+    </table>
+                  <h1 style="color: #18181b; font-size: 21px; font-weight: 700; margin: 0 0 12px; text-align: center;">New order</h1>
+                  
+                  <table role="presentation" cellpadding="0" cellspacing="0" width="100%" style="border-collapse: collapse; margin: 0 0 24px;"><tr>
+    <td style="padding: 9px 0; color: #71717a; font-size: 14px; ">Design</td>
+    <td style="padding: 9px 0; text-align: right; font-size: 14px; color: #18181b;   ">Midnight Fox</td>
+  </tr><tr>
+    <td style="padding: 9px 0; color: #71717a; font-size: 14px; ">Order</td>
+    <td style="padding: 9px 0; text-align: right; font-size: 14px; color: #18181b;  font-family: ui-monospace, SFMono-Regular, Menlo, monospace; ">abcd1234</td>
+  </tr><tr>
+    <td style="padding: 9px 0; color: #71717a; font-size: 14px; ">Customer</td>
+    <td style="padding: 9px 0; text-align: right; font-size: 14px; color: #18181b;   ">customer@example.com</td>
+  </tr><tr>
+    <td style="padding: 9px 0; color: #71717a; font-size: 14px; ">Classic Tee</td>
+    <td style="padding: 9px 0; text-align: right; font-size: 14px; color: #18181b;   ">Black / M</td>
+  </tr><tr>
+    <td style="padding: 9px 0; color: #71717a; font-size: 14px; ">Discount</td>
+    <td style="padding: 9px 0; text-align: right; font-size: 14px; color: #18181b;   ">HALF</td>
+  </tr><tr>
+    <td style="padding: 9px 0; color: #71717a; font-size: 14px; border-top: 1px solid #e4e4e7;">Total</td>
+    <td style="padding: 9px 0; text-align: right; font-size: 14px; color: #18181b; font-weight: 600;  border-top: 1px solid #e4e4e7;">$14.41</td>
+  </tr></table>
+                  <p style="margin: 4px 0 0;"><a href="https://prntd.org/admin/orders/abcd1234-5678-90ab-cdef-000000000000" style="display: inline-block; padding: 11px 22px; background: #18181b; color: #fff; text-decoration: none; border-radius: 8px; font-size: 14px; font-weight: 600;">View in admin</a></p>
+                </td>
+              </tr>
+              <tr>
+                <td style="border-top: 1px solid #e4e4e7; padding: 20px 28px; text-align: center;">
+                  <p style="color: #71717a; font-size: 12px; margin: 0;">PRNTD · <a href="https://prntd.org" style="color: #71717a; text-decoration: none;">prntd.org</a> · <a href="mailto:hello@prntd.org" style="color: #71717a; text-decoration: none;">hello@prntd.org</a></p>
+                </td>
+              </tr>
+            </table>
+          </td>
+        </tr>
+      </table>
+    </body>"
+`;
+
+exports[`sendOwnerOrderAlert > renders the admin alert with discount and design rows > subject 1`] = `"New order: Midnight Fox — Black M — $14.41"`;
+
+exports[`sendPasswordResetEmail > renders the reset CTA > html 1`] = `
+"
+    <body style="margin: 0; padding: 0; background: #fafafa;">
+      <span style="display:none!important;opacity:0;color:transparent;height:0;width:0;overflow:hidden;">Reset your PRNTD password</span>
+      <table role="presentation" cellpadding="0" cellspacing="0" width="100%" style="background: #fafafa; padding: 32px 16px;">
+        <tr>
+          <td align="center">
+            <table role="presentation" cellpadding="0" cellspacing="0" width="600" style="max-width: 600px; width: 100%; background: #ffffff; border: 1px solid #e4e4e7; border-radius: 16px; overflow: hidden; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;">
+              <tr>
+                <td style="background: #18181b; padding: 18px 28px;">
+                  <span style="color: #ffffff; font-size: 18px; font-weight: 700; letter-spacing: 0.18em;">PRNTD</span>
+                </td>
+              </tr>
+              <tr>
+                <td style="padding: 32px 28px 36px;">
+                  
+                  <h1 style="color: #18181b; font-size: 21px; font-weight: 700; margin: 0 0 12px; text-align: center;">Reset your password</h1>
+                  <p style="color: #52525b; font-size: 15px; line-height: 1.5; margin: 0 0 24px;">Click the button below to set a new password. This link expires in 1 hour. If you didn't request this, you can ignore this email.</p>
+                  
+                  <p style="margin: 4px 0 0;"><a href="https://prntd.org/reset-password?token=fixture-token" style="display: inline-block; padding: 11px 22px; background: #18181b; color: #fff; text-decoration: none; border-radius: 8px; font-size: 14px; font-weight: 600;">Reset password</a></p>
+                </td>
+              </tr>
+              <tr>
+                <td style="border-top: 1px solid #e4e4e7; padding: 20px 28px; text-align: center;">
+                  <p style="color: #71717a; font-size: 12px; margin: 0;">PRNTD · <a href="https://prntd.org" style="color: #71717a; text-decoration: none;">prntd.org</a> · <a href="mailto:hello@prntd.org" style="color: #71717a; text-decoration: none;">hello@prntd.org</a></p>
+                </td>
+              </tr>
+            </table>
+          </td>
+        </tr>
+      </table>
+    </body>"
+`;
+
+exports[`sendPasswordResetEmail > renders the reset CTA > subject 1`] = `"Reset your password"`;
+
+exports[`sendShippingNotification > with tracking number and URL > html 1`] = `
+"
+    <body style="margin: 0; padding: 0; background: #fafafa;">
+      <span style="display:none!important;opacity:0;color:transparent;height:0;width:0;overflow:hidden;">"Midnight Fox" (order abcd1234) has shipped.</span>
+      <table role="presentation" cellpadding="0" cellspacing="0" width="100%" style="background: #fafafa; padding: 32px 16px;">
+        <tr>
+          <td align="center">
+            <table role="presentation" cellpadding="0" cellspacing="0" width="600" style="max-width: 600px; width: 100%; background: #ffffff; border: 1px solid #e4e4e7; border-radius: 16px; overflow: hidden; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;">
+              <tr>
+                <td style="background: #18181b; padding: 18px 28px;">
+                  <span style="color: #ffffff; font-size: 18px; font-weight: 700; letter-spacing: 0.18em;">PRNTD</span>
+                </td>
+              </tr>
+              <tr>
+                <td style="padding: 32px 28px 36px;">
+                  
+    <table role="presentation" cellpadding="0" cellspacing="0" align="center" style="margin: 0 auto 28px;">
+      <tr>
+        <td align="center" valign="top" style="padding: 0 8px;">
+          <div style="background: #f4f4f5; border-radius: 12px; padding: 14px; line-height: 0;">
+            <img src="https://mock.example/front-mockup.png" width="200" alt="Front design" style="display: block; width: 200px; max-width: 100%; height: auto; border-radius: 6px;" />
+          </div>
+          <div style="color: #71717a; font-size: 11px; letter-spacing: 0.08em; text-transform: uppercase; margin-top: 8px;">Front</div>
+        </td>
+        <td align="center" valign="top" style="padding: 0 8px;">
+          <div style="background: #0c0c0c; border-radius: 12px; padding: 14px; line-height: 0;">
+            <img src="https://img.example/back-artwork.png" width="200" alt="Back design" style="display: block; width: 200px; max-width: 100%; height: auto; border-radius: 6px;" />
+          </div>
+          <div style="color: #71717a; font-size: 11px; letter-spacing: 0.08em; text-transform: uppercase; margin-top: 8px;">Back</div>
+        </td></tr>
+    </table>
+                  <h1 style="color: #18181b; font-size: 21px; font-weight: 700; margin: 0 0 12px; text-align: center;">Your order is on the way</h1>
+                  <p style="color: #52525b; font-size: 15px; line-height: 1.5; margin: 0 0 24px;">"Midnight Fox" (order abcd1234) has shipped.</p>
+                  <table role="presentation" cellpadding="0" cellspacing="0" width="100%" style="border-collapse: collapse; margin: 0 0 24px;"><tr>
+    <td style="padding: 9px 0; color: #71717a; font-size: 14px; ">Tracking #</td>
+    <td style="padding: 9px 0; text-align: right; font-size: 14px; color: #18181b;  font-family: ui-monospace, SFMono-Regular, Menlo, monospace; ">1Z999AA10123456784</td>
+  </tr></table>
+                  <p style="margin: 4px 0 0;"><a href="https://track.example/1Z999AA10123456784" style="display: inline-block; padding: 11px 22px; background: #18181b; color: #fff; text-decoration: none; border-radius: 8px; font-size: 14px; font-weight: 600;">Track your package</a></p>
+                </td>
+              </tr>
+              <tr>
+                <td style="border-top: 1px solid #e4e4e7; padding: 20px 28px; text-align: center;">
+                  <p style="color: #71717a; font-size: 12px; margin: 0;">PRNTD · <a href="https://prntd.org" style="color: #71717a; text-decoration: none;">prntd.org</a> · <a href="mailto:hello@prntd.org" style="color: #71717a; text-decoration: none;">hello@prntd.org</a></p>
+                </td>
+              </tr>
+            </table>
+          </td>
+        </tr>
+      </table>
+    </body>"
+`;
+
+exports[`sendShippingNotification > with tracking number and URL > subject 1`] = `"Your order shipped — Midnight Fox"`;
+
+exports[`sendShippingNotification > without tracking info yet > html 1`] = `
+"
+    <body style="margin: 0; padding: 0; background: #fafafa;">
+      <span style="display:none!important;opacity:0;color:transparent;height:0;width:0;overflow:hidden;">Order abcd1234 has shipped.</span>
+      <table role="presentation" cellpadding="0" cellspacing="0" width="100%" style="background: #fafafa; padding: 32px 16px;">
+        <tr>
+          <td align="center">
+            <table role="presentation" cellpadding="0" cellspacing="0" width="600" style="max-width: 600px; width: 100%; background: #ffffff; border: 1px solid #e4e4e7; border-radius: 16px; overflow: hidden; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;">
+              <tr>
+                <td style="background: #18181b; padding: 18px 28px;">
+                  <span style="color: #ffffff; font-size: 18px; font-weight: 700; letter-spacing: 0.18em;">PRNTD</span>
+                </td>
+              </tr>
+              <tr>
+                <td style="padding: 32px 28px 36px;">
+                  
+                  <h1 style="color: #18181b; font-size: 21px; font-weight: 700; margin: 0 0 12px; text-align: center;">Your order is on the way</h1>
+                  <p style="color: #52525b; font-size: 15px; line-height: 1.5; margin: 0 0 24px;">Order abcd1234 has shipped.</p>
+                  <p style="color: #52525b; font-size: 14px; text-align: center; margin: 0 0 24px;">Tracking info will be available soon.</p>
+                  
+                </td>
+              </tr>
+              <tr>
+                <td style="border-top: 1px solid #e4e4e7; padding: 20px 28px; text-align: center;">
+                  <p style="color: #71717a; font-size: 12px; margin: 0;">PRNTD · <a href="https://prntd.org" style="color: #71717a; text-decoration: none;">prntd.org</a> · <a href="mailto:hello@prntd.org" style="color: #71717a; text-decoration: none;">hello@prntd.org</a></p>
+                </td>
+              </tr>
+            </table>
+          </td>
+        </tr>
+      </table>
+    </body>"
+`;
+
+exports[`sendShippingNotification > without tracking info yet > subject 1`] = `"Your order shipped — abcd1234"`;

--- a/src/lib/__tests__/email-templates.test.ts
+++ b/src/lib/__tests__/email-templates.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Email template snapshots (WP5). Renders each shared-emailLayout template with
+ * fixed fixture data and snapshots the exact HTML + subject, so copy/layout
+ * regressions show up as reviewable diffs instead of shipping silently.
+ * Resend is mocked; nothing leaves the process.
+ *
+ * If a snapshot diff is INTENTIONAL (copy change, layout tweak), re-run with
+ * `npx vitest run -u src/lib/__tests__/email-templates.test.ts` and review the
+ * updated snapshot in the PR.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const sendMock = vi.hoisted(() => vi.fn().mockResolvedValue({ data: { id: "email_1" } }));
+vi.mock("resend", () => ({
+  Resend: vi.fn(() => ({ emails: { send: sendMock } })),
+}));
+
+import {
+  emailLayout,
+  sendOrderConfirmation,
+  sendOwnerOrderAlert,
+  sendShippingNotification,
+  sendPasswordResetEmail,
+} from "@/lib/email";
+
+type SentEmail = {
+  to: string;
+  subject: string;
+  html: string;
+};
+
+function lastSent(): SentEmail {
+  expect(sendMock).toHaveBeenCalledTimes(1);
+  return sendMock.mock.calls[0][0] as SentEmail;
+}
+
+const FRONT_IMAGE = {
+  label: "Front",
+  url: "https://mock.example/front-mockup.png",
+  backdrop: null,
+};
+const BACK_IMAGE = {
+  label: "Back",
+  url: "https://img.example/back-artwork.png",
+  backdrop: "#0c0c0c",
+};
+
+beforeEach(() => {
+  sendMock.mockClear();
+});
+
+describe("emailLayout", () => {
+  it("renders the shared wrapper (header, card, footer, CTA, hero) stably", () => {
+    const html = emailLayout({
+      preheader: "Preheader text",
+      heading: "A heading",
+      intro: "An intro paragraph.",
+      images: [FRONT_IMAGE, BACK_IMAGE],
+      bodyHtml: "<p>Body</p>",
+      ctaLabel: "Do the thing",
+      ctaUrl: "https://prntd.org/thing",
+    });
+    expect(html).toMatchSnapshot();
+  });
+
+  it("omits optional sections cleanly when absent", () => {
+    expect(emailLayout({ heading: "Bare" })).toMatchSnapshot();
+  });
+});
+
+describe("sendOrderConfirmation", () => {
+  it("single-line order with display name", async () => {
+    await sendOrderConfirmation({
+      to: "customer@example.com",
+      orderId: "abcd1234-5678-90ab-cdef-000000000000",
+      total: 24.12,
+      lines: [
+        { productName: "Classic Tee", size: "M", color: "Black", quantity: 1 },
+      ],
+      displayName: "Midnight Fox",
+      images: [FRONT_IMAGE],
+    });
+    const sent = lastSent();
+    expect(sent.to).toBe("customer@example.com");
+    expect(sent.subject).toMatchSnapshot("subject");
+    expect(sent.html).toMatchSnapshot("html");
+  });
+
+  it("multi-line cart order without display name", async () => {
+    await sendOrderConfirmation({
+      to: "customer@example.com",
+      orderId: "abcd1234-5678-90ab-cdef-000000000000",
+      total: 43.55,
+      lines: [
+        { productName: "Classic Tee", size: "M", color: "Black", quantity: 1 },
+        { productName: "Box Tee", size: "L", color: "White", quantity: 2 },
+      ],
+      displayName: null,
+    });
+    const sent = lastSent();
+    expect(sent.subject).toMatchSnapshot("subject");
+    expect(sent.html).toMatchSnapshot("html");
+  });
+});
+
+describe("sendOwnerOrderAlert", () => {
+  it("renders the admin alert with discount and design rows", async () => {
+    await sendOwnerOrderAlert({
+      orderId: "abcd1234-5678-90ab-cdef-000000000000",
+      customerEmail: "customer@example.com",
+      total: 14.41,
+      lines: [
+        { productName: "Classic Tee", size: "M", color: "Black", quantity: 1 },
+      ],
+      discountCode: "HALF",
+      displayName: "Midnight Fox",
+      images: [FRONT_IMAGE],
+    });
+    const sent = lastSent();
+    expect(sent.subject).toMatchSnapshot("subject");
+    expect(sent.html).toMatchSnapshot("html");
+  });
+});
+
+describe("sendShippingNotification", () => {
+  it("with tracking number and URL", async () => {
+    await sendShippingNotification({
+      to: "customer@example.com",
+      orderId: "abcd1234-5678-90ab-cdef-000000000000",
+      trackingNumber: "1Z999AA10123456784",
+      trackingUrl: "https://track.example/1Z999AA10123456784",
+      displayName: "Midnight Fox",
+      images: [FRONT_IMAGE, BACK_IMAGE],
+    });
+    const sent = lastSent();
+    expect(sent.subject).toMatchSnapshot("subject");
+    expect(sent.html).toMatchSnapshot("html");
+  });
+
+  it("without tracking info yet", async () => {
+    await sendShippingNotification({
+      to: "customer@example.com",
+      orderId: "abcd1234-5678-90ab-cdef-000000000000",
+      trackingNumber: null,
+      trackingUrl: null,
+      displayName: null,
+    });
+    const sent = lastSent();
+    expect(sent.subject).toMatchSnapshot("subject");
+    expect(sent.html).toMatchSnapshot("html");
+  });
+});
+
+describe("sendPasswordResetEmail", () => {
+  it("renders the reset CTA", async () => {
+    await sendPasswordResetEmail({
+      to: "customer@example.com",
+      url: "https://prntd.org/reset-password?token=fixture-token",
+    });
+    const sent = lastSent();
+    expect(sent.subject).toMatchSnapshot("subject");
+    expect(sent.html).toMatchSnapshot("html");
+  });
+});

--- a/src/lib/__tests__/order-state.test.ts
+++ b/src/lib/__tests__/order-state.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   canTransition,
   assertTransition,
+  canArchiveOrder,
   VALID_TRANSITIONS,
 } from "../order-state";
 
@@ -67,5 +68,48 @@ describe("VALID_TRANSITIONS", () => {
     for (const s of statuses) {
       expect(VALID_TRANSITIONS).toHaveProperty(s);
     }
+  });
+});
+
+describe("canArchiveOrder", () => {
+  const base = { trackingNumber: null, printfulOrderId: null };
+
+  it("allows pre-fulfillment statuses with no Printful footprint", () => {
+    for (const status of ["pending", "paid", "canceled"]) {
+      expect(canArchiveOrder({ ...base, status })).toBe(true);
+    }
+  });
+
+  it("blocks shipped and delivered orders", () => {
+    expect(canArchiveOrder({ ...base, status: "shipped" })).toBe(false);
+    expect(canArchiveOrder({ ...base, status: "delivered" })).toBe(false);
+  });
+
+  it("blocks any order with a Printful order id, regardless of status", () => {
+    expect(
+      canArchiveOrder({ ...base, status: "paid", printfulOrderId: "9999" })
+    ).toBe(false);
+    // A canceled order that WAS submitted keeps its Printful id — still locked.
+    expect(
+      canArchiveOrder({ ...base, status: "canceled", printfulOrderId: "9999" })
+    ).toBe(false);
+  });
+
+  it("blocks any order with a tracking number", () => {
+    expect(
+      canArchiveOrder({ ...base, status: "paid", trackingNumber: "1Z999" })
+    ).toBe(false);
+  });
+
+  it("treats an empty-string tracking number as absent (matches the old truthiness check)", () => {
+    expect(
+      canArchiveOrder({ ...base, status: "pending", trackingNumber: "" })
+    ).toBe(true);
+  });
+
+  it("blocks submitted orders (they always carry a Printful id in practice)", () => {
+    expect(
+      canArchiveOrder({ status: "submitted", trackingNumber: null, printfulOrderId: "8888" })
+    ).toBe(false);
   });
 });

--- a/src/lib/order-state.ts
+++ b/src/lib/order-state.ts
@@ -28,3 +28,22 @@ export function assertTransition(from: string, to: string): void {
     );
   }
 }
+
+/**
+ * Whether an admin may archive this order. Anything already submitted to
+ * Printful (an id or tracking exists) or past it (shipped/delivered) must stay
+ * visible — archiving is for pre-fulfillment dead ends (abandoned pending,
+ * canceled-before-submit, test noise).
+ */
+export function canArchiveOrder(order: {
+  status: string;
+  trackingNumber: string | null;
+  printfulOrderId: string | null;
+}): boolean {
+  return !(
+    order.status === "shipped" ||
+    order.status === "delivered" ||
+    Boolean(order.trackingNumber) ||
+    Boolean(order.printfulOrderId)
+  );
+}


### PR DESCRIPTION
Closes out the WP5 candidate list from the 2026-07-18 test-strategy review (all route/unit/integration level — the one Stripe test-mode e2e is a separate track).

## What's covered

**Stripe webhook route** (`src/app/api/webhooks/stripe/__tests__/route.test.ts`, 12 tests)
- Signature verification with the real `stripe.webhooks.constructEvent` against headers minted by `generateTestHeaderString` (missing header, wrong secret, tampered body → 400). No crypto mocked.
- Event routing: unrelated event types are acknowledged without touching Stripe or the handler; `checkout.session.completed` runs `toStripeSessionData` (real) → handler with the translated payload; missing metadata → 400.
- Error mapping locks the WP1 contract: a handler **throw** (only reachable pre-paid-claim) → 400 so Stripe redelivers; post-claim failures arrive as resolved actions (`paid`, `paid_printful_failed`) and must return **200**.
- Email branch: `sendPostOrderEmails` fires on submitted / paid / paid_printful_failed, not on skipped.

**Printful webhook route** (`src/app/api/webhooks/printful/__tests__/route.test.ts`, 9 tests)
- Runs against a real in-memory DB (`@/lib/db` mocked as a getter onto `createTestDb`), so the route's own joins and the shipping-email hero resolution execute for real — including both hero paths: cached Printful mockup (no backdrop) and artwork-on-shirt-color fallback (`getColorHex`).
- `package_shipped` (status + tracking + email payload), `order_canceled` (COGS reversal booked, no phantom `refund` row), redelivery at target status → 200 `ignored` with no duplicate email/ledger row, invalid JSON → 400, unknown Printful id → 404.

**`canArchiveOrder` extraction** (`src/lib/order-state.ts` + 6 tests in `order-state.test.ts`)
- The inline archive guard in `src/app/admin/actions.ts` is now a pure helper; behavior identical (same truthiness semantics, locked by a test). Only product-code change in the PR.

**Email template snapshots** (`src/lib/__tests__/email-templates.test.ts`, 8 tests / 14 snapshots)
- Every `emailLayout` sender (order confirmation single- and multi-line, owner alert with discount, shipping with/without tracking, password reset) rendered with fixed fixtures, Resend mocked. Copy/layout regressions now surface as snapshot diffs.

**`getFinancialSummary` integration** (`src/app/admin/__tests__/financial-summary.integration.test.ts`, 7 tests)
- Real-DB: seeds orders across classifications with ledger rows; asserts the grouped-sum → `summarizeLedger` math for unfiltered / `all` / `customer` / `test`, `refund_cogs_reversal` as a COGS correction (WP1), and the non-admin rejection. Also exercises `archiveOrder` allow/refuse through the new helper.
- Asserts CURRENT behavior, including two quirks documented inline (not changed here): archived orders drop out of `orderCount` but their ledger rows still sum, and unfiltered summaries include `test`-classified money (the docs/test-orders-and-accounting.md proposal would change the latter).

**Cron route auth** (`src/app/api/cron/retry-fulfillment/__tests__/route.test.ts`, 5 tests)
- Unset `CRON_SECRET` → 500 (misconfiguration, not an open door), missing/wrong/prefix-less Bearer → 401 without running the sweep, correct secret → 200 with the core's result and the shared fulfillment deps wired.

## Notes

- Route tests live next to their routes with `// @vitest-environment node` pragmas (app-dir tests default to jsdom).
- Suite: 672 tests green (was 625). Lint 0 errors, typecheck clean, build green under the CI dummy env.
- Found while writing these (no fix included, pre-existing + by design): `getFinancialSummary`'s ledger query never filters archived orders, so an archived order's money still counts while the order itself doesn't — flagged in-test as current behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016r36fkFu4LKU1jtBKAt2xR