### PR TITLE
feat: warm design-thread cache to kill /design empty-state flash (#87)

### DIFF
--- a/src/app/design/page.tsx
+++ b/src/app/design/page.tsx
@@ -26,6 +26,7 @@ import { breadcrumbTrail } from "@/lib/nav";
 import { isDesignEmpty } from "@/lib/design-view";
 import { createTurnTracker } from "@/lib/turn-tracker";
 import { ensureGuestSession } from "@/lib/ensure-guest-session";
+import { readWarmedThread } from "@/lib/design-thread-cache";
 
 export default function DesignPage() {
   return (
@@ -40,10 +41,22 @@ function DesignPageInner() {
   const searchParams = useSearchParams();
   const designId = useRef(searchParams.get("id") ?? crypto.randomUUID());
 
-  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  // #87 warm path: a card on /designs may have prefetched this thread. Hydrate
+  // from the snapshot on first render to skip the empty-composer flash. This is
+  // initial state ONLY — the resume effect below still revalidates fresh, so a
+  // stale or absent snapshot never changes the final rendered thread. Read once
+  // (lazy initializer) so a later warm can't retro-populate a live session.
+  const [warmed] = useState(() => {
+    const resumeId = searchParams.get("id");
+    return resumeId ? readWarmedThread(resumeId) : undefined;
+  });
+
+  const [messages, setMessages] = useState<ChatMessage[]>(warmed?.chat ?? []);
   const [images, setImages] = useState<DesignImage[]>([]);
   const [productGroups, setProductGroups] = useState<ProductVersionGroup[]>([]);
-  const [selectedImage, setSelectedImage] = useState<string | null>(null);
+  const [selectedImage, setSelectedImage] = useState<string | null>(
+    warmed?.design?.displayImageUrl ?? null
+  );
   const [loading, setLoading] = useState(false);
   const [generating, setGenerating] = useState(false);
   const [lightboxIndex, setLightboxIndex] = useState<number | null>(null);

--- a/src/app/designs/page.tsx
+++ b/src/app/designs/page.tsx
@@ -6,6 +6,7 @@ import { getUserDesigns, deleteDesign, archiveDesign, unpublishImage } from "./a
 import { Badge, Button } from "@/components/ui";
 import { PublishModal } from "@/components/publish-modal";
 import { publishedBackdrop } from "@/lib/blanks";
+import { WarmOnView } from "./warm-on-view";
 
 type Design = Awaited<ReturnType<typeof getUserDesigns>>[number];
 
@@ -110,7 +111,11 @@ export default function DesignsPage() {
                 ? publishedBackdrop(design.primaryImageBackgroundColor)
                 : { className: "bg-checkerboard", style: undefined };
               return (
-              <div key={design.id} className="border rounded-lg overflow-hidden group">
+              <WarmOnView
+                key={design.id}
+                designId={design.id}
+                className="border rounded-lg overflow-hidden group"
+              >
                 <Link href={getDesignHref(design)} className="block">
                   <div
                     className={`aspect-square flex items-center justify-center ${backdrop.className}`}
@@ -200,7 +205,7 @@ export default function DesignsPage() {
                     </div>
                   )}
                 </div>
-              </div>
+              </WarmOnView>
               );
             })}
           </div>

--- a/src/app/designs/warm-on-view.tsx
+++ b/src/app/designs/warm-on-view.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { getDesign, getDesignChat } from "@/app/design/actions";
+import { warmDesignThread } from "@/lib/design-thread-cache";
+
+/**
+ * Wraps a /designs card and prefetches its design thread (#87) when the card
+ * scrolls into view, or on touch/hover intent — so tapping through to
+ * /design?id= hydrates from cache instead of flashing an empty composer.
+ *
+ * Renders the card's own container element (no extra DOM) so grid layout is
+ * unchanged. Warming is deduped in the cache and fired at most once per mount;
+ * only viewport-visible/intended cards warm, which caps volume on long lists.
+ */
+export function WarmOnView({
+  designId,
+  className,
+  children,
+}: {
+  designId: string;
+  className?: string;
+  children: React.ReactNode;
+}) {
+  const ref = useRef<HTMLDivElement>(null);
+  const warmed = useRef(false);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+
+    const warm = () => {
+      if (warmed.current) return;
+      warmed.current = true;
+      warmDesignThread(designId, async () => {
+        const [design, chat] = await Promise.all([
+          getDesign(designId),
+          getDesignChat(designId),
+        ]);
+        return {
+          design: design
+            ? { displayImageUrl: design.displayImageUrl }
+            : null,
+          chat,
+        };
+      });
+    };
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries.some((e) => e.isIntersecting)) {
+          warm();
+          observer.disconnect();
+        }
+      },
+      // Warm a little before the card is fully on screen.
+      { rootMargin: "200px" }
+    );
+    observer.observe(el);
+
+    // Phone-first: touchstart is the tap precursor (no hover on touch);
+    // mouseenter covers pointer devices.
+    el.addEventListener("touchstart", warm, { passive: true });
+    el.addEventListener("mouseenter", warm);
+
+    return () => {
+      observer.disconnect();
+      el.removeEventListener("touchstart", warm);
+      el.removeEventListener("mouseenter", warm);
+    };
+  }, [designId]);
+
+  return (
+    <div ref={ref} className={className}>
+      {children}
+    </div>
+  );
+}

--- a/src/lib/__tests__/ttl-cache.test.ts
+++ b/src/lib/__tests__/ttl-cache.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi } from "vitest";
+import { createTtlCache } from "@/lib/ttl-cache";
+
+describe("createTtlCache", () => {
+  it("returns a set value while fresh and undefined once expired", () => {
+    let clock = 1000;
+    const cache = createTtlCache<string>({ ttlMs: 100, now: () => clock });
+
+    cache.set("a", "value");
+    expect(cache.get("a")).toBe("value");
+    expect(cache.has("a")).toBe(true);
+
+    clock += 99;
+    expect(cache.get("a")).toBe("value");
+
+    clock += 1; // now exactly at expiry (expiresAt <= now → expired)
+    expect(cache.get("a")).toBeUndefined();
+    expect(cache.has("a")).toBe(false);
+  });
+
+  it("returns undefined for an unknown key", () => {
+    const cache = createTtlCache<number>({ ttlMs: 100, now: () => 0 });
+    expect(cache.get("nope")).toBeUndefined();
+  });
+
+  it("delete removes a fresh value", () => {
+    const cache = createTtlCache<number>({ ttlMs: 100, now: () => 0 });
+    cache.set("a", 1);
+    cache.delete("a");
+    expect(cache.get("a")).toBeUndefined();
+  });
+
+  it("warm loads once and caches the result", async () => {
+    const cache = createTtlCache<string>({ ttlMs: 100, now: () => 0 });
+    const loader = vi.fn().mockResolvedValue("loaded");
+
+    await expect(cache.warm("a", loader)).resolves.toBe("loaded");
+    expect(cache.get("a")).toBe("loaded");
+
+    // Second warm while fresh does not re-run the loader.
+    await expect(cache.warm("a", loader)).resolves.toBe("loaded");
+    expect(loader).toHaveBeenCalledTimes(1);
+  });
+
+  it("dedupes concurrent warms of the same key to one load", async () => {
+    const cache = createTtlCache<string>({ ttlMs: 100, now: () => 0 });
+    let resolve!: (v: string) => void;
+    const loader = vi.fn(
+      () => new Promise<string>((r) => (resolve = r))
+    );
+
+    const p1 = cache.warm("a", loader);
+    const p2 = cache.warm("a", loader);
+    expect(loader).toHaveBeenCalledTimes(1);
+
+    resolve("loaded");
+    await Promise.all([p1, p2]);
+    expect(await p1).toBe("loaded");
+    expect(await p2).toBe("loaded");
+  });
+
+  it("does not cache a rejected load and retries on the next warm", async () => {
+    const cache = createTtlCache<string>({ ttlMs: 100, now: () => 0 });
+    const loader = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("boom"))
+      .mockResolvedValueOnce("recovered");
+
+    await expect(cache.warm("a", loader)).rejects.toThrow("boom");
+    expect(cache.get("a")).toBeUndefined();
+
+    await expect(cache.warm("a", loader)).resolves.toBe("recovered");
+    expect(loader).toHaveBeenCalledTimes(2);
+  });
+
+  it("re-runs the loader once a cached value has expired", async () => {
+    let clock = 0;
+    const cache = createTtlCache<string>({ ttlMs: 100, now: () => clock });
+    const loader = vi
+      .fn()
+      .mockResolvedValueOnce("first")
+      .mockResolvedValueOnce("second");
+
+    await cache.warm("a", loader);
+    clock += 100; // expired
+    await expect(cache.warm("a", loader)).resolves.toBe("second");
+    expect(loader).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/lib/design-thread-cache.ts
+++ b/src/lib/design-thread-cache.ts
@@ -1,0 +1,47 @@
+/**
+ * Warm-path cache for design threads (#87).
+ *
+ * /designs cards link to /design?id=<id>, whose page fetches its thread
+ * (getDesign + getDesignChat) in a mount effect — so tapping a card renders an
+ * empty composer, then the thread pops in. Warming that fetch when a card is
+ * visible/touched lets the page hydrate from a synchronous snapshot on mount
+ * and skip the flash.
+ *
+ * Snapshots are initial state only: the page still revalidates fresh in the
+ * background, so a stale or absent entry never breaks correctness — worst case
+ * is the flash it exists to remove. Loader-injected to keep this lib free of
+ * server-action imports; the TTL/dedupe live in the pure ttl-cache.
+ */
+import type { ChatMessage } from "@/lib/db/schema";
+import { createTtlCache } from "@/lib/ttl-cache";
+
+/** The subset of getDesign the /design page reads on mount. */
+export interface DesignThreadSnapshot {
+  design: { displayImageUrl: string | null } | null;
+  chat: ChatMessage[];
+}
+
+// A few minutes: long enough to cover the scroll-then-tap window, short enough
+// that a warmed thread can't shadow a design the user edited elsewhere for long
+// (the page revalidates on mount regardless).
+const TTL_MS = 3 * 60 * 1000;
+
+const cache = createTtlCache<DesignThreadSnapshot>({ ttlMs: TTL_MS });
+
+/**
+ * Prefetch a design thread unless one is already fresh or in-flight (deduped).
+ * Failures are swallowed — warming is best-effort and never user-visible.
+ */
+export function warmDesignThread(
+  designId: string,
+  loader: () => Promise<DesignThreadSnapshot>
+): void {
+  void cache.warm(designId, loader).catch(() => {});
+}
+
+/** Synchronous read for the /design page mount. undefined when absent/expired. */
+export function readWarmedThread(
+  designId: string
+): DesignThreadSnapshot | undefined {
+  return cache.get(designId);
+}

--- a/src/lib/ttl-cache.ts
+++ b/src/lib/ttl-cache.ts
@@ -1,0 +1,75 @@
+/**
+ * Small in-memory TTL cache with in-flight dedupe. Pure and framework-free so
+ * the expiry/dedupe logic is unit-testable with an injected clock; callers hold
+ * a module-level instance.
+ *
+ * `warm` is the write path: it runs the loader at most once per key while a
+ * fresh value or an in-flight load already exists, so repeated warm requests
+ * (e.g. a card re-entering the viewport, then hovered, then touched) collapse
+ * to a single load. A rejected load is not cached — the next warm retries.
+ */
+export interface TtlCache<V> {
+  /** Fresh value for the key, or undefined if absent or expired. */
+  get(key: string): V | undefined;
+  set(key: string, value: V): void;
+  /** True when a fresh (non-expired) value exists. */
+  has(key: string): boolean;
+  delete(key: string): void;
+  /**
+   * Ensure a value for the key. Returns the fresh cached value, the existing
+   * in-flight load, or a new load from `loader` (stored on success).
+   */
+  warm(key: string, loader: () => Promise<V>): Promise<V>;
+}
+
+export function createTtlCache<V>(opts: {
+  ttlMs: number;
+  now?: () => number;
+}): TtlCache<V> {
+  const { ttlMs } = opts;
+  const now = opts.now ?? Date.now;
+  const values = new Map<string, { value: V; expiresAt: number }>();
+  const inFlight = new Map<string, Promise<V>>();
+
+  function get(key: string): V | undefined {
+    const entry = values.get(key);
+    if (!entry) return undefined;
+    if (entry.expiresAt <= now()) {
+      values.delete(key);
+      return undefined;
+    }
+    return entry.value;
+  }
+
+  function set(key: string, value: V): void {
+    values.set(key, { value, expiresAt: now() + ttlMs });
+  }
+
+  return {
+    get,
+    set,
+    has(key) {
+      return get(key) !== undefined;
+    },
+    delete(key) {
+      values.delete(key);
+      inFlight.delete(key);
+    },
+    warm(key, loader) {
+      const fresh = get(key);
+      if (fresh !== undefined) return Promise.resolve(fresh);
+      const pending = inFlight.get(key);
+      if (pending) return pending;
+      const load = loader()
+        .then((value) => {
+          set(key, value);
+          return value;
+        })
+        .finally(() => {
+          inFlight.delete(key);
+        });
+      inFlight.set(key, load);
+      return load;
+    },
+  };
+}


### PR DESCRIPTION
Closes #87.

## Problem
`/designs` cards link to `/design?id=<id>`. The `/design` page fetches its thread client-side in a mount effect (`Promise.all([getDesign, getDesignChat])`), so tapping a card renders an empty composer first, then the thread pops in — a visible flash, worst on phones.

## Approach
Warm the thread fetch when a card is likely to be tapped, and hydrate `/design` from the warmed snapshot on first render.

- **`src/lib/ttl-cache.ts`** — pure, framework-free TTL cache with in-flight dedupe and an injected clock. Unit-tested (`src/lib/__tests__/ttl-cache.test.ts`): expiry, dedupe of concurrent loads, no-cache-on-reject + retry, re-load after expiry.
- **`src/lib/design-thread-cache.ts`** — module-level `Map`-backed snapshot cache (3-minute TTL). Loader-injected so the lib pulls in no server-action code, keeping the import graph acyclic. `warmDesignThread` (best-effort, swallows errors) + synchronous `readWarmedThread`.
- **`src/app/designs/warm-on-view.tsx`** — wraps each card (renders the card's own container, no extra DOM). Warms on `IntersectionObserver` visibility (`rootMargin: 200px`) and on `touchstart`/`mouseenter`. Fires at most once per mount; the cache dedupes in-flight. Only viewport-visible / intended cards warm, so volume stays capped on long lists.
- **`/design`** reads the snapshot as **initial state only** via a lazy `useState` initializer. The existing resume effect still runs `getDesign` + `getDesignChat` to revalidate fresh, so a stale or absent entry never changes the final rendered thread — worst case is the flash it exists to remove. It only seeds `messages` and `selectedImage`; the turn-tracker, `activeGeneration`, `options`, and `readyToGenerate` are untouched, so cancelled/in-flight generation guards can't be confused by a warmed snapshot.

### Why a module-level Map (not sessionStorage)
The warmed payload includes `Date` objects (`ChatMessage.createdAt`) — `sessionStorage` would need serialize/revive plumbing to avoid handing the page date-shaped strings. An in-memory Map stores the live objects with zero serialization risk. The cache is a pure flash-avoidance optimization (the page always revalidates), so surviving a full page reload buys nothing; it only needs to live across the in-SPA `/designs → /design` navigation, which the module scope does.

## Phone-first
`touchstart` triggers the warm on tap-down (no hover on touch); the IntersectionObserver path covers scrolling. The Shop feed cards route to `/d/[imageId]` (public buy pages), not design threads, so they're intentionally untouched.

## Verification
- `npm run lint` — 0 errors (pre-existing `<img>`/deps warnings only; no new ones).
- `npm test` — 691 passed (7 new).
- `npm run build` — TypeScript compiles + type-checks clean; page-data collection then fails on the untouched `/api/webhooks/printful` route because this worktree has no `.env` (`RESEND_API_KEY` unset). Env-only, unrelated to this diff; CI has the secret.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FYw9FZQzyH1wkvnXzKMgL3