### PR TITLE
fix: financial summary orderCount includes archived orders

### DIFF
--- a/src/app/admin/__tests__/financial-summary.integration.test.ts
+++ b/src/app/admin/__tests__/financial-summary.integration.test.ts
@@ -2,10 +2,11 @@
 /**
  * Real-DB integration test for getFinancialSummary (WP5): seeds orders +
  * ledger rows across classifications and asserts the grouped-sum →
- * summarizeLedger math the admin dashboard shows. Asserts CURRENT behavior,
- * including two quirks worth knowing about (documented inline): archived
- * orders drop out of orderCount but their ledger rows still count, and
- * unfiltered summaries include test-classified orders' money.
+ * summarizeLedger math the admin dashboard shows. Asserts CURRENT behavior:
+ * archival is a display/workflow state, never a financial one, so archived
+ * orders count in orderCount just like their ledger rows already count in
+ * revenue (#105); unfiltered summaries include test-classified orders'
+ * money (only an explicit classification filter excludes it).
  */
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { eq } from "drizzle-orm";
@@ -131,33 +132,34 @@ describe("getFinancialSummary", () => {
     await seedOrder({ id: "o-unclassified", classification: null });
   });
 
-  it("unfiltered: sums EVERY ledger row — including test-classified orders — and counts non-archived orders", async () => {
+  it("unfiltered: sums EVERY ledger row — including test-classified orders — and counts every order, archived or not", async () => {
     const summary = await getFinancialSummary();
 
     // Current behavior: no default exclusion of `test` orders (the
-    // docs/test-orders-and-accounting.md proposal would change this), and the
-    // archived order's sale still counts even though the order itself doesn't.
+    // docs/test-orders-and-accounting.md proposal would change this), and
+    // archived orders count in orderCount just like their ledger rows
+    // already count in revenue — money always counts (#105).
     expect(summary.revenue).toBeCloseTo(24.12 + 10.0 + 5.0, 5);
     expect(summary.stripeFees).toBeCloseTo(-1.59, 5);
     expect(summary.cogs).toBeCloseTo(12.5, 5);
     expect(summary.grossProfit).toBeCloseTo(39.12 - 1.59 - 12.5, 5);
-    expect(summary.orderCount).toBe(3); // o-archived excluded, o-unclassified included
+    expect(summary.orderCount).toBe(4); // o-customer, o-test, o-archived, o-unclassified
   });
 
   it('"all" behaves the same as no filter', async () => {
     const summary = await getFinancialSummary("all");
     expect(summary.revenue).toBeCloseTo(39.12, 5);
-    expect(summary.orderCount).toBe(3);
+    expect(summary.orderCount).toBe(4);
   });
 
-  it("customer filter: joins ledger through order classification; archived customer money still counts", async () => {
+  it("customer filter: joins ledger through order classification; archived customer order counts in both revenue and orderCount", async () => {
     const summary = await getFinancialSummary("customer");
 
     expect(summary.revenue).toBeCloseTo(24.12 + 5.0, 5); // o-customer + archived o-archived
     expect(summary.stripeFees).toBeCloseTo(-1.0, 5);
     expect(summary.cogs).toBeCloseTo(12.5, 5);
     expect(summary.grossProfit).toBeCloseTo(29.12 - 1.0 - 12.5, 5);
-    expect(summary.orderCount).toBe(1); // only the non-archived customer order
+    expect(summary.orderCount).toBe(2); // o-customer + archived o-archived
   });
 
   it("test filter: isolates test-order money", async () => {

--- a/src/app/admin/actions.ts
+++ b/src/app/admin/actions.ts
@@ -11,7 +11,7 @@ import {
   user as userTable,
   ledgerEntry,
 } from "@/lib/db/schema";
-import { eq, desc, asc, isNull, isNotNull, sum, count, and, sql } from "drizzle-orm";
+import { eq, desc, asc, isNotNull, sum, count, sql } from "drizzle-orm";
 import { alias } from "drizzle-orm/sqlite-core";
 import { revalidatePath } from "next/cache";
 import { createOrder, getOrderByExternalId } from "@/lib/printful";
@@ -319,15 +319,15 @@ export async function getFinancialSummary(classificationFilter?: OrderClassifica
     byType[e.type] = parseFloat(e.total ?? "0");
   }
 
-  const orderConditions = [isNull(orderTable.archivedAt)];
-  if (filterClassification) {
-    orderConditions.push(eq(orderTable.classification, filterClassification));
-  }
-
-  const countRows = await db
-    .select({ orderCount: count() })
-    .from(orderTable)
-    .where(and(...orderConditions));
+  // Archival is a display/workflow state, never a financial one — an
+  // archived order's ledger rows already count above, so orderCount must
+  // include it too or the summary's own numbers disagree with each other.
+  const countRows = filterClassification
+    ? await db
+        .select({ orderCount: count() })
+        .from(orderTable)
+        .where(eq(orderTable.classification, filterClassification))
+    : await db.select({ orderCount: count() }).from(orderTable);
   const orderCount = countRows[0].orderCount;
 
   return { ...summarizeLedger(byType), orderCount };


### PR DESCRIPTION
## Summary
- `getFinancialSummary`'s orderCount query filtered out archived orders while the ledger sum above it had no such filter, so the summary's own revenue and orderCount numbers disagreed for any archived order.
- Money always counts: archival is a display/workflow state, not a financial one. Dropped the `isNull(orderTable.archivedAt)` condition from the orderCount query (classification filters unaffected).

## Test plan
- [x] Updated `src/app/admin/__tests__/financial-summary.integration.test.ts` to assert archived orders count in orderCount for both the unfiltered/"all" case and the classification-filtered case, and its ledger rows still count in revenue.
- [x] `npm run lint` — 0 errors (pre-existing warnings only)
- [x] `npm test` — 700/700 passed
- [x] `npm run build` — succeeds (verified with dummy env vars in this worktree, which lacks `.env.local`)

Closes #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FYw9FZQzyH1wkvnXzKMgL3