### PR TITLE
ci: nightly Stripe test-mode e2e (#104)

### DIFF
--- a/.github/workflows/stripe-e2e.yml
+++ b/.github/workflows/stripe-e2e.yml
@@ -1,0 +1,153 @@
+name: Stripe E2E (nightly)
+
+# The one real-money-path test (e2e/stripe-money-path.spec.ts, docs/stripe-e2e.md)
+# only ever ran when someone remembered `npm run e2e:stripe` locally (#104).
+# This gives it a nightly run + a manual trigger, entirely separate from PR CI:
+# it pays through Stripe's real hosted test checkout and depends on Stripe's
+# live checkout DOM (three layout fixes needed on the first live run,
+# 2026-07-21), so it is deliberately NOT wired into the pull_request/push
+# `check`/`e2e` jobs in ci.yml — that would add third-party flake to every PR.
+
+on:
+  schedule:
+    # 08:23 UTC (off-the-hour, off-peak) — a couple hours after CI's typical
+    # daytime PR traffic. Pick any time; the only requirement is "runs daily
+    # without a human remembering."
+    - cron: "23 8 * * *"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  issues: write
+
+# Serialize: two overlapping runs would both branch a Turso DB and both pay
+# through Stripe test mode. Queue rather than cancel — cancelling mid-payment
+# would leave a stray charge/branch behind.
+concurrency:
+  group: stripe-e2e-nightly
+  cancel-in-progress: false
+
+jobs:
+  stripe-e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    env:
+      # Real secret — the spec refuses anything that isn't sk_test_… (see
+      # scripts/e2e-stripe.sh), but a missing/misconfigured secret must fail
+      # loud, not silently self-skip and report green.
+      STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}
+      # Fake vendor creds for SDK constructors that run at module-eval time
+      # during `next build` / at server boot. The spec never exercises real
+      # Anthropic/Replicate/Printful/R2 calls (Printful stays dry-run;
+      # generateOrderName degrades on failure by design — see CLAUDE.md
+      # 2026-07-21 handoff notes). Mirrors ci.yml's `check`/`e2e` jobs.
+      BETTER_AUTH_SECRET: ci-stripe-e2e-secret-not-real
+      NEXT_PUBLIC_R2_PUBLIC_URL: https://example.com
+      ANTHROPIC_API_KEY: sk-ant-ci-skip
+      REPLICATE_API_TOKEN: r8_ci_skip
+      PRINTFUL_API_KEY: pf_ci_skip
+      R2_ACCOUNT_ID: ci-skip
+      R2_ACCESS_KEY_ID: ci-skip
+      R2_SECRET_ACCESS_KEY: ci-skip
+      R2_BUCKET_NAME: ci-skip
+      ADMIN_EMAIL: ci-skip@example.com
+      # scripts/e2e-stripe.sh exports NEXT_PUBLIC_APP_URL, PRINTFUL_DRY_RUN,
+      # RESEND_API_KEY, E2E_STRIPE, and STRIPE_WEBHOOK_SECRET itself at
+      # runtime (docs/stripe-e2e.md) — don't set them here, the script owns
+      # that sequencing (webhook secret comes from the live `stripe listen`
+      # forwarder it spawns).
+      #
+      # Ephemeral Turso branch, same mechanism ci.yml's `e2e` job uses for
+      # per-PR isolation (#31/#108): named so it contains "prntd-preview",
+      # which e2e/helpers/db.ts's never-prod guard requires.
+      CI_DB_NAME: prntd-preview-stripe-nightly-${{ github.run_id }}-${{ github.run_attempt }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - run: npm ci
+
+      # Official apt install (docs.stripe.com/stripe-cli/install) — provides
+      # the `stripe listen --print-secret` / `stripe listen --forward-to`
+      # scripts/e2e-stripe.sh needs.
+      - name: Install Stripe CLI
+        run: |
+          curl -s https://packages.stripe.dev/api/security/keypair/stripe-cli-gpg/public | gpg --dearmor | sudo tee /usr/share/keyrings/stripe.gpg > /dev/null
+          echo "deb [signed-by=/usr/share/keyrings/stripe.gpg] https://packages.stripe.dev/stripe-cli-debian-local stable main" | sudo tee -a /etc/apt/sources.list.d/stripe.list
+          sudo apt-get update
+          sudo apt-get install -y stripe
+          stripe --version
+
+      - name: Install Turso CLI
+        run: |
+          curl -sSfL https://get.tur.so/install.sh | bash
+          echo "$HOME/.turso" >> "$GITHUB_PATH"
+
+      # Branch off prntd-preview (schema-current seeded copy) instead of
+      # running against the shared prntd-preview DB or prntd-dev — keeps this
+      # nightly run from contending with anything else (cf. flake #101).
+      - name: Create ephemeral Turso branch
+        env:
+          TURSO_API_TOKEN: ${{ secrets.TURSO_API_TOKEN }}
+        run: |
+          turso db create "$CI_DB_NAME" --from-db prntd-preview --group default
+          url=$(turso db show "$CI_DB_NAME" --url)
+          token=$(turso db tokens create "$CI_DB_NAME")
+          echo "::add-mask::$token"
+          echo "DATABASE_URL=$url" >> "$GITHUB_ENV"
+          echo "DATABASE_AUTH_TOKEN=$token" >> "$GITHUB_ENV"
+
+      - name: Apply migrations to ephemeral branch
+        run: npm run db:migrate
+
+      - run: npx playwright install --with-deps chromium
+
+      # Boots the compiled build on :3100 (playwright.config.ts webServer,
+      # same as local), spawns `stripe listen`, and runs the one @stripe spec.
+      # See docs/stripe-e2e.md for the full sequencing.
+      - name: Run Stripe test-mode e2e
+        run: npm run e2e:stripe
+
+      - name: Destroy ephemeral Turso branch
+        if: always()
+        env:
+          TURSO_API_TOKEN: ${{ secrets.TURSO_API_TOKEN }}
+        run: turso db destroy "$CI_DB_NAME" --yes || true
+
+      - uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: stripe-e2e-playwright-report
+          path: playwright-report
+          retention-days: 7
+
+      - uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: stripe-e2e-playwright-traces
+          path: test-results
+          retention-days: 7
+
+      # A red run must not be silent (that's the whole point of #104) — file
+      # a tracking issue, or comment on the existing one so repeated failures
+      # dedupe into one thread instead of paging with a new issue nightly.
+      - name: Report failure
+        if: failure()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          run_url="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+          body="Nightly Stripe e2e failed: $run_url"
+          existing=$(gh issue list --repo "$GITHUB_REPOSITORY" --label stripe-e2e-nightly --state open --json number --jq '.[0].number // empty')
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --repo "$GITHUB_REPOSITORY" --body "$body"
+          else
+            gh issue create --repo "$GITHUB_REPOSITORY" \
+              --title "Nightly Stripe e2e failed" \
+              --label stripe-e2e-nightly \
+              --body "$body"$'\n\n'"Reruns of this workflow dedupe onto this issue while it stays open. Close it once the underlying cause is fixed."
+          fi

--- a/docs/stripe-e2e.md
+++ b/docs/stripe-e2e.md
@@ -44,10 +44,32 @@ and throwaway account are deleted from the dev DB afterward.
 ## Gating
 
 The spec is tagged `@stripe` and skips itself unless `E2E_STRIPE=1`, so plain
-`npm run e2e` and CI never run it. It also skips when `E2E_BASE_URL` is set
-(CI runs against a Vercel preview, where Stripe redirect URLs build from
-`NEXT_PUBLIC_APP_URL` = prod and checkout would bounce off the deployment
-under test) and when `STRIPE_SECRET_KEY` isn't `sk_test_…`.
+`npm run e2e` and the PR `check`/`e2e` jobs never run it. It also skips when
+`E2E_BASE_URL` is set (that means a Vercel preview, where Stripe redirect URLs
+build from `NEXT_PUBLIC_APP_URL` = prod and checkout would bounce off the
+deployment under test) and when `STRIPE_SECRET_KEY` isn't `sk_test_…`.
+
+## Nightly CI run (#104)
+
+`.github/workflows/stripe-e2e.yml` runs this spec on a schedule (nightly) and
+via manual `workflow_dispatch`. It is intentionally **not** wired into
+`pull_request`/`push` — it moves real (test-mode) money through Stripe's
+actual hosted checkout DOM, which is third-party flake every PR shouldn't
+have to eat.
+
+The workflow installs the Stripe CLI, branches an ephemeral Turso DB off
+`prntd-preview` (same mechanism as the per-PR e2e job, #31/#108 — named so it
+contains `prntd-preview`, satisfying `e2e/helpers/db.ts`'s never-prod guard),
+migrates it, then runs `npm run e2e:stripe` exactly as described above —
+`scripts/e2e-stripe.sh` now tolerates having no `.env.local` (CI exports
+`DATABASE_URL`/`DATABASE_AUTH_TOKEN`/`STRIPE_SECRET_KEY` as job env instead;
+it sources `.env.local` only when the file exists). No `E2E_BASE_URL` is set,
+so the spec runs against the workflow's own locally-booted compiled build,
+same code path as local — nothing in the spec's skip logic needed to change.
+
+Repo secrets required: `STRIPE_SECRET_KEY` (test-mode) and `TURSO_API_TOKEN`
+(already added for #108). On failure the job files/comments on a GitHub issue
+labeled `stripe-e2e-nightly` so a red run isn't silent.
 
 ## Troubleshooting
 

--- a/scripts/e2e-stripe.sh
+++ b/scripts/e2e-stripe.sh
@@ -13,8 +13,16 @@ if ! command -v stripe >/dev/null 2>&1; then
   exit 1
 fi
 
-if [ ! -f .env.local ]; then
-  echo ".env.local not found — the spec needs the dev DB + test-mode Stripe key" >&2
+# Local dev reads DB creds + STRIPE_SECRET_KEY from .env.local. CI (the
+# nightly stripe-e2e.yml workflow) has none — it exports DATABASE_URL /
+# DATABASE_AUTH_TOKEN / STRIPE_SECRET_KEY as job env instead, so only source
+# the file when it's there.
+if [ -f .env.local ]; then
+  set -a
+  . ./.env.local
+  set +a
+elif [ -z "${DATABASE_URL:-}" ]; then
+  echo ".env.local not found and DATABASE_URL not set — the spec needs the dev/preview DB + test-mode Stripe key" >&2
   exit 1
 fi
 
@@ -25,14 +33,10 @@ if lsof -nP -iTCP:3100 -sTCP:LISTEN >/dev/null 2>&1; then
   exit 1
 fi
 
-set -a
-. ./.env.local
-set +a
-
 case "${STRIPE_SECRET_KEY:-}" in
   sk_test_*) ;;
   *)
-    echo "STRIPE_SECRET_KEY in .env.local is missing or not test-mode (sk_test_…). Refusing to pay." >&2
+    echo "STRIPE_SECRET_KEY is missing or not test-mode (sk_test_…). Refusing to pay." >&2
     exit 1
     ;;
 esac


### PR DESCRIPTION
## Summary

- New `.github/workflows/stripe-e2e.yml`: runs `e2e/stripe-money-path.spec.ts` (the WP5/#99 Stripe test-mode money-path spec) nightly (`23 8 * * *` UTC) + on manual `workflow_dispatch`. Deliberately **not** wired into `pull_request`/`push` — it pays through Stripe's real hosted test checkout, so it stays out of the PR gate on purpose (per #104).
- Installs the Stripe CLI via the official apt repo (`docs.stripe.com/stripe-cli/install`), branches an **ephemeral Turso DB** off `prntd-preview` using the same mechanism #108 added to `ci.yml` for per-PR isolation (named `prntd-preview-stripe-nightly-<run>-<attempt>` so `e2e/helpers/db.ts`'s never-prod guard covers it), migrates it, then runs `npm run e2e:stripe` against a locally-booted compiled build — same code path as a local run.
- A missing/non-test `STRIPE_SECRET_KEY` fails the job loudly (the script's existing `sk_test_` guard) instead of silently self-skipping green — the whole point of a scheduled run is visibility.
- On failure: creates or comments on a `stripe-e2e-nightly`-labeled issue (label already created on the repo) so a red run isn't silent. `permissions: issues: write`.

## Spec changes

None to the skip logic. `e2e/stripe-money-path.spec.ts` already self-skips on three independent conditions (`E2E_STRIPE` unset, `E2E_BASE_URL` set, non-`sk_test_` key) — the workflow satisfies all three the same way a local `npm run e2e:stripe` run does (opts in via `E2E_STRIPE=1`, never sets `E2E_BASE_URL` since it boots its own server, supplies a real `sk_test_…` key), so nothing in the spec needed to change.

`scripts/e2e-stripe.sh` got one small change: it used to hard-require `.env.local` to exist. Now it only sources that file when present, and falls through to already-exported job env (`DATABASE_URL`/`DATABASE_AUTH_TOKEN`/`STRIPE_SECRET_KEY`) otherwise — so the same script drives both the local flow (unchanged) and the new CI workflow, no duplicated logic. `docs/stripe-e2e.md` documents the new nightly path.

## Repo secrets

Already present (added for #108):
- `TURSO_API_TOKEN`

**Needs to be added before the first scheduled/manual run:** `STRIPE_SECRET_KEY` — a **test-mode** key (`sk_test_…`). Add at:
https://github.com/nicolovejoy/prntd/settings/secrets/actions

The spec refuses anything that isn't `sk_test_…`, so a live key would just make the job fail loud (safe, but pointless — use test mode).

## Manual first run

Once `STRIPE_SECRET_KEY` is added:

```
gh workflow run stripe-e2e.yml --repo nicolovejoy/prntd
```

Then watch it:

```
gh run watch --repo nicolovejoy/prntd
```

## Test plan

- [x] `npm run lint` — 0 errors (17 pre-existing warnings, unrelated files)
- [x] `npm run typecheck` — clean
- [x] `npm test` — 700/700 passing
- [x] `npm run build` — succeeds with CI-skip fake env vars (mirrors `ci.yml`'s `check` job)
- [x] `actionlint` (includes embedded-shellcheck) on both `stripe-e2e.yml` and `ci.yml` — no findings
- [x] `shellcheck scripts/e2e-stripe.sh` — clean (one informational SC1091, pre-existing, about not statically following a sourced dotfile)
- [ ] Cannot run the workflow itself here (needs `STRIPE_SECRET_KEY` + the schedule) — first real run is the manual trigger above, once the secret is added.

Closes #104

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FYw9FZQzyH1wkvnXzKMgL3
