### PR TITLE
fix: mockup R2 keys carry product/source/scale + content hash (#102)

### DIFF
--- a/src/app/preview/actions.ts
+++ b/src/app/preview/actions.ts
@@ -17,6 +17,10 @@ import {
   type AspectRatio,
 } from "@/lib/blanks";
 import { uploadMockupImage, uploadDesignImage } from "@/lib/r2";
+import {
+  mockupCacheKey,
+  mockupCacheProductPrefix,
+} from "@/lib/mockup-cache";
 import { generateAnchoredTransparent } from "@/lib/replicate";
 import {
   insertDesignImage,
@@ -107,11 +111,16 @@ export async function generateMockup(
   const scaleKey = Math.round(clampedScale * 100);
 
   // Cache key includes product, placement, scale, and (for non-front) the
-  // source pick so two back choices don't collide on one key. Placement was
-  // added in #25 2.1; front keys stay `${product}:front:${color}:${scale}`.
-  const cacheKey = sourceImageId
-    ? `${productId}:${placementId}:${sourceImageId}:${colorName}:${scaleKey}`
-    : `${productId}:${placementId}:${colorName}:${scaleKey}`;
+  // source pick so two back choices don't collide on one key (#25 2.1). The
+  // shared builder version-bumps the format (#102) so pre-fix entries — whose
+  // URLs point at collided R2 objects — never satisfy a lookup again.
+  const cacheKey = mockupCacheKey({
+    productId,
+    placementId,
+    sourceImageId,
+    colorName,
+    scaleKey,
+  });
   const cached = found.mockupUrls?.[cacheKey];
   if (cached) return { mockupUrl: cached };
 
@@ -187,7 +196,13 @@ export async function generateMockup(
   // Download and persist to R2
   const response = await fetch(tempUrl);
   const buffer = Buffer.from(await response.arrayBuffer());
-  const r2Url = await uploadMockupImage(designId, colorName, buffer, placement.id);
+  const r2Url = await uploadMockupImage(designId, buffer, {
+    productId,
+    placementId: placement.id,
+    sourceImageId,
+    colorName,
+    scaleKey,
+  });
 
   // Re-read before update to avoid clobbering concurrent preloads
   const fresh = await db.query.design.findFirst({
@@ -394,7 +409,9 @@ export async function ensureMockupsPrefetched(
     throw new Error("Unauthorized");
   }
 
-  const prefix = `${productId}:`;
+  // Current-version entries only — pre-#102 entries point at collided
+  // objects, so their presence must not suppress a re-prefetch.
+  const prefix = mockupCacheProductPrefix(productId);
   const hasAny = Object.keys(found.mockupUrls ?? {}).some((k) =>
     k.startsWith(prefix)
   );
@@ -489,9 +506,14 @@ export async function prefetchProductMockups(
           const response = await fetch(r.mockupUrl);
           if (!response.ok) throw new Error(`fetch ${response.status}`);
           const buffer = Buffer.from(await response.arrayBuffer());
-          const r2Url = await uploadMockupImage(designId, colorName, buffer, "front");
-          // Cache key matches generateMockup: productId:placement:color:scale (100 = 1.0)
-          newEntries[`${productId}:front:${colorName}:100`] = r2Url;
+          const parts = {
+            productId,
+            placementId: "front",
+            colorName,
+            scaleKey: 100,
+          };
+          const r2Url = await uploadMockupImage(designId, buffer, parts);
+          newEntries[mockupCacheKey(parts)] = r2Url;
         } catch (err) {
           const msg = err instanceof Error ? err.message : String(err);
           console.warn(

--- a/src/app/preview/page.tsx
+++ b/src/app/preview/page.tsx
@@ -39,6 +39,7 @@ import {
   mockupBackdrop,
   resolveHeroDisplay,
 } from "@/lib/instant-preview";
+import { mockupCacheKey } from "@/lib/mockup-cache";
 
 type Placement = "front" | "back";
 
@@ -372,11 +373,15 @@ function PreviewPageInner() {
     // the mockup matches the pick and the cache key doesn't collide (#25).
     const sourceImageId = placement === "back" ? backImageId ?? undefined : undefined;
     const scaleKey = Math.round(scale * 100);
-    // Key must match the server's cache key (#25 2.1): front stays
-    // product:placement:color:scale; non-front inserts the source pick.
-    const cacheKey = sourceImageId
-      ? `${productId}:${placement}:${sourceImageId}:${colorName}:${scaleKey}`
-      : `${productId}:${placement}:${colorName}:${scaleKey}`;
+    // Shared builder keeps this in lockstep with the server's cache key —
+    // entries warmed from design.mockupUrls only hit when formats match.
+    const cacheKey = mockupCacheKey({
+      productId,
+      placementId: placement,
+      sourceImageId,
+      colorName,
+      scaleKey,
+    });
 
     const cached = mockupCache.current.get(cacheKey);
     if (cached) {

--- a/src/lib/__tests__/email-images.test.ts
+++ b/src/lib/__tests__/email-images.test.ts
@@ -89,6 +89,30 @@ describe("resolveOrderEmailImages", () => {
     expect(images.map((i) => i.label)).toEqual(["Front"]);
   });
 
+  it("matches version-prefixed (v2, #102) cache keys, front and back", () => {
+    const images = resolveOrderEmailImages({
+      ...BASE,
+      placements: { front: "img-front", back: "img-back" },
+      mockupUrls: {
+        "v2:bella-canvas-3001:front:White:100": "https://printful/v2-front.png",
+        "v2:bella-canvas-3001:back:img-back:White:100": "https://printful/v2-back.png",
+      },
+    });
+    expect(images.map((i) => i.url)).toEqual([
+      "https://printful/v2-front.png",
+      "https://printful/v2-back.png",
+    ]);
+  });
+
+  it("a version segment alone is not a match (v2-only entries, old-format lookup misses)", () => {
+    const images = resolveOrderEmailImages({
+      ...BASE,
+      placements: { front: "img-front" },
+      mockupUrls: { "v2:other-product:front:White:100": "https://printful/wrong.png" },
+    });
+    expect(images[0].url).toBe("https://r2/front.png");
+  });
+
   it("omits an image entirely when neither mockup nor artwork is available", () => {
     const images = resolveOrderEmailImages({
       ...BASE,

--- a/src/lib/__tests__/mockup-cache.test.ts
+++ b/src/lib/__tests__/mockup-cache.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from "vitest";
+import {
+  mockupCacheKey,
+  mockupCacheProductPrefix,
+  mockupObjectKey,
+} from "../mockup-cache";
+
+describe("mockupCacheKey", () => {
+  it("front key: version, product, placement, color, scale", () => {
+    expect(
+      mockupCacheKey({
+        productId: "bella-canvas-3001",
+        placementId: "front",
+        colorName: "White",
+        scaleKey: 100,
+      })
+    ).toBe("v2:bella-canvas-3001:front:White:100");
+  });
+
+  it("back key inserts the source pick", () => {
+    expect(
+      mockupCacheKey({
+        productId: "bella-canvas-3001",
+        placementId: "back",
+        sourceImageId: "img-abc",
+        colorName: "Black",
+        scaleKey: 80,
+      })
+    ).toBe("v2:bella-canvas-3001:back:img-abc:Black:80");
+  });
+
+  it("product prefix matches its keys and only its keys", () => {
+    const prefix = mockupCacheProductPrefix("bella-canvas-3001");
+    expect(
+      mockupCacheKey({
+        productId: "bella-canvas-3001",
+        placementId: "front",
+        colorName: "White",
+        scaleKey: 100,
+      }).startsWith(prefix)
+    ).toBe(true);
+    // Pre-#102 entries (no version segment) must not match — their URLs
+    // point at collided objects.
+    expect("bella-canvas-3001:front:White:100".startsWith(prefix)).toBe(false);
+    expect(
+      mockupCacheKey({
+        productId: "box-tee",
+        placementId: "front",
+        colorName: "White",
+        scaleKey: 100,
+      }).startsWith(prefix)
+    ).toBe(false);
+  });
+});
+
+describe("mockupObjectKey", () => {
+  const base = {
+    productId: "bella-canvas-3001",
+    placementId: "back",
+    colorName: "Vintage White",
+    scaleKey: 100,
+  };
+
+  it("distinct back sources → distinct object keys (#102)", () => {
+    const a = mockupObjectKey("d1", { ...base, sourceImageId: "src-a" }, "h1");
+    const b = mockupObjectKey("d1", { ...base, sourceImageId: "src-b" }, "h1");
+    expect(a).not.toBe(b);
+  });
+
+  it("distinct products and scales → distinct object keys", () => {
+    const tee = mockupObjectKey("d1", base, "h1");
+    const box = mockupObjectKey("d1", { ...base, productId: "box-tee" }, "h1");
+    const small = mockupObjectKey("d1", { ...base, scaleKey: 60 }, "h1");
+    expect(new Set([tee, box, small]).size).toBe(3);
+  });
+
+  it("content hash changes the key, so re-renders get fresh URLs", () => {
+    expect(mockupObjectKey("d1", base, "aaaa1111")).not.toBe(
+      mockupObjectKey("d1", base, "bbbb2222")
+    );
+  });
+
+  it("slugs multi-word colors and stays under the design's mockups prefix", () => {
+    const key = mockupObjectKey("d1", base, "h1");
+    expect(key.startsWith("designs/d1/mockups/")).toBe(true);
+    expect(key).toContain("vintage-white");
+    expect(key.endsWith(".jpg")).toBe(true);
+  });
+});

--- a/src/lib/email-images.ts
+++ b/src/lib/email-images.ts
@@ -23,7 +23,9 @@ export type EmailImage = {
  * Find a cached mockup URL by matching key segments, ignoring the trailing
  * scale segment so a mockup rendered at a non-default scale still resolves.
  * Front keys are `${product}:front:${color}:${scale}`; back keys (which pin a
- * source image) are `${product}:back:${sourceId}:${color}:${scale}`.
+ * source image) are `${product}:back:${sourceId}:${color}:${scale}`. Keys
+ * written since #102 lead with a version segment (`v2:…`) — skip it so both
+ * generations resolve: old orders only have old-format entries.
  */
 function findCachedMockup(
   mockupUrls: Record<string, string> | null | undefined,
@@ -31,7 +33,8 @@ function findCachedMockup(
 ): string | null {
   for (const [key, url] of Object.entries(mockupUrls ?? {})) {
     const parts = key.split(":");
-    if (segments.every((seg, i) => parts[i] === seg)) return url;
+    const offset = /^v\d+$/.test(parts[0]) ? 1 : 0;
+    if (segments.every((seg, i) => parts[i + offset] === seg)) return url;
   }
   return null;
 }

--- a/src/lib/mockup-cache.ts
+++ b/src/lib/mockup-cache.ts
@@ -1,0 +1,58 @@
+/**
+ * Mockup cache keys — the single source for both the `design.mockupUrls`
+ * DB/client cache key and the R2 object key a mockup is uploaded under.
+ *
+ * The two keys must carry the same distinguishing parts. #102 was the two
+ * drifting: the DB key included product/source/scale but the R2 key was only
+ * `{color}-{placement}.jpg`, so every back-source (and product, and scale)
+ * choice overwrote one shared object and stale cache entries served the
+ * wrong artwork — always the last-rendered one.
+ *
+ * The `v2` version segment retires every pre-#102 cache entry: those URLs
+ * point at collided objects whose bytes are whatever rendered last, so they
+ * must never satisfy a lookup again. Old entries stay in the JSON untouched —
+ * emails for already-placed orders still resolve them (content may be wrong
+ * for old orders; that was true the moment the collision happened).
+ */
+
+const MOCKUP_CACHE_VERSION = "v2";
+
+export type MockupKeyParts = {
+  productId: string;
+  placementId: string;
+  /** Source image the placement was rendered from — non-front only. */
+  sourceImageId?: string | null;
+  colorName: string;
+  /** Scale as an integer percentage, e.g. 100 for 1.0. */
+  scaleKey: number;
+};
+
+/** DB/client cache key for `design.mockupUrls`. */
+export function mockupCacheKey(p: MockupKeyParts): string {
+  const src = p.sourceImageId ? `:${p.sourceImageId}` : "";
+  return `${MOCKUP_CACHE_VERSION}:${p.productId}:${p.placementId}${src}:${p.colorName}:${p.scaleKey}`;
+}
+
+/** Prefix matching every current-version cache entry for a product. */
+export function mockupCacheProductPrefix(productId: string): string {
+  return `${MOCKUP_CACHE_VERSION}:${productId}:`;
+}
+
+function slug(value: string): string {
+  return value.toLowerCase().replace(/[^a-z0-9]+/g, "-");
+}
+
+/**
+ * R2 object key for an uploaded mockup. Carries every part the cache key
+ * distinguishes, plus a content hash so re-renders of the same combination
+ * (e.g. after the design regenerates) get a fresh URL instead of mutating
+ * bytes behind one the browser has cached.
+ */
+export function mockupObjectKey(
+  designId: string,
+  p: MockupKeyParts,
+  contentHash: string
+): string {
+  const src = p.sourceImageId ? `-${slug(p.sourceImageId)}` : "";
+  return `designs/${designId}/mockups/${slug(p.productId)}-${slug(p.colorName)}-${slug(p.placementId)}${src}-s${p.scaleKey}-${contentHash}.jpg`;
+}

--- a/src/lib/r2.ts
+++ b/src/lib/r2.ts
@@ -5,6 +5,8 @@ import {
   CopyObjectCommand,
   DeleteObjectCommand,
 } from "@aws-sdk/client-s3";
+import { createHash } from "crypto";
+import { mockupObjectKey, type MockupKeyParts } from "@/lib/mockup-cache";
 
 const r2 = new S3Client({
   region: "auto",
@@ -40,16 +42,19 @@ export async function uploadDesignImage(
 
 export async function uploadMockupImage(
   designId: string,
-  colorName: string,
   imageBuffer: Buffer,
-  placementId: string = "front"
+  parts: MockupKeyParts
 ): Promise<string> {
-  const slug = colorName.toLowerCase().replace(/\s+/g, "-");
-  // Front keeps the legacy `{color}.jpg` key so already-cached URLs stay
-  // valid; other placements get a `-{placement}` suffix so front/back
-  // mockups for the same color don't overwrite each other.
-  const suffix = placementId === "front" ? "" : `-${placementId}`;
-  const key = `designs/${designId}/mockups/${slug}${suffix}.jpg`;
+  // The object key carries every part the mockupUrls cache key distinguishes
+  // (#102: a key of just `{color}-{placement}.jpg` made every back-source /
+  // product / scale choice overwrite one object, so cache entries served the
+  // last-rendered artwork instead of their own). The content hash gives
+  // re-renders a fresh URL so browser caches can't pin stale bytes.
+  const contentHash = createHash("sha256")
+    .update(imageBuffer)
+    .digest("hex")
+    .slice(0, 8);
+  const key = mockupObjectKey(designId, parts, contentHash);
 
   await r2.send(
     new PutObjectCommand({


### PR DESCRIPTION
Closes #102.

## Repro (local, three labeled placeholder designs)
Pick back source BLUE → hero shows the previously rendered GREEN. Mechanism: the `design.mockupUrls` cache key distinguishes product / placement / back source / scale, but `uploadMockupImage` wrote every mockup for a color to **one** R2 object (`designs/{id}/mockups/{color}-{placement}.jpg`). Every back-source pick overwrote the shared object, so all cache entries pointing at that URL served whatever rendered last — after the first pick you never see the design you chose. The identical URL also let the browser image cache pin stale bytes. Same collision existed across products (Box Tee vs Classic Tee, same color) and scales.

## Fix
- New `src/lib/mockup-cache.ts` — single source for both keys, used by server actions, the client page, and tests (kills the previously hand-synced duplication):
  - **DB/client cache key** version-bumped to `v2:` so poisoned pre-fix entries never satisfy a lookup again; caches self-heal by re-rendering on next use (one extra Printful mockup per combination).
  - **R2 object key** now carries product, color, placement, source, scale, plus a sha256 content hash — re-renders (e.g. after design regeneration) get a fresh URL instead of mutating bytes behind a cached one.
- `ensureMockupsPrefetched` counts only v2 entries, so the front bulk prefetch re-runs once per design/product.
- `email-images.ts` matcher skips a leading version segment — already-placed orders keep resolving their v1 entries.

## Verification
- Live repro before/after: same poisoned data, picking BLUE now renders BLUE (was GREEN).
- 693 tests green, incl. new `mockup-cache` unit tests (distinct sources/products/scales/hashes → distinct object keys) and v2-key email-resolution cases.

No migration: old R2 objects and v1 cache entries stay untouched for old orders' emails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FYw9FZQzyH1wkvnXzKMgL3