### PR TITLE
fix(e2e): drive Stripe's new accordion checkout in the money-path spec

### DIFF
--- a/e2e/stripe-money-path.spec.ts
+++ b/e2e/stripe-money-path.spec.ts
@@ -56,12 +56,13 @@ async function fillFirstVisible(
  * present and skipped when not.
  */
 async function completeStripeCheckout(page: Page, email: string) {
-  // The card number field is the last thing to hydrate; once it's visible the
-  // form is interactable.
-  const cardNumber = page
-    .locator("#cardNumber")
-    .or(page.getByPlaceholder("1234 1234 1234 1234"));
-  await expect(cardNumber.first()).toBeVisible({ timeout: 60_000 });
+  // The form is interactable once the email field renders. (The card fields
+  // can't be the readiness signal: payment methods are a collapsed accordion
+  // and the card inputs don't mount until the Card method is expanded.)
+  const emailField = page
+    .locator("#email")
+    .or(page.getByRole("textbox", { name: /email/i }));
+  await expect(emailField.first()).toBeVisible({ timeout: 60_000 });
 
   const filledEmail = await fillFirstVisible(
     [page.locator("#email"), page.getByRole("textbox", { name: /email/i })],
@@ -96,7 +97,36 @@ async function completeStripeCheckout(page: Page, email: string) {
     await stateSelect.selectOption("WA");
   }
 
-  // Card details. The 4242 test card never triggers 3DS.
+  // Card details. Expand the Card accordion first when the inputs aren't
+  // already mounted (Stripe lists Card / Cash App / Klarna / … collapsed).
+  // Every click is bounded: an unbounded click on this accordion hung until
+  // the test timeout once (actionability retried forever on a target that
+  // never stabilized).
+  const cardNumber = page
+    .locator("#cardNumber")
+    .or(page.getByPlaceholder("1234 1234 1234 1234"));
+  const cardExpanders = [
+    page.getByRole("radio", { name: /^Card$/ }),
+    page.getByRole("listitem").filter({ hasText: /^Card\b/ }),
+    page.getByRole("button", { name: /pay with card/i }),
+  ];
+  for (const expander of cardExpanders) {
+    if (await cardNumber.first().isVisible().catch(() => false)) break;
+    const target = expander.first();
+    if (!(await target.isVisible().catch(() => false))) continue;
+    const clicked = await target
+      .click({ timeout: 5_000 })
+      .then(() => true)
+      .catch(() => false);
+    if (!clicked) {
+      // Custom radios are often visually hidden or covered — skip
+      // actionability checks as a last resort.
+      await target.click({ timeout: 5_000, force: true }).catch(() => {});
+    }
+  }
+  await expect(cardNumber.first()).toBeVisible({ timeout: 30_000 });
+
+  // The 4242 test card never triggers 3DS.
   await cardNumber.first().fill(TEST_CARD);
   await fillFirstVisible(
     [page.locator("#cardExpiry"), page.getByPlaceholder("MM / YY")],
@@ -111,9 +141,24 @@ async function completeStripeCheckout(page: Page, email: string) {
     "E2E Stripe Buyer"
   );
 
+  // "Save my information" (Link) is checked by default and makes the empty
+  // phone-number field required — Pay then fails client-side validation and
+  // never navigates. Uncheck it.
+  const saveInfo = page.getByRole("checkbox", { name: /save my information/i });
+  if (await saveInfo.first().isChecked().catch(() => false)) {
+    await saveInfo
+      .first()
+      .uncheck({ timeout: 5_000 })
+      .catch(() =>
+        saveInfo.first().click({ timeout: 5_000, force: true }).catch(() => {})
+      );
+  }
+
+  // /^Pay\b/ would also match the accordion's "Pay with card" / "Pay with
+  // Klarna" buttons, which precede the submit button in the DOM.
   const payButton = page
     .getByTestId("hosted-payment-submit-button")
-    .or(page.getByRole("button", { name: /^Pay/ }));
+    .or(page.getByRole("button", { name: /^Pay(\s*\$[\d.,]+)?$/ }));
   await payButton.first().click({ timeout: 30_000 });
 }
 


### PR DESCRIPTION
First live run of the #99 Stripe e2e (predicted to need selector tweaks) hit three layout changes on Stripe's hosted checkout, fixed iteratively against real runs:

1. **Card inputs don't exist until the Card accordion expands.** Payment methods render collapsed (Card / Cash App / Klarna / Amazon Pay / Bank). The spec waited 60s for `#cardNumber`, which never mounts. Readiness now gates on the email field; the accordion is expanded via bounded clicks (radio → list row → button, 5s each) with a force-click fallback — the plain radio click fails actionability, force works. An earlier unbounded click here hung until the 300s test timeout.
2. **`/^Pay/` matched the wrong buttons.** The per-method "Pay with card"/"Pay with Klarna" buttons precede the submit button in the DOM. Matcher is now testid-first with an exact `Pay`/`Pay $X` fallback.
3. **Link's "Save my information" is checked by default** and makes the empty phone-number field required — Pay then fails client-side validation and never navigates (this burned a full 120s waitForURL). The spec unchecks it before paying.

Verified green live: 28.6s, real test-mode payment → signed webhook → paid → dry-run Printful → sale/stripe_fee ledger asserts. The `generateOrderName` 400 seen in the run is a seed artifact (placehold.co blocks Anthropic's image fetcher via robots.txt) and the handler degrades as designed.

Note: this spec self-skips in CI (no test key), so CI green here doesn't exercise it — the live run above is the evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FYw9FZQzyH1wkvnXzKMgL3