### PR TITLE
feat: Model B slice 1 — additive tables + backfill + dual-write

### DIFF
--- a/drizzle/0005_sticky_tag.sql
+++ b/drizzle/0005_sticky_tag.sql
@@ -1,0 +1,50 @@
+CREATE TABLE `conversation_image` (
+	`id` text PRIMARY KEY NOT NULL,
+	`design_id` text NOT NULL,
+	`image_id` text NOT NULL,
+	`role` text NOT NULL,
+	`created_at` integer NOT NULL,
+	FOREIGN KEY (`design_id`) REFERENCES `design`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `conversation_image_unique` ON `conversation_image` (`design_id`,`image_id`,`role`);--> statement-breakpoint
+CREATE TABLE `image` (
+	`id` text PRIMARY KEY NOT NULL,
+	`owner_id` text NOT NULL,
+	`r2_key` text,
+	`image_url` text NOT NULL,
+	`aspect_ratio` text NOT NULL,
+	`prompt` text,
+	`generator` text,
+	`generation_cost` real DEFAULT 0 NOT NULL,
+	`parent_image_id` text,
+	`seed_image_id` text,
+	`original_designer_id` text,
+	`source_design_id` text,
+	`created_at` integer NOT NULL,
+	FOREIGN KEY (`owner_id`) REFERENCES `user`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+CREATE TABLE `listing` (
+	`image_id` text PRIMARY KEY NOT NULL,
+	`published_at` integer NOT NULL,
+	`is_hidden` integer DEFAULT false NOT NULL,
+	`title` text,
+	`description` text,
+	`background_color` text,
+	`feed_rank` integer,
+	`created_at` integer NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE `placement_render` (
+	`id` text PRIMARY KEY NOT NULL,
+	`design_id` text NOT NULL,
+	`source_image_id` text,
+	`blank_id` text NOT NULL,
+	`placement_id` text NOT NULL,
+	`image_url` text NOT NULL,
+	`aspect_ratio` text NOT NULL,
+	`generation_cost` real DEFAULT 0 NOT NULL,
+	`created_at` integer NOT NULL,
+	FOREIGN KEY (`design_id`) REFERENCES `design`(`id`) ON UPDATE no action ON DELETE no action
+);

--- a/drizzle/meta/0005_snapshot.json
+++ b/drizzle/meta/0005_snapshot.json
@@ -1,0 +1,1982 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "53b7e419-06ae-4d01-a285-6073501b1afe",
+  "prevId": "d32439e5-6c8d-429b-8072-0c6922c3ebb2",
+  "tables": {
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "cart_item": {
+      "name": "cart_item",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "design_id": {
+          "name": "design_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size": {
+          "name": "size",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "placements": {
+          "name": "placements",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "cart_item_user_id_user_id_fk": {
+          "name": "cart_item_user_id_user_id_fk",
+          "tableFrom": "cart_item",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "cart_item_design_id_design_id_fk": {
+          "name": "cart_item_design_id_design_id_fk",
+          "tableFrom": "cart_item",
+          "tableTo": "design",
+          "columnsFrom": [
+            "design_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "chat_message": {
+      "name": "chat_message",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "design_id": {
+          "name": "design_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image_id": {
+          "name": "image_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "chat_message_design_id_design_id_fk": {
+          "name": "chat_message_design_id_design_id_fk",
+          "tableFrom": "chat_message",
+          "tableTo": "design",
+          "columnsFrom": [
+            "design_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "conversation_image": {
+      "name": "conversation_image",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "design_id": {
+          "name": "design_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image_id": {
+          "name": "image_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "conversation_image_unique": {
+          "name": "conversation_image_unique",
+          "columns": [
+            "design_id",
+            "image_id",
+            "role"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "conversation_image_design_id_design_id_fk": {
+          "name": "conversation_image_design_id_design_id_fk",
+          "tableFrom": "conversation_image",
+          "tableTo": "design",
+          "columnsFrom": [
+            "design_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "design": {
+      "name": "design",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'draft'"
+        },
+        "primary_image_id": {
+          "name": "primary_image_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "generation_count": {
+          "name": "generation_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "generation_cost": {
+          "name": "generation_cost",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "mockup_urls": {
+          "name": "mockup_urls",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "original_designer_id": {
+          "name": "original_designer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "forked_from_image_id": {
+          "name": "forked_from_image_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "active_generator_id": {
+          "name": "active_generator_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "design_user_id_user_id_fk": {
+          "name": "design_user_id_user_id_fk",
+          "tableFrom": "design",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "design_image": {
+      "name": "design_image",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "design_id": {
+          "name": "design_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parent_image_id": {
+          "name": "parent_image_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "aspect_ratio": {
+          "name": "aspect_ratio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "placement_id": {
+          "name": "placement_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "generation_cost": {
+          "name": "generation_cost",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "is_approved": {
+          "name": "is_approved",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_hidden": {
+          "name": "is_hidden",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "background_color": {
+          "name": "background_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "generator": {
+          "name": "generator",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "feed_rank": {
+          "name": "feed_rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "design_image_design_id_design_id_fk": {
+          "name": "design_image_design_id_design_id_fk",
+          "tableFrom": "design_image",
+          "tableTo": "design",
+          "columnsFrom": [
+            "design_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "generation_usage": {
+      "name": "generation_usage",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bucket": {
+          "name": "bucket",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "day": {
+          "name": "day",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "generation_usage_bucket_day": {
+          "name": "generation_usage_bucket_day",
+          "columns": [
+            "bucket",
+            "day"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "image": {
+      "name": "image",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "r2_key": {
+          "name": "r2_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "aspect_ratio": {
+          "name": "aspect_ratio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "generator": {
+          "name": "generator",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "generation_cost": {
+          "name": "generation_cost",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "parent_image_id": {
+          "name": "parent_image_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "seed_image_id": {
+          "name": "seed_image_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "original_designer_id": {
+          "name": "original_designer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_design_id": {
+          "name": "source_design_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "image_owner_id_user_id_fk": {
+          "name": "image_owner_id_user_id_fk",
+          "tableFrom": "image",
+          "tableTo": "user",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "ledger_entry": {
+      "name": "ledger_entry",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'USD'"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "ledger_entry_order_type_unique": {
+          "name": "ledger_entry_order_type_unique",
+          "columns": [
+            "order_id",
+            "type"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "ledger_entry_order_id_order_id_fk": {
+          "name": "ledger_entry_order_id_order_id_fk",
+          "tableFrom": "ledger_entry",
+          "tableTo": "order",
+          "columnsFrom": [
+            "order_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "listing": {
+      "name": "listing",
+      "columns": {
+        "image_id": {
+          "name": "image_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_hidden": {
+          "name": "is_hidden",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "background_color": {
+          "name": "background_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "feed_rank": {
+          "name": "feed_rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "order": {
+      "name": "order",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "design_id": {
+          "name": "design_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "placements": {
+          "name": "placements",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "printful_order_id": {
+          "name": "printful_order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "stripe_session_id": {
+          "name": "stripe_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "size": {
+          "name": "size",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'bella-canvas-3001'"
+        },
+        "store_id": {
+          "name": "store_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "store_product_id": {
+          "name": "store_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "quality": {
+          "name": "quality",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_price": {
+          "name": "total_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "item_price": {
+          "name": "item_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "shipping_price": {
+          "name": "shipping_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tax_collected": {
+          "name": "tax_collected",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "shipping_name": {
+          "name": "shipping_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "shipping_address1": {
+          "name": "shipping_address1",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "shipping_address2": {
+          "name": "shipping_address2",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "shipping_city": {
+          "name": "shipping_city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "shipping_state": {
+          "name": "shipping_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "shipping_zip": {
+          "name": "shipping_zip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "shipping_country": {
+          "name": "shipping_country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "stripe_payment_intent_id": {
+          "name": "stripe_payment_intent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tracking_number": {
+          "name": "tracking_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tracking_url": {
+          "name": "tracking_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "printful_cost": {
+          "name": "printful_cost",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "classification": {
+          "name": "classification",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "discount_code": {
+          "name": "discount_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "discount_amount": {
+          "name": "discount_amount",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "order_user_id_user_id_fk": {
+          "name": "order_user_id_user_id_fk",
+          "tableFrom": "order",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "order_design_id_design_id_fk": {
+          "name": "order_design_id_design_id_fk",
+          "tableFrom": "order",
+          "tableTo": "design",
+          "columnsFrom": [
+            "design_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "order_store_id_store_id_fk": {
+          "name": "order_store_id_store_id_fk",
+          "tableFrom": "order",
+          "tableTo": "store",
+          "columnsFrom": [
+            "store_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "order_store_product_id_product_id_fk": {
+          "name": "order_store_product_id_product_id_fk",
+          "tableFrom": "order",
+          "tableTo": "product",
+          "columnsFrom": [
+            "store_product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "order_item": {
+      "name": "order_item",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "design_id": {
+          "name": "design_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size": {
+          "name": "size",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "placements": {
+          "name": "placements",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "item_price": {
+          "name": "item_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "printful_cost": {
+          "name": "printful_cost",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "order_item_order_id_order_id_fk": {
+          "name": "order_item_order_id_order_id_fk",
+          "tableFrom": "order_item",
+          "tableTo": "order",
+          "columnsFrom": [
+            "order_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "order_item_design_id_design_id_fk": {
+          "name": "order_item_design_id_design_id_fk",
+          "tableFrom": "order_item",
+          "tableTo": "design",
+          "columnsFrom": [
+            "design_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "placement_render": {
+      "name": "placement_render",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "design_id": {
+          "name": "design_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_image_id": {
+          "name": "source_image_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "blank_id": {
+          "name": "blank_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "placement_id": {
+          "name": "placement_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "aspect_ratio": {
+          "name": "aspect_ratio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "generation_cost": {
+          "name": "generation_cost",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "placement_render_design_id_design_id_fk": {
+          "name": "placement_render_design_id_design_id_fk",
+          "tableFrom": "placement_render",
+          "tableTo": "design",
+          "columnsFrom": [
+            "design_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "product": {
+      "name": "product",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "store_id": {
+          "name": "store_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "design_id": {
+          "name": "design_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "blank_id": {
+          "name": "blank_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "placements": {
+          "name": "placements",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "price": {
+          "name": "price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'draft'"
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "product_owner_id_user_id_fk": {
+          "name": "product_owner_id_user_id_fk",
+          "tableFrom": "product",
+          "tableTo": "user",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "product_store_id_store_id_fk": {
+          "name": "product_store_id_store_id_fk",
+          "tableFrom": "product",
+          "tableTo": "store",
+          "columnsFrom": [
+            "store_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "product_design_id_design_id_fk": {
+          "name": "product_design_id_design_id_fk",
+          "tableFrom": "product",
+          "tableTo": "design",
+          "columnsFrom": [
+            "design_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "product_offering": {
+      "name": "product_offering",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "printful_category_id": {
+          "name": "printful_category_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "available_from": {
+          "name": "available_from",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "available_until": {
+          "name": "available_until",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "store": {
+      "name": "store",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "accent_color": {
+          "name": "accent_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'draft'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "store_slug_unique": {
+          "name": "store_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "store_owner_id_user_id_fk": {
+          "name": "store_owner_id_user_id_fk",
+          "tableFrom": "store",
+          "tableTo": "user",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_anonymous": {
+          "name": "is_anonymous",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1784501381229,
       "tag": "0004_sad_electro",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "6",
+      "when": 1784691678504,
+      "tag": "0005_sticky_tag",
+      "breakpoints": true
     }
   ]
 }

--- a/scripts/backfill-model-b.ts
+++ b/scripts/backfill-model-b.ts
@@ -1,0 +1,194 @@
+/**
+ * Model B slice-1 backfill (docs/model-b-migration-plan.md). Populates the new
+ * additive tables from the existing `design_image` / `design` rows so slice 2
+ * can read from them. Additive-only — reads design_image, never mutates it.
+ *
+ * Split rule: a design_image with product_id IS NULL is a source artifact →
+ * `image` (+ role=output link); with product_id set it's a placement render →
+ * `placement_render`. Both keep the design_image id (id reuse §2/§5) so pinned
+ * order/product placements resolve unchanged. Published rows (published_at NOT
+ * NULL) also get a `listing`. A design with forked_from_image_id gets a
+ * role=seed link, and its images carry seed_image_id / original_designer_id
+ * from the design (provenance moves onto the image graph, item 4).
+ *
+ * Idempotent: every insert is ON CONFLICT DO NOTHING (PKs + the
+ * conversation_image unique index), so re-runs are safe and chunked in bulk
+ * statements (never db.transaction — libSQL serverless HTTP).
+ *
+ * Run dry first:
+ *   source .env.local && npx tsx scripts/backfill-model-b.ts --dry-run
+ * Then for real:
+ *   source .env.local && npx tsx scripts/backfill-model-b.ts
+ */
+import { drizzle } from "drizzle-orm/libsql";
+import { createClient } from "@libsql/client";
+import { fileURLToPath } from "node:url";
+import * as schema from "../src/lib/db/schema";
+import type { db as appDb } from "../src/lib/db";
+import {
+  buildImageRow,
+  buildOutputLinkRow,
+  buildPlacementRenderRow,
+  buildListingRow,
+} from "../src/lib/model-b-writes";
+
+const CHUNK = 100;
+
+function chunk<T>(rows: T[], size: number): T[][] {
+  const out: T[][] = [];
+  for (let i = 0; i < rows.length; i += size) out.push(rows.slice(i, i + size));
+  return out;
+}
+
+export type BackfillCounts = {
+  images: number;
+  outputLinks: number;
+  placementRenders: number;
+  listings: number;
+  seedLinks: number;
+};
+
+export async function backfillModelB(
+  db: typeof appDb,
+  opts: { dryRun?: boolean } = {}
+): Promise<BackfillCounts> {
+  const dryRun = opts.dryRun ?? false;
+
+  const designs = await db
+    .select({
+      id: schema.design.id,
+      userId: schema.design.userId,
+      forkedFromImageId: schema.design.forkedFromImageId,
+      originalDesignerId: schema.design.originalDesignerId,
+    })
+    .from(schema.design);
+  const designById = new Map(designs.map((d) => [d.id, d]));
+
+  const rows = await db.select().from(schema.designImage);
+
+  const imageRows: (typeof schema.image.$inferInsert)[] = [];
+  const outputLinks: (typeof schema.conversationImage.$inferInsert)[] = [];
+  const renderRows: (typeof schema.placementRender.$inferInsert)[] = [];
+  const listingRows: (typeof schema.listing.$inferInsert)[] = [];
+
+  for (const r of rows) {
+    const design = designById.get(r.designId);
+    if (!design) continue; // orphaned design_image — skip, nothing owns it
+
+    if (r.productId === null) {
+      imageRows.push(
+        buildImageRow({
+          id: r.id,
+          ownerId: design.userId,
+          designId: r.designId,
+          imageUrl: r.imageUrl,
+          aspectRatio: r.aspectRatio,
+          prompt: r.prompt,
+          generator: r.generator,
+          generationCost: r.generationCost,
+          parentImageId: r.parentImageId,
+          seedImageId: design.forkedFromImageId,
+          originalDesignerId: design.originalDesignerId,
+        })
+      );
+      outputLinks.push(buildOutputLinkRow(r.designId, r.id));
+    } else {
+      renderRows.push(
+        buildPlacementRenderRow({
+          id: r.id,
+          designId: r.designId,
+          sourceImageId: r.parentImageId,
+          blankId: r.productId,
+          placementId: r.placementId,
+          imageUrl: r.imageUrl,
+          aspectRatio: r.aspectRatio,
+          generationCost: r.generationCost,
+        })
+      );
+    }
+
+    if (r.publishedAt !== null) {
+      listingRows.push(
+        buildListingRow({
+          imageId: r.id,
+          publishedAt: r.publishedAt,
+          isHidden: r.isHidden,
+          title: r.title,
+          description: r.description,
+          backgroundColor: r.backgroundColor,
+          feedRank: r.feedRank,
+        })
+      );
+    }
+  }
+
+  // One seed link per forked design.
+  const seedLinks: (typeof schema.conversationImage.$inferInsert)[] = [];
+  for (const d of designs) {
+    if (d.forkedFromImageId) {
+      seedLinks.push({
+        id: crypto.randomUUID(),
+        designId: d.id,
+        imageId: d.forkedFromImageId,
+        role: "seed",
+      });
+    }
+  }
+
+  const counts: BackfillCounts = {
+    images: imageRows.length,
+    outputLinks: outputLinks.length,
+    placementRenders: renderRows.length,
+    listings: listingRows.length,
+    seedLinks: seedLinks.length,
+  };
+
+  if (dryRun) return counts;
+
+  for (const c of chunk(imageRows, CHUNK)) {
+    await db.insert(schema.image).values(c).onConflictDoNothing();
+  }
+  for (const c of chunk(renderRows, CHUNK)) {
+    await db.insert(schema.placementRender).values(c).onConflictDoNothing();
+  }
+  for (const c of chunk(listingRows, CHUNK)) {
+    await db.insert(schema.listing).values(c).onConflictDoNothing();
+  }
+  // Links go last so their image_ids already exist (opaque text, but keeps the
+  // graph consistent at every intermediate point of a partial run).
+  for (const c of chunk([...outputLinks, ...seedLinks], CHUNK)) {
+    await db.insert(schema.conversationImage).values(c).onConflictDoNothing();
+  }
+
+  return counts;
+}
+
+const invokedDirectly =
+  typeof process.argv[1] === "string" &&
+  process.argv[1] === fileURLToPath(import.meta.url);
+
+if (invokedDirectly) {
+  const dryRun = process.argv.includes("--dry-run");
+  const db = drizzle(
+    createClient({
+      url: process.env.DATABASE_URL!,
+      authToken: process.env.DATABASE_AUTH_TOKEN,
+    }),
+    { schema }
+  ) as unknown as typeof appDb;
+
+  console.log(dryRun ? "DRY RUN — no writes" : "LIVE RUN");
+  backfillModelB(db, { dryRun })
+    .then((c) => {
+      console.log("---");
+      console.log(`images:            ${c.images}`);
+      console.log(`output links:      ${c.outputLinks}`);
+      console.log(`placement renders: ${c.placementRenders}`);
+      console.log(`listings:          ${c.listings}`);
+      console.log(`seed links:        ${c.seedLinks}`);
+    })
+    .catch((err) => {
+      console.error(err);
+      process.exit(1);
+    });
+}

--- a/src/app/admin/actions.ts
+++ b/src/app/admin/actions.ts
@@ -11,6 +11,7 @@ import {
   user as userTable,
   ledgerEntry,
 } from "@/lib/db/schema";
+import { listingSyncStatement } from "@/lib/model-b-writes";
 import { eq, desc, asc, isNotNull, sum, count, sql } from "drizzle-orm";
 import { alias } from "drizzle-orm/sqlite-core";
 import { revalidatePath } from "next/cache";
@@ -437,10 +438,14 @@ export async function setImageFeedRank(
     throw new Error("Rank must be a whole number between 1 and 9999");
   }
 
-  await db
-    .update(designImageTable)
-    .set({ feedRank })
-    .where(eq(designImageTable.id, imageId));
+  // Model B dual-write (slice 1): mirror onto the listing (no-op if unpublished).
+  await db.batch([
+    db
+      .update(designImageTable)
+      .set({ feedRank })
+      .where(eq(designImageTable.id, imageId)),
+    listingSyncStatement(db, imageId, { kind: "update", set: { feedRank } }),
+  ]);
 
   // The Shop feed renders on / and /prints; bust both plus the admin grid.
   revalidatePath("/");
@@ -454,10 +459,14 @@ export async function setImageHidden(imageId: string, hidden: boolean) {
     throw new Error("Unauthorized");
   }
 
-  await db
-    .update(designImageTable)
-    .set({ isHidden: hidden })
-    .where(eq(designImageTable.id, imageId));
+  // Model B dual-write (slice 1): mirror onto the listing (no-op if unpublished).
+  await db.batch([
+    db
+      .update(designImageTable)
+      .set({ isHidden: hidden })
+      .where(eq(designImageTable.id, imageId)),
+    listingSyncStatement(db, imageId, { kind: "update", set: { isHidden: hidden } }),
+  ]);
 
   // Discover feed on / and the public /d/[imageId] page both filter
   // by isHidden — bust their caches so the change is visible.

--- a/src/app/design/actions.ts
+++ b/src/app/design/actions.ts
@@ -12,8 +12,11 @@ import {
   designImage as designImageTable,
   chatMessage as chatMessageTable,
   order as orderTable,
+  image as imageTable,
+  conversationImage as conversationImageTable,
 } from "@/lib/db/schema";
 import { eq, sql } from "drizzle-orm";
+import { buildImageRow, buildOutputLinkRow } from "@/lib/model-b-writes";
 import { chatAboutDesign, constructFluxPrompt, assessReadiness } from "@/lib/ai";
 import { uploadDesignImage, deleteDesignImageObject } from "@/lib/r2";
 import { getGenerator } from "@/lib/generators/registry";
@@ -281,6 +284,22 @@ async function runGenerate({
         generator: generator.id,
         isApproved: false,
       }),
+      // Model B dual-write (slice 1): mirror the source artifact into image +
+      // output link, same id. found.userId is the verified design owner.
+      db.insert(imageTable).values(
+        buildImageRow({
+          id: newImageId,
+          ownerId: found.userId,
+          designId,
+          imageUrl: r2Url,
+          aspectRatio: "1:1",
+          prompt: aiResponse.fluxPrompt,
+          generator: generator.id,
+          generationCost: generator.costPerImage,
+          parentImageId,
+        })
+      ),
+      db.insert(conversationImageTable).values(buildOutputLinkRow(designId, newImageId)),
       ...(userMessage
         ? [
             db.insert(chatMessageTable).values({

--- a/src/app/designs/actions.ts
+++ b/src/app/designs/actions.ts
@@ -8,10 +8,15 @@ import {
   designImage as designImageTable,
   chatMessage as chatMessageTable,
   order as orderTable,
+  image as imageTable,
+  conversationImage as conversationImageTable,
+  placementRender as placementRenderTable,
+  listing as listingTable,
 } from "@/lib/db/schema";
 import { eq, desc, and, not, count, inArray } from "drizzle-orm";
 import { revalidatePath } from "next/cache";
 import { resolveDesignDisplayImageUrls } from "@/lib/design-images";
+import { listingSyncStatement, type ListingUpdate } from "@/lib/model-b-writes";
 import { generatePublishedNaming } from "@/lib/ai";
 import { DEFAULT_PUBLISH_BACKGROUND } from "@/lib/blanks";
 
@@ -129,8 +134,32 @@ export async function deleteDesign(designId: string) {
     return;
   }
 
+  // Also clear the Model B mirrors keyed to this design (slice 1). Images and
+  // their output links / listings key on the design's image ids; placement
+  // renders and conversation links key on design_id directly. Slice 4 replaces
+  // the blanket image delete with ref-counting (survive-if-shared); until then
+  // seed links only reference published/own images, so this stays safe.
+  const imageIds = (
+    await db
+      .select({ id: designImageTable.id })
+      .from(designImageTable)
+      .where(eq(designImageTable.designId, designId))
+  ).map((r) => r.id);
+
   await db.batch([
     db.delete(chatMessageTable).where(eq(chatMessageTable.designId, designId)),
+    db
+      .delete(conversationImageTable)
+      .where(eq(conversationImageTable.designId, designId)),
+    db
+      .delete(placementRenderTable)
+      .where(eq(placementRenderTable.designId, designId)),
+    ...(imageIds.length
+      ? [
+          db.delete(imageTable).where(inArray(imageTable.id, imageIds)),
+          db.delete(listingTable).where(inArray(listingTable.imageId, imageIds)),
+        ]
+      : []),
     db.delete(designImageTable).where(eq(designImageTable.designId, designId)),
     db.delete(designTable).where(eq(designTable.id, designId)),
   ]);
@@ -202,17 +231,27 @@ export async function publishImage(
     description = description || gen.description;
   }
 
-  await db
-    .update(designImageTable)
-    .set({
-      publishedAt: new Date(),
-      title,
-      description,
-      // Publish never leaves the backdrop transparent (#73): no pick — or an
-      // explicit null from a legacy caller — persists as White.
-      backgroundColor: opts.backgroundColor ?? DEFAULT_PUBLISH_BACKGROUND,
-    })
-    .where(eq(designImageTable.id, imageId));
+  const publishedAt = new Date();
+  const backgroundColor = opts.backgroundColor ?? DEFAULT_PUBLISH_BACKGROUND;
+  // Publish never leaves the backdrop transparent (#73): no pick — or an
+  // explicit null from a legacy caller — persists as White.
+  await db.batch([
+    db
+      .update(designImageTable)
+      .set({ publishedAt, title, description, backgroundColor })
+      .where(eq(designImageTable.id, imageId)),
+    // Model B dual-write (slice 1): the listing carries the image's current
+    // hidden/feed-rank so it's a faithful snapshot of the publish state.
+    listingSyncStatement(db, imageId, {
+      kind: "publish",
+      publishedAt,
+      isHidden: image.isHidden,
+      title: title ?? null,
+      description: description ?? null,
+      backgroundColor,
+      feedRank: image.feedRank,
+    }),
+  ]);
 
   revalidatePath("/");
   revalidatePath("/prints");
@@ -257,14 +296,17 @@ export async function updatePublishedNaming(
   // sends title + description. The picker no longer offers a transparent
   // option (#73); a legacy null still displays as White via
   // publishedBackdrop, so the guard stays `!== undefined`, not truthiness.
-  await db
-    .update(designImageTable)
-    .set({
-      ...(title !== undefined ? { title: title.trim() } : {}),
-      ...(description !== undefined ? { description: description.trim() } : {}),
-      ...(backgroundColor !== undefined ? { backgroundColor } : {}),
-    })
-    .where(eq(designImageTable.id, imageId));
+  const set: ListingUpdate = {};
+  if (title !== undefined) set.title = title.trim();
+  if (description !== undefined) set.description = description.trim();
+  if (backgroundColor !== undefined) set.backgroundColor = backgroundColor;
+
+  // Model B dual-write (slice 1): the same partial keeps the listing in
+  // lockstep. The listing update no-ops when the image predates its listing row.
+  await db.batch([
+    db.update(designImageTable).set(set).where(eq(designImageTable.id, imageId)),
+    listingSyncStatement(db, imageId, { kind: "update", set }),
+  ]);
 
   revalidatePath("/");
   revalidatePath("/prints");
@@ -302,10 +344,15 @@ export async function unpublishImage(imageId: string) {
 
   if (!image.publishedAt) return;
 
-  await db
-    .update(designImageTable)
-    .set({ publishedAt: null })
-    .where(eq(designImageTable.id, imageId));
+  // Model B dual-write (slice 1): unpublish = delete the listing row, matching
+  // the reversible semantics (title/backdrop stay on design_image for re-publish).
+  await db.batch([
+    db
+      .update(designImageTable)
+      .set({ publishedAt: null })
+      .where(eq(designImageTable.id, imageId)),
+    listingSyncStatement(db, imageId, { kind: "unpublish" }),
+  ]);
 
   revalidatePath("/");
   revalidatePath("/prints");

--- a/src/lib/__tests__/model-b-backfill.integration.test.ts
+++ b/src/lib/__tests__/model-b-backfill.integration.test.ts
@@ -1,0 +1,246 @@
+/**
+ * Model B slice-1 backfill (docs/model-b-migration-plan.md). Seeds legacy
+ * design_image / design rows directly (bypassing the dual-write) and asserts
+ * the backfill reconstructs the new tables: the artifact/render split, listings
+ * from published rows, seed lineage from forked designs — with the design_image
+ * id reused verbatim (risky spot §5) — and that a second run is a no-op.
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+import { eq } from "drizzle-orm";
+import { createTestDb } from "./test-db";
+import * as schema from "@/lib/db/schema";
+import { backfillModelB } from "../../../scripts/backfill-model-b";
+
+type Db = Awaited<ReturnType<typeof createTestDb>>;
+let db: Db;
+
+async function seedUser(id: string) {
+  await db.insert(schema.user).values({ id, email: `${id}@e.com`, name: id });
+}
+
+beforeEach(async () => {
+  db = await createTestDb();
+});
+
+describe("backfillModelB", () => {
+  it("splits artifacts vs renders and reuses ids", async () => {
+    await seedUser("u1");
+    const [design] = await db
+      .insert(schema.design)
+      .values({ userId: "u1" })
+      .returning();
+
+    const [artifact] = await db
+      .insert(schema.designImage)
+      .values({
+        designId: design.id,
+        aspectRatio: "1:1",
+        imageUrl: "https://cdn/x/designs/d/1.png",
+        prompt: "a fox",
+        generator: "ideogram",
+        generationCost: 0.03,
+      })
+      .returning();
+    const [render] = await db
+      .insert(schema.designImage)
+      .values({
+        designId: design.id,
+        aspectRatio: "1:2",
+        productId: "bella-canvas-3001",
+        placementId: "back",
+        parentImageId: artifact.id,
+        imageUrl: "https://cdn/x/renders/back.png",
+        generationCost: 0.03,
+      })
+      .returning();
+
+    const counts = await backfillModelB(db);
+    expect(counts.images).toBe(1);
+    expect(counts.placementRenders).toBe(1);
+    expect(counts.outputLinks).toBe(1);
+
+    // Artifact → image row, SAME id (risky spot §5).
+    const [img] = await db
+      .select()
+      .from(schema.image)
+      .where(eq(schema.image.id, artifact.id));
+    expect(img).toBeTruthy();
+    expect(img.id).toBe(artifact.id);
+    expect(img.ownerId).toBe("u1");
+    expect(img.sourceDesignId).toBe(design.id);
+    expect(img.generator).toBe("ideogram");
+    expect(img.r2Key).toBe("x/designs/d/1.png");
+
+    // The render is NOT an image; it's a placement_render with the same id.
+    expect(
+      await db.select().from(schema.image).where(eq(schema.image.id, render.id))
+    ).toHaveLength(0);
+    const [pr] = await db
+      .select()
+      .from(schema.placementRender)
+      .where(eq(schema.placementRender.id, render.id));
+    expect(pr.blankId).toBe("bella-canvas-3001");
+    expect(pr.placementId).toBe("back");
+    expect(pr.sourceImageId).toBe(artifact.id);
+
+    // Output link for the artifact only.
+    const links = await db.select().from(schema.conversationImage);
+    expect(links).toHaveLength(1);
+    expect(links[0]).toMatchObject({
+      designId: design.id,
+      imageId: artifact.id,
+      role: "output",
+    });
+  });
+
+  it("coalesces a null placement to 'default'", async () => {
+    await seedUser("u1");
+    const [design] = await db.insert(schema.design).values({ userId: "u1" }).returning();
+    const [render] = await db
+      .insert(schema.designImage)
+      .values({
+        designId: design.id,
+        aspectRatio: "1:1",
+        productId: "bella-canvas-3001",
+        placementId: null,
+        imageUrl: "https://cdn/front.png",
+        generationCost: 0,
+      })
+      .returning();
+
+    await backfillModelB(db);
+    const [pr] = await db
+      .select()
+      .from(schema.placementRender)
+      .where(eq(schema.placementRender.id, render.id));
+    expect(pr.placementId).toBe("default");
+  });
+
+  it("creates a listing for published rows", async () => {
+    await seedUser("u1");
+    const [design] = await db.insert(schema.design).values({ userId: "u1" }).returning();
+    const publishedAt = new Date("2026-07-01T00:00:00Z");
+    const [pubImg] = await db
+      .insert(schema.designImage)
+      .values({
+        designId: design.id,
+        aspectRatio: "1:1",
+        imageUrl: "https://cdn/pub.png",
+        generationCost: 0,
+        publishedAt,
+        isHidden: true,
+        title: "Published",
+        description: "Desc",
+        backgroundColor: "Black",
+        feedRank: 2,
+      })
+      .returning();
+
+    const counts = await backfillModelB(db);
+    expect(counts.listings).toBe(1);
+    const [listing] = await db
+      .select()
+      .from(schema.listing)
+      .where(eq(schema.listing.imageId, pubImg.id));
+    expect(listing.publishedAt.getTime()).toBe(publishedAt.getTime());
+    expect(listing.isHidden).toBe(true);
+    expect(listing.title).toBe("Published");
+    expect(listing.feedRank).toBe(2);
+  });
+
+  it("records seed lineage from a forked design", async () => {
+    await seedUser("u1");
+    await seedUser("u2");
+    // The seed image lives in another design owned by u2.
+    const [seedDesign] = await db.insert(schema.design).values({ userId: "u2" }).returning();
+    const [seedImg] = await db
+      .insert(schema.designImage)
+      .values({
+        designId: seedDesign.id,
+        aspectRatio: "1:1",
+        imageUrl: "https://cdn/seed.png",
+        generationCost: 0,
+      })
+      .returning();
+    // A forked design under u1.
+    const [forked] = await db
+      .insert(schema.design)
+      .values({
+        userId: "u1",
+        forkedFromImageId: seedImg.id,
+        originalDesignerId: "u2",
+      })
+      .returning();
+    const [forkImg] = await db
+      .insert(schema.designImage)
+      .values({
+        designId: forked.id,
+        aspectRatio: "1:1",
+        imageUrl: "https://cdn/fork.png",
+        generationCost: 0,
+      })
+      .returning();
+
+    const counts = await backfillModelB(db);
+    expect(counts.seedLinks).toBe(1);
+
+    // Seed link on the forked conversation.
+    const seedLinks = await db
+      .select()
+      .from(schema.conversationImage)
+      .where(eq(schema.conversationImage.role, "seed"));
+    expect(seedLinks).toHaveLength(1);
+    expect(seedLinks[0]).toMatchObject({
+      designId: forked.id,
+      imageId: seedImg.id,
+      role: "seed",
+    });
+
+    // The forked design's image carries seed_image_id + original_designer_id.
+    const [img] = await db
+      .select()
+      .from(schema.image)
+      .where(eq(schema.image.id, forkImg.id));
+    expect(img.seedImageId).toBe(seedImg.id);
+    expect(img.originalDesignerId).toBe("u2");
+  });
+
+  it("is idempotent — a second run inserts nothing new", async () => {
+    await seedUser("u1");
+    const [design] = await db.insert(schema.design).values({ userId: "u1" }).returning();
+    await db.insert(schema.designImage).values([
+      {
+        designId: design.id,
+        aspectRatio: "1:1",
+        imageUrl: "https://cdn/a.png",
+        generationCost: 0,
+        publishedAt: new Date(),
+      },
+      {
+        designId: design.id,
+        aspectRatio: "1:2",
+        productId: "bella-canvas-3001",
+        placementId: "back",
+        imageUrl: "https://cdn/b.png",
+        generationCost: 0,
+      },
+    ]);
+
+    await backfillModelB(db);
+    const after1 = {
+      images: (await db.select().from(schema.image)).length,
+      links: (await db.select().from(schema.conversationImage)).length,
+      renders: (await db.select().from(schema.placementRender)).length,
+      listings: (await db.select().from(schema.listing)).length,
+    };
+    await backfillModelB(db);
+    const after2 = {
+      images: (await db.select().from(schema.image)).length,
+      links: (await db.select().from(schema.conversationImage)).length,
+      renders: (await db.select().from(schema.placementRender)).length,
+      listings: (await db.select().from(schema.listing)).length,
+    };
+    expect(after2).toEqual(after1);
+    expect(after1).toEqual({ images: 1, links: 1, renders: 1, listings: 1 });
+  });
+});

--- a/src/lib/__tests__/model-b-dual-write.integration.test.ts
+++ b/src/lib/__tests__/model-b-dual-write.integration.test.ts
@@ -1,0 +1,273 @@
+/**
+ * Model B slice-1 dual-write (docs/model-b-migration-plan.md). Every write path
+ * that touches design_image must land the matching new-table shape in the same
+ * batch, with the id reused. Runs against a real in-memory libSQL (#28), and
+ * drives the server actions with db + auth mocked so the batches actually run.
+ */
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { eq } from "drizzle-orm";
+import { createTestDb } from "./test-db";
+import * as schema from "@/lib/db/schema";
+
+type Db = Awaited<ReturnType<typeof createTestDb>>;
+let testDb: Db;
+let currentUserId: string;
+
+vi.mock("@/lib/db", () => ({
+  get db() {
+    return testDb;
+  },
+}));
+
+// designs/actions.ts and admin/actions.ts authorize via the session; stub it to
+// the current owner (admin email for the admin actions).
+vi.mock("next/headers", () => ({ headers: async () => new Headers() }));
+vi.mock("next/cache", () => ({ revalidatePath: () => {} }));
+vi.mock("@/lib/auth", () => ({
+  auth: {
+    api: {
+      getSession: async () => ({
+        user: { id: currentUserId, email: process.env.ADMIN_EMAIL },
+      }),
+    },
+  },
+  isAnonymousUser: () => false,
+}));
+vi.mock("@/lib/ai", () => ({
+  generatePublishedNaming: async () => ({
+    title: "Auto Title",
+    description: "Auto Description",
+  }),
+}));
+
+// admin/actions pulls the Stripe/Resend clients in at module load (they
+// construct on import). The publish-family paths under test never call them;
+// dummy keys just get the modules loaded.
+process.env.STRIPE_SECRET_KEY ??= "sk_test_dummy";
+process.env.RESEND_API_KEY ??= "re_dummy";
+// admin/actions reads ADMIN_EMAIL at module load; it also gates the admin
+// actions and matches the seeded owner so the session check passes.
+process.env.ADMIN_EMAIL = "owner@example.com";
+
+const { insertDesignImage } = await import("@/lib/design-images");
+const { publishImage, unpublishImage, updatePublishedNaming, deleteDesign } =
+  await import("@/app/designs/actions");
+const { setImageHidden, setImageFeedRank } = await import("@/app/admin/actions");
+
+async function seedDesign(): Promise<{ userId: string; designId: string }> {
+  const userId = "owner-1";
+  await testDb.insert(schema.user).values({
+    id: userId,
+    email: "owner@example.com",
+    name: "Owner",
+  });
+  const [design] = await testDb
+    .insert(schema.design)
+    .values({ userId })
+    .returning();
+  return { userId, designId: design.id };
+}
+
+beforeEach(async () => {
+  testDb = await createTestDb();
+});
+
+describe("insertDesignImage dual-write", () => {
+  it("source generation lands image + output link with the same id", async () => {
+    const { designId } = await seedDesign();
+    currentUserId = "owner-1";
+
+    const id = await insertDesignImage({
+      designId,
+      imageUrl: "https://cdn.example.com/designs/d/1.png",
+      aspectRatio: "1:1",
+      prompt: "a cat",
+      generationCost: 0.03,
+    });
+
+    const [img] = await testDb
+      .select()
+      .from(schema.image)
+      .where(eq(schema.image.id, id));
+    expect(img).toBeTruthy();
+    expect(img.ownerId).toBe("owner-1");
+    expect(img.sourceDesignId).toBe(designId);
+    expect(img.imageUrl).toBe("https://cdn.example.com/designs/d/1.png");
+    // r2_key parsed best-effort from the URL path.
+    expect(img.r2Key).toBe("designs/d/1.png");
+
+    const links = await testDb
+      .select()
+      .from(schema.conversationImage)
+      .where(eq(schema.conversationImage.imageId, id));
+    expect(links).toHaveLength(1);
+    expect(links[0].role).toBe("output");
+    expect(links[0].designId).toBe(designId);
+
+    // Not a placement render.
+    const renders = await testDb
+      .select()
+      .from(schema.placementRender)
+      .where(eq(schema.placementRender.id, id));
+    expect(renders).toHaveLength(0);
+  });
+
+  it("placement render lands placement_render with the same id, no image row", async () => {
+    const { designId } = await seedDesign();
+    currentUserId = "owner-1";
+    const src = await insertDesignImage({
+      designId,
+      imageUrl: "https://img/src.png",
+      aspectRatio: "1:1",
+      generationCost: 0,
+    });
+
+    const renderId = await insertDesignImage({
+      designId,
+      imageUrl: "https://img/back.png",
+      aspectRatio: "1:2",
+      generationCost: 0.03,
+      productId: "bella-canvas-3001",
+      placementId: "back",
+      parentImageId: src,
+    });
+
+    const [render] = await testDb
+      .select()
+      .from(schema.placementRender)
+      .where(eq(schema.placementRender.id, renderId));
+    expect(render).toBeTruthy();
+    expect(render.blankId).toBe("bella-canvas-3001");
+    expect(render.placementId).toBe("back");
+    expect(render.sourceImageId).toBe(src);
+
+    // A render is not an artifact — no image row for it.
+    const img = await testDb
+      .select()
+      .from(schema.image)
+      .where(eq(schema.image.id, renderId));
+    expect(img).toHaveLength(0);
+  });
+});
+
+describe("publish-family dual-write", () => {
+  async function seedSourceImage() {
+    const { designId } = await seedDesign();
+    currentUserId = "owner-1";
+    const imageId = await insertDesignImage({
+      designId,
+      imageUrl: "https://img/pub.png",
+      aspectRatio: "1:1",
+      generationCost: 0,
+    });
+    return { designId, imageId };
+  }
+
+  it("publishImage inserts a listing row", async () => {
+    const { imageId } = await seedSourceImage();
+    await publishImage(imageId, { title: "T", description: "D", backgroundColor: "Black" });
+
+    const [listing] = await testDb
+      .select()
+      .from(schema.listing)
+      .where(eq(schema.listing.imageId, imageId));
+    expect(listing).toBeTruthy();
+    expect(listing.title).toBe("T");
+    expect(listing.backgroundColor).toBe("Black");
+    expect(listing.isHidden).toBe(false);
+  });
+
+  it("updatePublishedNaming keeps the listing in lockstep", async () => {
+    const { imageId } = await seedSourceImage();
+    await publishImage(imageId, { title: "T", description: "D", backgroundColor: "Black" });
+    await updatePublishedNaming(imageId, { title: "New", backgroundColor: "White" });
+
+    const [listing] = await testDb
+      .select()
+      .from(schema.listing)
+      .where(eq(schema.listing.imageId, imageId));
+    expect(listing.title).toBe("New");
+    expect(listing.backgroundColor).toBe("White");
+    // design_image stays in lockstep.
+    const [di] = await testDb
+      .select()
+      .from(schema.designImage)
+      .where(eq(schema.designImage.id, imageId));
+    expect(di.title).toBe("New");
+    expect(di.backgroundColor).toBe("White");
+  });
+
+  it("setImageHidden / setImageFeedRank mirror onto the listing", async () => {
+    const { imageId } = await seedSourceImage();
+    await publishImage(imageId, { title: "T", description: "D" });
+    await setImageHidden(imageId, true);
+    await setImageFeedRank(imageId, 3);
+
+    const [listing] = await testDb
+      .select()
+      .from(schema.listing)
+      .where(eq(schema.listing.imageId, imageId));
+    expect(listing.isHidden).toBe(true);
+    expect(listing.feedRank).toBe(3);
+  });
+
+  it("unpublishImage deletes the listing", async () => {
+    const { imageId } = await seedSourceImage();
+    await publishImage(imageId, { title: "T", description: "D" });
+    await unpublishImage(imageId);
+
+    const listing = await testDb
+      .select()
+      .from(schema.listing)
+      .where(eq(schema.listing.imageId, imageId));
+    expect(listing).toHaveLength(0);
+    // design_image publish flag cleared too.
+    const [di] = await testDb
+      .select()
+      .from(schema.designImage)
+      .where(eq(schema.designImage.id, imageId));
+    expect(di.publishedAt).toBeNull();
+  });
+
+  it("editing an unpublished image conjures no listing", async () => {
+    const { imageId } = await seedSourceImage();
+    await setImageFeedRank(imageId, 5);
+    await setImageHidden(imageId, true);
+    const listing = await testDb
+      .select()
+      .from(schema.listing)
+      .where(eq(schema.listing.imageId, imageId));
+    expect(listing).toHaveLength(0);
+  });
+});
+
+describe("deleteDesign clears Model B rows", () => {
+  it("removes image, links, listing, and placement renders", async () => {
+    const { designId } = await seedDesign();
+    currentUserId = "owner-1";
+    const imageId = await insertDesignImage({
+      designId,
+      imageUrl: "https://img/one.png",
+      aspectRatio: "1:1",
+      generationCost: 0,
+    });
+    await insertDesignImage({
+      designId,
+      imageUrl: "https://img/render.png",
+      aspectRatio: "1:2",
+      generationCost: 0,
+      productId: "bella-canvas-3001",
+      placementId: "front",
+      parentImageId: imageId,
+    });
+    await publishImage(imageId, { title: "T", description: "D" });
+
+    await deleteDesign(designId);
+
+    expect(await testDb.select().from(schema.image)).toHaveLength(0);
+    expect(await testDb.select().from(schema.conversationImage)).toHaveLength(0);
+    expect(await testDb.select().from(schema.placementRender)).toHaveLength(0);
+    expect(await testDb.select().from(schema.listing)).toHaveLength(0);
+    expect(await testDb.select().from(schema.designImage)).toHaveLength(0);
+  });
+});

--- a/src/lib/__tests__/model-b-writes.test.ts
+++ b/src/lib/__tests__/model-b-writes.test.ts
@@ -1,0 +1,41 @@
+/**
+ * Immutability guardrail (docs/model-b-migration-plan.md §3): a published
+ * listing points at an `image` row nothing mutates, so publishing is a snapshot
+ * by construction. The image write layer (model-b-writes.ts) must expose no
+ * helper that updates an image's imageUrl / r2Key / prompt after insert. This
+ * test fails if such a path is ever added — the enforcement the doc asks for.
+ */
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, it, expect } from "vitest";
+import * as writes from "@/lib/model-b-writes";
+import { r2KeyFromUrl } from "@/lib/model-b-writes";
+
+const source = readFileSync(
+  fileURLToPath(new URL("../model-b-writes.ts", import.meta.url)),
+  "utf8"
+);
+
+describe("image write layer immutability", () => {
+  it("exposes no update against the image table", () => {
+    // Any UPDATE on the image table would be an escape hatch around the
+    // snapshot guarantee. The module writes image rows via INSERT only.
+    expect(source).not.toMatch(/\.update\(\s*imageTable\b/);
+    expect(source).not.toMatch(/update\(image\b/);
+  });
+
+  it("only builds image rows, never mutates the immutable fields", () => {
+    // No exported helper name suggests mutating an artifact's content.
+    const names = Object.keys(writes);
+    for (const n of names) {
+      expect(n).not.toMatch(/updateImage|setImageUrl|setR2Key|setPrompt/i);
+    }
+  });
+
+  it("r2KeyFromUrl parses the object key from a public URL", () => {
+    expect(r2KeyFromUrl("https://pub-x.r2.dev/designs/d/1.png")).toBe(
+      "designs/d/1.png"
+    );
+    expect(r2KeyFromUrl("not a url")).toBeNull();
+  });
+});

--- a/src/lib/__tests__/reparent-user.integration.test.ts
+++ b/src/lib/__tests__/reparent-user.integration.test.ts
@@ -61,6 +61,15 @@ describe("reparentUserData", () => {
         blankId: "bella-canvas-3001",
       })
       .returning();
+    const [image] = await db
+      .insert(schema.image)
+      .values({
+        ownerId: "anon-1",
+        imageUrl: "https://img/a.png",
+        aspectRatio: "1:1",
+        sourceDesignId: design.id,
+      })
+      .returning();
 
     await reparentUserData(db, "anon-1", "real-1");
 
@@ -82,6 +91,10 @@ describe("reparentUserData", () => {
     ).toBe("real-1");
     expect(
       (await db.query.product.findFirst({ where: eq(schema.product.id, product.id) }))
+        ?.ownerId
+    ).toBe("real-1");
+    expect(
+      (await db.query.image.findFirst({ where: eq(schema.image.id, image.id) }))
         ?.ownerId
     ).toBe("real-1");
 

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -325,6 +325,104 @@ export const generationUsage = sqliteTable(
   (t) => [uniqueIndex("generation_usage_bucket_day").on(t.bucket, t.day)]
 );
 
+/**
+ * Model B (conversation/image split, docs/model-b-migration-plan.md). The
+ * standalone artifact: a generated image, owned by a user, reusable across
+ * conversations. On backfill every row keeps its `design_image.id` (id reuse
+ * §2) so order/product/cart placement refs — which store image ids as opaque
+ * strings — never move.
+ *
+ * Slice 1 dual-writes this alongside `design_image` for source generations;
+ * readers stay on `design_image` until slice 2. Immutability guardrail
+ * (§3): nothing may update `imageUrl`/`r2Key`/`prompt` after insert — the
+ * write layer (src/lib/model-b-writes.ts) exposes no such helper, so a listing
+ * that points at a row is a snapshot by construction.
+ *
+ * Image-id columns (parent/seed/original-designer/source-design) are opaque
+ * text, no FK — matching the existing schema (design.forkedFromImageId,
+ * design_image.parentImageId are FK-less) and the id-reuse contract, and
+ * avoiding backfill/dual-write ordering hazards. Only `ownerId` (→ user) is a
+ * FK, so reparenting and owner joins stay sound.
+ */
+export const image = sqliteTable("image", {
+  id: text("id").primaryKey().$defaultFn(() => crypto.randomUUID()),
+  ownerId: text("owner_id").notNull().references(() => user.id),
+  // Null when a legacy URL can't be parsed to a key; imageUrl is authoritative
+  // for display, r2Key is best-effort for object operations.
+  r2Key: text("r2_key"),
+  imageUrl: text("image_url").notNull(),
+  aspectRatio: text("aspect_ratio").notNull(),
+  prompt: text("prompt"),
+  generator: text("generator"),
+  generationCost: real("generation_cost").notNull().default(0),
+  // Within-thread iteration chain (was design_image.parentImageId).
+  parentImageId: text("parent_image_id"),
+  // Cross-conversation lineage (was design.forkedFromImageId).
+  seedImageId: text("seed_image_id"),
+  // Denormalized attribution root (was design.originalDesignerId).
+  originalDesignerId: text("original_designer_id"),
+  // The conversation that generated it (mirrors the role=output link).
+  sourceDesignId: text("source_design_id"),
+  createdAt: integer("created_at", { mode: "timestamp" }).notNull().$defaultFn(() => new Date()),
+});
+
+/**
+ * Model B join between a conversation (`design`) and an `image`. `output` =
+ * the conversation generated it; `seed` = it was carried into the conversation
+ * as a starting point (replaces the copy-based fork in a later slice). Many
+ * conversations can reference one image. `imageId` is opaque text (no FK) per
+ * the id-reuse contract; `designId` FKs `design` (always present).
+ */
+export const conversationImage = sqliteTable(
+  "conversation_image",
+  {
+    id: text("id").primaryKey().$defaultFn(() => crypto.randomUUID()),
+    designId: text("design_id").notNull().references(() => design.id),
+    imageId: text("image_id").notNull(),
+    role: text("role", { enum: ["output", "seed"] }).notNull(),
+    createdAt: integer("created_at", { mode: "timestamp" }).notNull().$defaultFn(() => new Date()),
+  },
+  (t) => [uniqueIndex("conversation_image_unique").on(t.designId, t.imageId, t.role)]
+);
+
+/**
+ * Model B published-listing state, split off `design_image` (simplification
+ * item 3). One listing per image (PK = imageId). A row exists iff the image is
+ * published — unpublish deletes it. Naming/hidden/feed-rank edits update it in
+ * lockstep with the `design_image` publish columns during the dual-write
+ * window (risky spot §3). `imageId` is opaque text (no FK).
+ */
+export const listing = sqliteTable("listing", {
+  imageId: text("image_id").primaryKey(),
+  publishedAt: integer("published_at", { mode: "timestamp" }).notNull(),
+  isHidden: integer("is_hidden", { mode: "boolean" }).notNull().default(false),
+  title: text("title"),
+  description: text("description"),
+  backgroundColor: text("background_color"),
+  feedRank: integer("feed_rank"),
+  createdAt: integer("created_at", { mode: "timestamp" }).notNull().$defaultFn(() => new Date()),
+});
+
+/**
+ * Model B placement-render cache, split off `design_image` (simplification
+ * item 3). These are derived renders (a source image composed onto a blank's
+ * placement), not artifacts — they never appear as `image` rows. On backfill
+ * each keeps its `design_image.id` (id reuse) so orders that pin a render id in
+ * their placements keep resolving. `sourceImageId` is the #25 anchor (was
+ * design_image.parentImageId); `blankId` was design_image.productId.
+ */
+export const placementRender = sqliteTable("placement_render", {
+  id: text("id").primaryKey().$defaultFn(() => crypto.randomUUID()),
+  designId: text("design_id").notNull().references(() => design.id),
+  sourceImageId: text("source_image_id"),
+  blankId: text("blank_id").notNull(),
+  placementId: text("placement_id").notNull(),
+  imageUrl: text("image_url").notNull(),
+  aspectRatio: text("aspect_ratio").notNull(),
+  generationCost: real("generation_cost").notNull().default(0),
+  createdAt: integer("created_at", { mode: "timestamp" }).notNull().$defaultFn(() => new Date()),
+});
+
 export type ChatMessage = {
   id: string;
   designId: string;

--- a/src/lib/design-images.ts
+++ b/src/lib/design-images.ts
@@ -3,10 +3,18 @@ import {
   design as designTable,
   designImage as designImageTable,
   chatMessage as chatMessageTable,
+  image as imageTable,
+  conversationImage as conversationImageTable,
+  placementRender as placementRenderTable,
   type ChatMessage,
 } from "@/lib/db/schema";
 import { eq, and, asc, desc, inArray, isNull, isNotNull, sql } from "drizzle-orm";
 import { getBlank, type AspectRatio } from "@/lib/blanks";
+import {
+  buildImageRow,
+  buildOutputLinkRow,
+  buildPlacementRenderRow,
+} from "@/lib/model-b-writes";
 
 /**
  * Atomically reserve `count` generation numbers for a design in a single
@@ -125,18 +133,64 @@ export async function insertDesignImage(params: {
   }
 
   const id = crypto.randomUUID();
-  await db.insert(designImageTable).values({
+  const productId = params.productId ?? null;
+  const designImageInsert = db.insert(designImageTable).values({
     id,
     designId: params.designId,
     parentImageId,
     aspectRatio: params.aspectRatio,
-    productId: params.productId ?? null,
+    productId,
     placementId: params.placementId ?? null,
     imageUrl: params.imageUrl,
     prompt: params.prompt ?? null,
     generationCost: params.generationCost,
     isApproved: false,
   });
+
+  // Model B dual-write (slice 1). A row with product_id set is a placement
+  // render (cache) → placement_render; otherwise it's a source artifact →
+  // image + output link. Same id in both so slice-2 readers and pinned order
+  // placements resolve unchanged.
+  if (productId !== null) {
+    await db.batch([
+      designImageInsert,
+      db.insert(placementRenderTable).values(
+        buildPlacementRenderRow({
+          id,
+          designId: params.designId,
+          sourceImageId: parentImageId,
+          blankId: productId,
+          placementId: params.placementId,
+          imageUrl: params.imageUrl,
+          aspectRatio: params.aspectRatio,
+          generationCost: params.generationCost,
+        })
+      ),
+    ]);
+  } else {
+    const [owner] = await db
+      .select({ userId: designTable.userId })
+      .from(designTable)
+      .where(eq(designTable.id, params.designId))
+      .limit(1);
+    if (!owner) throw new Error("Design not found");
+    await db.batch([
+      designImageInsert,
+      db.insert(imageTable).values(
+        buildImageRow({
+          id,
+          ownerId: owner.userId,
+          designId: params.designId,
+          imageUrl: params.imageUrl,
+          aspectRatio: params.aspectRatio,
+          prompt: params.prompt,
+          generationCost: params.generationCost,
+          parentImageId,
+        })
+      ),
+      db.insert(conversationImageTable).values(buildOutputLinkRow(params.designId, id)),
+    ]);
+  }
   return id;
 }
 
@@ -531,14 +585,24 @@ export async function deleteDesignImageRow(
   designId: string,
   imageId: string
 ): Promise<{ newPrimaryId: string | null }> {
-  await db
-    .delete(designImageTable)
-    .where(
-      and(
-        eq(designImageTable.id, imageId),
-        eq(designImageTable.designId, designId)
-      )
-    );
+  // Delete the design_image row and its Model B mirrors (slice 1) atomically.
+  // The id is shared, so the same id addresses the image / placement_render
+  // rows; the output link keys on image_id.
+  await db.batch([
+    db
+      .delete(designImageTable)
+      .where(
+        and(
+          eq(designImageTable.id, imageId),
+          eq(designImageTable.designId, designId)
+        )
+      ),
+    db.delete(imageTable).where(eq(imageTable.id, imageId)),
+    db.delete(placementRenderTable).where(eq(placementRenderTable.id, imageId)),
+    db
+      .delete(conversationImageTable)
+      .where(eq(conversationImageTable.imageId, imageId)),
+  ]);
 
   const remaining = await db
     .select({ id: designImageTable.id })

--- a/src/lib/model-b-writes.ts
+++ b/src/lib/model-b-writes.ts
@@ -1,0 +1,215 @@
+/**
+ * Model B dual-write builders (docs/model-b-migration-plan.md, slice 1).
+ *
+ * Slice 1 keeps `design_image` authoritative but mirrors every write into the
+ * new tables (`image`, `conversation_image`, `listing`, `placement_render`) so
+ * slice 2 can flip readers over with the data already present. These builders
+ * are the single source of the column mapping — both design_image insert sites
+ * (the inline batch in generateDesign and insertDesignImage) and every
+ * publish-family action route through here, so the two shapes can't drift
+ * (risky spots §3, §5).
+ *
+ * Each builder returns a plain row/values object; the caller splices the
+ * corresponding `db.insert(...).values(row)` / `db.update(...)` into its
+ * existing `db.batch`. Keeping the batching at the call site (rather than
+ * returning query builders) avoids leaking drizzle's batch-item types through
+ * this module and keeps each site's atomicity explicit.
+ *
+ * Immutability guardrail (§3): this module builds image INSERT rows only. It
+ * deliberately exposes NO helper that updates image.imageUrl / r2Key / prompt.
+ * A published listing points at an image row nothing mutates, so publishing is
+ * a snapshot by construction. `model-b-writes.test.ts` locks this in.
+ */
+import { eq } from "drizzle-orm";
+import type { db as appDb } from "@/lib/db";
+import {
+  image as imageTable,
+  conversationImage as conversationImageTable,
+  listing as listingTable,
+  placementRender as placementRenderTable,
+} from "@/lib/db/schema";
+
+type ImageRow = typeof imageTable.$inferInsert;
+type ConversationImageRow = typeof conversationImageTable.$inferInsert;
+type ListingRow = typeof listingTable.$inferInsert;
+type PlacementRenderRow = typeof placementRenderTable.$inferInsert;
+
+/**
+ * Best-effort R2 key for an image URL: the object key is the URL path minus
+ * the leading slash (works for both the r2.dev host and a custom domain).
+ * Returns null when the URL can't be parsed — imageUrl stays authoritative.
+ */
+export function r2KeyFromUrl(url: string): string | null {
+  try {
+    return new URL(url).pathname.replace(/^\//, "") || null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Build the `image` row for a source generation (an artifact — never a
+ * placement render). `id` is reused from the design_image row so orders/
+ * products that pin the id keep resolving after slice 2.
+ */
+export function buildImageRow(params: {
+  id: string;
+  ownerId: string;
+  designId: string;
+  imageUrl: string;
+  aspectRatio: string;
+  prompt?: string | null;
+  generator?: string | null;
+  generationCost: number;
+  parentImageId?: string | null;
+  seedImageId?: string | null;
+  originalDesignerId?: string | null;
+}): ImageRow {
+  return {
+    id: params.id,
+    ownerId: params.ownerId,
+    r2Key: r2KeyFromUrl(params.imageUrl),
+    imageUrl: params.imageUrl,
+    aspectRatio: params.aspectRatio,
+    prompt: params.prompt ?? null,
+    generator: params.generator ?? null,
+    generationCost: params.generationCost,
+    parentImageId: params.parentImageId ?? null,
+    seedImageId: params.seedImageId ?? null,
+    originalDesignerId: params.originalDesignerId ?? null,
+    sourceDesignId: params.designId,
+  };
+}
+
+/** Build the `conversation_image` link row for a generation's output image. */
+export function buildOutputLinkRow(
+  designId: string,
+  imageId: string
+): ConversationImageRow {
+  return {
+    id: crypto.randomUUID(),
+    designId,
+    imageId,
+    role: "output",
+  };
+}
+
+/**
+ * Build the `placement_render` row for a placement-targeted render. `id` is
+ * reused from the design_image row. `placementId` coalesces to "default" —
+ * legacy front renders stored a null placement, but the cache table requires
+ * one and "default" is the established front fallback (getDesignPlacementRenders).
+ */
+export function buildPlacementRenderRow(params: {
+  id: string;
+  designId: string;
+  sourceImageId?: string | null;
+  blankId: string;
+  placementId?: string | null;
+  imageUrl: string;
+  aspectRatio: string;
+  generationCost: number;
+}): PlacementRenderRow {
+  return {
+    id: params.id,
+    designId: params.designId,
+    sourceImageId: params.sourceImageId ?? null,
+    blankId: params.blankId,
+    placementId: params.placementId ?? "default",
+    imageUrl: params.imageUrl,
+    aspectRatio: params.aspectRatio,
+    generationCost: params.generationCost,
+  };
+}
+
+/**
+ * Build the `listing` row for a freshly published image. Mirrors the full
+ * publish state so the row is self-contained; feed-rank/hidden carry the
+ * image's current values (publishImage no-ops if already published, so this is
+ * always an insert of a new row).
+ */
+export function buildListingRow(params: {
+  imageId: string;
+  publishedAt: Date;
+  isHidden: boolean;
+  title: string | null;
+  description: string | null;
+  backgroundColor: string | null;
+  feedRank: number | null;
+}): ListingRow {
+  return {
+    imageId: params.imageId,
+    publishedAt: params.publishedAt,
+    isHidden: params.isHidden,
+    title: params.title,
+    description: params.description,
+    backgroundColor: params.backgroundColor,
+    feedRank: params.feedRank,
+  };
+}
+
+/**
+ * Fields a publish-family edit (naming / hidden / feed-rank) applies to an
+ * existing listing. Undefined fields are left untouched; the caller passes the
+ * same partial it applies to design_image so the two stay in lockstep. Update
+ * only — never inserts — so editing an unpublished image (no listing row)
+ * is a natural no-op.
+ */
+export type ListingUpdate = Partial<{
+  title: string | null;
+  description: string | null;
+  backgroundColor: string | null;
+  isHidden: boolean;
+  feedRank: number | null;
+}>;
+
+export type ListingSyncOp =
+  | {
+      kind: "publish";
+      publishedAt: Date;
+      isHidden: boolean;
+      title: string | null;
+      description: string | null;
+      backgroundColor: string | null;
+      feedRank: number | null;
+    }
+  | { kind: "unpublish" }
+  | { kind: "update"; set: ListingUpdate };
+
+/**
+ * The single choke point every publish-family action routes through (risky
+ * spot §3): given the operation, return the one `listing` statement to splice
+ * into the same `db.batch` as the `design_image` publish-column write, so the
+ * two shapes stay in lockstep.
+ *
+ *  - publish  → insert the listing (publishImage no-ops if already published).
+ *  - unpublish→ delete it.
+ *  - update   → partial update; no-op when the image has no listing (editing an
+ *               unpublished image), so it never conjures a phantom listing.
+ */
+export function listingSyncStatement(
+  db: typeof appDb,
+  imageId: string,
+  op: ListingSyncOp
+) {
+  if (op.kind === "publish") {
+    return db.insert(listingTable).values(
+      buildListingRow({
+        imageId,
+        publishedAt: op.publishedAt,
+        isHidden: op.isHidden,
+        title: op.title,
+        description: op.description,
+        backgroundColor: op.backgroundColor,
+        feedRank: op.feedRank,
+      })
+    );
+  }
+  if (op.kind === "unpublish") {
+    return db.delete(listingTable).where(eq(listingTable.imageId, imageId));
+  }
+  return db
+    .update(listingTable)
+    .set(op.set)
+    .where(eq(listingTable.imageId, imageId));
+}

--- a/src/lib/reparent-user.ts
+++ b/src/lib/reparent-user.ts
@@ -6,6 +6,7 @@ import {
   cartItem as cartItemTable,
   store as storeTable,
   product as productTable,
+  image as imageTable,
 } from "@/lib/db/schema";
 
 /**
@@ -16,9 +17,11 @@ import {
  * product) for the cleanup to cascade away. Atomic now: all moved or none.
  *
  * design_image + chat_message follow via design_id; everything else owns a
- * user/owner column directly. When the conversation/image migration adds
- * tables, extend this list — the integration test seeds one row per table as
- * the checklist.
+ * user/owner column directly. The Model B `image` table denormalizes owner_id,
+ * so it re-parents directly here (placement_render / conversation_image follow
+ * via design_id, listing via its image). When later migration slices add
+ * user-owned tables, extend this list — the integration test seeds one row per
+ * table as the checklist.
  */
 export async function reparentUserData(
   db: typeof appDb,
@@ -32,5 +35,6 @@ export async function reparentUserData(
     db.update(cartItemTable).set({ userId: toId }).where(eq(cartItemTable.userId, fromId)),
     db.update(storeTable).set({ ownerId: toId }).where(eq(storeTable.ownerId, fromId)),
     db.update(productTable).set({ ownerId: toId }).where(eq(productTable.ownerId, fromId)),
+    db.update(imageTable).set({ ownerId: toId }).where(eq(imageTable.ownerId, fromId)),
   ]);
 }


### PR DESCRIPTION
Slice 1 of `docs/model-b-migration-plan.md`. **Additive only** — no readers moved, no columns/tables dropped. Reverting the code leaves the new tables inert.

## Schema — migration `0005` (additive CREATE TABLE only)
- `image` — standalone artifact (owner_id FK → user; image-id refs are opaque text, no FK, matching decision §2 and the existing schema)
- `conversation_image` — design↔image join, `role` output|seed, unique (design_id, image_id, role)
- `listing` — published-listing state split off `design_image` (item 3)
- `placement_render` — placement-render cache split off `design_image` (item 3)

## Dual-write (each inside the existing `db.batch`, id reused §2/§5)
- **Source generations** land `image` + `conversation_image(output)`. There are two source-gen write sites, not one: the inline batch in `generateDesign` **and** `insertDesignImage` (uploads); both go through the shared row builders in `src/lib/model-b-writes.ts`.
- **Placement renders** (`insertDesignImage` with `product_id`) land `placement_render`.
- **Publish family** — `publishImage` / `unpublishImage` / `updatePublishedNaming` / `setImageHidden` / `setImageFeedRank` all route through one shared `listingSyncStatement` helper so `design_image` publish cols and `listing` stay in lockstep (risky spot §3).
- `deleteDesign` and `deleteDesignImageRow` delete the new rows in the same batch.
- `reparent-user.ts` adds `image.owner_id` to the claim batch.

## Backfill — `scripts/backfill-model-b.ts`
Idempotent, chunked bulk inserts (`ON CONFLICT DO NOTHING`, never `db.transaction`). Splits `design_image` on `product_id`, mirrors publish state into `listing`, moves fork provenance (`seed_image_id` / `original_designer_id` / seed links) onto the image graph, reuses ids verbatim.

## Immutability guardrail (§3)
All image writes live in `model-b-writes.ts`, which exposes INSERT builders only — no helper updates `image_url` / `r2_key` / `prompt`. `model-b-writes.test.ts` locks this in.

## Verification
- Full suite **716 passed**; `npm run lint` 0 errors; `npx tsc --noEmit` clean.
- `npm run build`: TypeScript step passes; page-data collection needs real secrets (this worktree has none) — confirmed green once dummy env vars are supplied.
- Reviewed `drizzle/0005_sticky_tag.sql` — four CREATE TABLE + one unique index, no ALTER/DROP.

## Deviation from the plan doc
The doc's `image` schema shows FK arrows on image-id columns. Implemented image-id references (`parent/seed/original-designer/source-design`, `conversation_image.image_id`, `listing.image_id`, `placement_render.source_image_id`) as **opaque text without FK**, matching decision §2 ("stored as opaque strings, no FK") and the existing schema (`design.forkedFromImageId`, `design_image.parentImageId` are FK-less). Only `owner_id → user` and the `design_id → design` links are FKs. This avoids batch-ordering / publish-before-backfill FK hazards while keeping reparent + owner joins sound.

## Manual follow-ups (per the doc's Ship checklist — out of scope here)
- preview auto-migrate (CI) → prod backup → prod `db:migrate` → run backfill against prod → smoke.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FYw9FZQzyH1wkvnXzKMgL3