### PR TITLE
feat: Model B slice 2 — read-path swap

### DIFF
--- a/docs/model-b-migration-plan.md
+++ b/docs/model-b-migration-plan.md
@@ -244,6 +244,28 @@ sites don't churn:
 - Revert: readers flip back; dual-write kept both shapes current, so
   reverting loses nothing.
 
+**Slice 2 status (built 2026-07-25).** Done as scoped. Two things the plan
+didn't anticipate:
+
+- The backfill has to carry `created_at` onto `image` / `placement_render`.
+  The slice-2 readers order the thread gallery, the latest-artifact fallback
+  and the render cache by it, and without the carry every backfilled row would
+  share the backfill run's timestamp. `buildImageRow` /
+  `buildPlacementRenderRow` take an optional `createdAt` (backfill only; live
+  writes still default to now). **Consequence: the prod backfill must be run
+  from this slice's code, not slice 1's** — the inserts are
+  `onConflictDoNothing`, so re-running after the fix would not correct rows
+  already written with a run timestamp.
+- `created_at` is second-resolution, so two rows written in the same second
+  tie. The ordering reads add `rowid` as the tiebreaker, which is the insert
+  order the old `design_image` scans got implicitly.
+
+Publish-family actions (`publishImage` / `unpublishImage` /
+`updatePublishedNaming` / `setImageHidden` / `setImageFeedRank`) deliberately
+keep reading `design_image`: an unpublished image has no listing row, so the
+`is_hidden` / `feed_rank` a new listing must snapshot live nowhere else until
+the slice-4 writer cutover.
+
 ### Slice 3 — lifecycle + fresh-start
 
 - `design.closed_at` (migration `0006`, additive).

--- a/e2e/helpers/db.ts
+++ b/e2e/helpers/db.ts
@@ -50,7 +50,15 @@ export async function userIdForSessionCookie(
 
 const PLACEHOLDER_IMAGE = "https://placehold.co/1024x1024/png";
 
-/** Seed a draft design (with a primary image) owned by `userId`. */
+/**
+ * Seed a draft design (with a primary image) owned by `userId`.
+ *
+ * Writes BOTH shapes, exactly like production's dual-write
+ * (src/lib/model-b-writes.ts): design_image for the legacy writers, and
+ * image + conversation_image(role=output) with the same id for the Model B
+ * readers the app is on since slice 2. Seeding only design_image would leave
+ * every spec looking at a design with no images.
+ */
 export async function seedDesign(userId: string, key: string): Promise<string> {
   const designId = `e2e-${key}`;
   const imageId = `e2e-${key}-img`;
@@ -67,6 +75,18 @@ export async function seedDesign(userId: string, key: string): Promise<string> {
           ON CONFLICT(id) DO UPDATE SET image_url = excluded.image_url`,
     args: [imageId, designId, PLACEHOLDER_IMAGE],
   });
+  await c.execute({
+    sql: `INSERT INTO image (id, owner_id, r2_key, image_url, aspect_ratio, generation_cost, source_design_id, created_at)
+          VALUES (?, ?, NULL, ?, '1:1', 0, ?, unixepoch())
+          ON CONFLICT(id) DO UPDATE SET owner_id = excluded.owner_id, image_url = excluded.image_url, source_design_id = excluded.source_design_id`,
+    args: [imageId, userId, PLACEHOLDER_IMAGE, designId],
+  });
+  await c.execute({
+    sql: `INSERT INTO conversation_image (id, design_id, image_id, role, created_at)
+          VALUES (?, ?, ?, 'output', unixepoch())
+          ON CONFLICT(design_id, image_id, role) DO NOTHING`,
+    args: [`${imageId}-link`, designId, imageId],
+  });
   return designId;
 }
 
@@ -77,6 +97,25 @@ export async function cleanupDesigns(designIds: string[]): Promise<void> {
   const placeholders = designIds.map(() => "?").join(",");
   await c.execute({
     sql: `DELETE FROM cart_item WHERE design_id IN (${placeholders})`,
+    args: designIds,
+  });
+  // Model B rows: images key off the design's design_image ids, links and
+  // renders off design_id, listings off the image ids.
+  await c.execute({
+    sql: `DELETE FROM listing WHERE image_id IN (SELECT id FROM design_image WHERE design_id IN (${placeholders}))`,
+    args: designIds,
+  });
+  await c.execute({
+    sql: `DELETE FROM image WHERE id IN (SELECT id FROM design_image WHERE design_id IN (${placeholders}))
+          OR source_design_id IN (${placeholders})`,
+    args: [...designIds, ...designIds],
+  });
+  await c.execute({
+    sql: `DELETE FROM conversation_image WHERE design_id IN (${placeholders})`,
+    args: designIds,
+  });
+  await c.execute({
+    sql: `DELETE FROM placement_render WHERE design_id IN (${placeholders})`,
     args: designIds,
   });
   await c.execute({

--- a/scripts/backfill-model-b.ts
+++ b/scripts/backfill-model-b.ts
@@ -11,6 +11,10 @@
  * role=seed link, and its images carry seed_image_id / original_designer_id
  * from the design (provenance moves onto the image graph, item 4).
  *
+ * Timestamps carry across (createdAt), because the slice-2 readers order the
+ * thread gallery and the render cache by them — without it every backfilled
+ * row would share the run's timestamp.
+ *
  * Idempotent: every insert is ON CONFLICT DO NOTHING (PKs + the
  * conversation_image unique index), so re-runs are safe and chunked in bulk
  * statements (never db.transaction — libSQL serverless HTTP).
@@ -89,6 +93,7 @@ export async function backfillModelB(
           parentImageId: r.parentImageId,
           seedImageId: design.forkedFromImageId,
           originalDesignerId: design.originalDesignerId,
+          createdAt: r.createdAt,
         })
       );
       outputLinks.push(buildOutputLinkRow(r.designId, r.id));
@@ -103,6 +108,7 @@ export async function backfillModelB(
           imageUrl: r.imageUrl,
           aspectRatio: r.aspectRatio,
           generationCost: r.generationCost,
+          createdAt: r.createdAt,
         })
       );
     }

--- a/src/app/admin/actions.ts
+++ b/src/app/admin/actions.ts
@@ -8,11 +8,13 @@ import {
   orderItem as orderItemTable,
   design as designTable,
   designImage as designImageTable,
+  image as imageTable,
+  listing as listingTable,
   user as userTable,
   ledgerEntry,
 } from "@/lib/db/schema";
 import { listingSyncStatement } from "@/lib/model-b-writes";
-import { eq, desc, asc, isNotNull, sum, count, sql } from "drizzle-orm";
+import { eq, desc, asc, sum, count, sql } from "drizzle-orm";
 import { alias } from "drizzle-orm/sqlite-core";
 import { revalidatePath } from "next/cache";
 import { createOrder, getOrderByExternalId } from "@/lib/printful";
@@ -383,25 +385,26 @@ export async function getRecentPublishedForAdmin(
 
   // Same order as the Shop feed (ranked first, then newest) so the admin
   // grid mirrors what customers see.
+  // Published = has a listing row (Model B); hidden ones stay in the grid so
+  // the admin can unhide them.
   const rows = await db
     .select({
-      imageId: designImageTable.id,
-      imageUrl: designImageTable.imageUrl,
-      title: designImageTable.title,
-      publishedAt: designImageTable.publishedAt,
-      isHidden: designImageTable.isHidden,
-      feedRank: designImageTable.feedRank,
+      imageId: imageTable.id,
+      imageUrl: imageTable.imageUrl,
+      title: listingTable.title,
+      publishedAt: listingTable.publishedAt,
+      isHidden: listingTable.isHidden,
+      feedRank: listingTable.feedRank,
       designerName: userTable.name,
       designerEmail: userTable.email,
     })
-    .from(designImageTable)
-    .innerJoin(designTable, eq(designTable.id, designImageTable.designId))
-    .innerJoin(userTable, eq(userTable.id, designTable.userId))
-    .where(isNotNull(designImageTable.publishedAt))
+    .from(listingTable)
+    .innerJoin(imageTable, eq(imageTable.id, listingTable.imageId))
+    .innerJoin(userTable, eq(userTable.id, imageTable.ownerId))
     .orderBy(
-      sql`${designImageTable.feedRank} is null`,
-      asc(designImageTable.feedRank),
-      desc(designImageTable.publishedAt)
+      sql`${listingTable.feedRank} is null`,
+      asc(listingTable.feedRank),
+      desc(listingTable.publishedAt)
     )
     .limit(limit);
 
@@ -411,7 +414,7 @@ export async function getRecentPublishedForAdmin(
     title: r.title,
     designerName: r.designerName,
     designerEmail: r.designerEmail,
-    publishedAt: r.publishedAt!,
+    publishedAt: r.publishedAt,
     isHidden: r.isHidden,
     feedRank: r.feedRank,
   }));

--- a/src/app/api/webhooks/printful/__tests__/route.test.ts
+++ b/src/app/api/webhooks/printful/__tests__/route.test.ts
@@ -11,6 +11,7 @@ import { NextRequest } from "next/server";
 import * as schema from "@/lib/db/schema";
 import { getColorHex } from "@/lib/blanks";
 import { createTestDb } from "@/lib/__tests__/test-db";
+import { makeSourceImage } from "@/lib/__tests__/factories";
 
 const state = vi.hoisted(() => ({
   db: null as unknown,
@@ -151,17 +152,14 @@ describe("Printful webhook route — package_shipped", () => {
 
   it("falls back to the design artwork on a shirt-color backdrop when no mockup is cached", async () => {
     const { design } = await seed();
-    const [image] = await db()
-      .insert(schema.designImage)
-      .values({
-        designId: design.id,
-        aspectRatio: "1:1",
-        imageUrl: "https://img.example/artwork.png",
-      })
-      .returning();
+    const imageId = await makeSourceImage(db(), {
+      designId: design.id,
+      ownerId: design.userId,
+      imageUrl: "https://img.example/artwork.png",
+    });
     await db()
       .update(schema.design)
-      .set({ primaryImageId: image.id })
+      .set({ primaryImageId: imageId })
       .where(eq(schema.design.id, design.id));
 
     const res = await POST(

--- a/src/app/d/__tests__/buy-published-design.integration.test.ts
+++ b/src/app/d/__tests__/buy-published-design.integration.test.ts
@@ -12,7 +12,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { eq as schemaEq } from "drizzle-orm";
 import { createTestDb } from "@/lib/__tests__/test-db";
 import * as schema from "@/lib/db/schema";
-import { makeUser } from "@/lib/__tests__/factories";
+import { makeUser, makeSourceImage } from "@/lib/__tests__/factories";
 
 const h = vi.hoisted(() => ({
   db: null as unknown,
@@ -60,48 +60,39 @@ async function seed(db: Db) {
     .insert(schema.design)
     .values({ userId: "seller" })
     .returning();
-  const [listing] = await db
-    .insert(schema.designImage)
-    .values({
-      designId: sold.id,
-      aspectRatio: "1:1",
-      imageUrl: "https://img.example/listing.png",
-      publishedAt: new Date(),
-    })
-    .returning();
-  const [sellerPrivate] = await db
-    .insert(schema.designImage)
-    .values({
-      designId: sold.id,
-      aspectRatio: "1:1",
-      imageUrl: "https://img.example/seller-private.png",
-    })
-    .returning();
+  const listingId = await makeSourceImage(db, {
+    designId: sold.id,
+    ownerId: "seller",
+    imageUrl: "https://img.example/listing.png",
+    publishedAt: new Date(),
+  });
+  const sellerPrivateId = await makeSourceImage(db, {
+    designId: sold.id,
+    ownerId: "seller",
+    imageUrl: "https://img.example/seller-private.png",
+  });
 
   // The buyer's own design → a legitimate back source.
   const [mine] = await db
     .insert(schema.design)
     .values({ userId: "buyer" })
     .returning();
-  const [myBack] = await db
-    .insert(schema.designImage)
-    .values({
-      designId: mine.id,
-      aspectRatio: "1:1",
-      imageUrl: "https://img.example/my-back.png",
-    })
-    .returning();
+  const myBackId = await makeSourceImage(db, {
+    designId: mine.id,
+    ownerId: "buyer",
+    imageUrl: "https://img.example/my-back.png",
+  });
   // My Designs lists primaries only.
   await db
     .update(schema.design)
-    .set({ primaryImageId: myBack.id })
+    .set({ primaryImageId: myBackId })
     .where(schemaEq(schema.design.id, mine.id));
 
   return {
     soldDesignId: sold.id,
-    listingId: listing.id,
-    sellerPrivateId: sellerPrivate.id,
-    myBackId: myBack.id,
+    listingId,
+    sellerPrivateId,
+    myBackId,
   };
 }
 
@@ -253,5 +244,76 @@ describe("getBuyPageBackSources gating", () => {
     expect(groupIds).not.toContain("this-design");
     expect(groupIds).toContain("my-designs");
     expect(groupIds).toContain("shop");
+  });
+});
+
+/**
+ * The /d page read swap (Model B slice 2): the listing carries the public
+ * copy, and the attribution chain walks image.seed_image_id instead of
+ * design.forked_from_image_id.
+ */
+describe("getPublishedImage (Model B reads)", () => {
+  it("serves the listing's copy and the designer", async () => {
+    const db = h.db as Db;
+    const ids = await seed(db);
+    await db
+      .update(schema.listing)
+      .set({ title: "Fox", description: "A fox", backgroundColor: "Black" })
+      .where(schemaEq(schema.listing.imageId, ids.listingId));
+
+    const { getPublishedImage } = await import("@/app/d/actions");
+    const img = await getPublishedImage(ids.listingId);
+    expect(img?.imageUrl).toBe("https://img.example/listing.png");
+    expect(img?.title).toBe("Fox");
+    expect(img?.backgroundColor).toBe("Black");
+    expect(img?.designerName).toBe("seller");
+    expect(img?.forkChain).toEqual([]);
+  });
+
+  it("404s an unpublished image and a hidden one", async () => {
+    const db = h.db as Db;
+    const ids = await seed(db);
+    const { getPublishedImage } = await import("@/app/d/actions");
+
+    expect(await getPublishedImage(ids.sellerPrivateId)).toBeNull();
+
+    await db
+      .update(schema.listing)
+      .set({ isHidden: true })
+      .where(schemaEq(schema.listing.imageId, ids.listingId));
+    expect(await getPublishedImage(ids.listingId)).toBeNull();
+  });
+
+  it("walks the attribution chain over image.seed_image_id", async () => {
+    const db = h.db as Db;
+    const ids = await seed(db);
+    await db
+      .update(schema.listing)
+      .set({ title: "Seed" })
+      .where(schemaEq(schema.listing.imageId, ids.listingId));
+
+    const [child] = await db
+      .insert(schema.design)
+      .values({ userId: "buyer" })
+      .returning();
+    const childImageId = await makeSourceImage(db, {
+      designId: child.id,
+      ownerId: "buyer",
+      imageUrl: "https://img.example/child.png",
+      seedImageId: ids.listingId,
+      publishedAt: new Date(),
+    });
+
+    const { getPublishedImage } = await import("@/app/d/actions");
+    const img = await getPublishedImage(childImageId);
+    expect(img?.forkChain.map((e) => e.imageId)).toEqual([ids.listingId]);
+    expect(img?.forkChain[0].title).toBe("Seed");
+
+    // Hiding the parent breaks the public chain.
+    await db
+      .update(schema.listing)
+      .set({ isHidden: true })
+      .where(schemaEq(schema.listing.imageId, ids.listingId));
+    expect((await getPublishedImage(childImageId))?.forkChain).toEqual([]);
   });
 });

--- a/src/app/d/actions.ts
+++ b/src/app/d/actions.ts
@@ -4,11 +4,12 @@ import { headers } from "next/headers";
 import { auth, isAnonymousUser } from "@/lib/auth";
 import { db } from "@/lib/db";
 import {
-  design as designTable,
-  designImage as designImageTable,
+  image as imageTable,
+  listing as listingTable,
   user as userTable,
 } from "@/lib/db/schema";
 import { eq } from "drizzle-orm";
+import { getDesignImageWithOwner } from "@/lib/design-images";
 import { computePrice } from "@/lib/pricing";
 import { DEFAULT_BLANK_ID, multiPlacementEnabled } from "@/lib/blanks";
 import { createStripeCheckoutForOrder } from "@/app/order/actions";
@@ -82,19 +83,22 @@ export async function getDiscoverFeed(limit = 60): Promise<PublishedImage[]> {
  * and user so we can render the chain without further round-trips.
  */
 async function fetchForkChainRow(imageId: string): Promise<ForkChainRow | null> {
+  // Lineage now lives on the image graph (image.seed_image_id), not on the
+  // conversation. Publish state comes from the listing — a left join, so an
+  // unpublished hop still returns a row and buildForkChain stops on it.
   const rows = await db
     .select({
-      imageId: designImageTable.id,
-      title: designImageTable.title,
-      publishedAt: designImageTable.publishedAt,
-      isHidden: designImageTable.isHidden,
+      imageId: imageTable.id,
+      title: listingTable.title,
+      publishedAt: listingTable.publishedAt,
+      isHidden: listingTable.isHidden,
       designerName: userTable.name,
-      forkedFromImageId: designTable.forkedFromImageId,
+      forkedFromImageId: imageTable.seedImageId,
     })
-    .from(designImageTable)
-    .innerJoin(designTable, eq(designTable.id, designImageTable.designId))
-    .innerJoin(userTable, eq(userTable.id, designTable.userId))
-    .where(eq(designImageTable.id, imageId))
+    .from(imageTable)
+    .innerJoin(userTable, eq(userTable.id, imageTable.ownerId))
+    .leftJoin(listingTable, eq(listingTable.imageId, imageTable.id))
+    .where(eq(imageTable.id, imageId))
     .limit(1);
   const r = rows[0];
   if (!r) return null;
@@ -104,7 +108,7 @@ async function fetchForkChainRow(imageId: string): Promise<ForkChainRow | null> 
     designerName: r.designerName,
     forkedFromImageId: r.forkedFromImageId,
     publishedAt: r.publishedAt,
-    isHidden: r.isHidden,
+    isHidden: r.isHidden ?? false,
   };
 }
 
@@ -117,25 +121,25 @@ export async function getPublishedImage(
 ): Promise<PublishedImage | null> {
   const rows = await db
     .select({
-      imageId: designImageTable.id,
-      imageUrl: designImageTable.imageUrl,
-      title: designImageTable.title,
-      description: designImageTable.description,
-      backgroundColor: designImageTable.backgroundColor,
-      publishedAt: designImageTable.publishedAt,
-      isHidden: designImageTable.isHidden,
+      imageId: imageTable.id,
+      imageUrl: imageTable.imageUrl,
+      title: listingTable.title,
+      description: listingTable.description,
+      backgroundColor: listingTable.backgroundColor,
+      publishedAt: listingTable.publishedAt,
+      isHidden: listingTable.isHidden,
       designerName: userTable.name,
       designerId: userTable.id,
-      forkedFromImageId: designTable.forkedFromImageId,
+      forkedFromImageId: imageTable.seedImageId,
     })
-    .from(designImageTable)
-    .innerJoin(designTable, eq(designTable.id, designImageTable.designId))
-    .innerJoin(userTable, eq(userTable.id, designTable.userId))
-    .where(eq(designImageTable.id, imageId))
+    .from(listingTable)
+    .innerJoin(imageTable, eq(imageTable.id, listingTable.imageId))
+    .innerJoin(userTable, eq(userTable.id, imageTable.ownerId))
+    .where(eq(imageTable.id, imageId))
     .limit(1);
 
   const r = rows[0];
-  if (!r || !r.publishedAt || r.isHidden) return null;
+  if (!r || r.isHidden) return null;
 
   // Walk forkedFromImageId upward, stopping at the first invisible
   // parent so admin moderation also breaks the public chain.
@@ -179,10 +183,10 @@ export async function getBuyPageBackSources(
   const session = await auth.api.getSession({ headers: await headers() });
   if (!session || isAnonymousUser(session.user)) return { groups: [] };
 
-  const image = await db.query.designImage.findFirst({
-    where: eq(designImageTable.id, imageId),
-  });
-  if (!image || !canBuyPublishedImage(image)) return { groups: [] };
+  const image = await getDesignImageWithOwner(imageId);
+  if (!image || !image.designId || !canBuyPublishedImage(image)) {
+    return { groups: [] };
+  }
 
   const groups = await getBuyPageBackSourceGroups({
     designId: image.designId,
@@ -222,10 +226,8 @@ export async function buyPublishedDesign(params: {
     return { url: null, needsAuth: true };
   }
 
-  const image = await db.query.designImage.findFirst({
-    where: eq(designImageTable.id, params.imageId),
-  });
-  if (!image) throw new Error("Image not found");
+  const image = await getDesignImageWithOwner(params.imageId);
+  if (!image || !image.designId) throw new Error("Image not found");
 
   if (!canBuyPublishedImage(image)) {
     throw new Error("Image is not available to buy");

--- a/src/app/dashboard/actions.ts
+++ b/src/app/dashboard/actions.ts
@@ -2,7 +2,7 @@
 
 import { headers } from "next/headers";
 import { revalidatePath } from "next/cache";
-import { and, desc, eq, inArray, not } from "drizzle-orm";
+import { and, desc, eq, not } from "drizzle-orm";
 import { auth, isAnonymousUser } from "@/lib/auth";
 import { db } from "@/lib/db";
 import { storesEnabled } from "@/lib/flags";
@@ -12,8 +12,8 @@ import {
   store as storeTable,
   product as productTable,
   design as designTable,
-  designImage as designImageTable,
 } from "@/lib/db/schema";
+import { resolveImagesByIds } from "@/lib/design-images";
 import { getBlank, type AspectRatio } from "@/lib/blanks";
 
 type Store = typeof storeTable.$inferSelect;
@@ -143,15 +143,7 @@ export async function getComposableDesigns(): Promise<ComposableDesign[]> {
     .filter((id): id is string => id !== null);
   if (primaryIds.length === 0) return [];
 
-  const imgs = await db
-    .select({
-      id: designImageTable.id,
-      imageUrl: designImageTable.imageUrl,
-      aspectRatio: designImageTable.aspectRatio,
-    })
-    .from(designImageTable)
-    .where(inArray(designImageTable.id, primaryIds));
-  const byId = new Map(imgs.map((r) => [r.id, r]));
+  const byId = await resolveImagesByIds(primaryIds);
 
   return designs.flatMap((d) => {
     const img = d.primaryImageId ? byId.get(d.primaryImageId) : undefined;
@@ -161,7 +153,7 @@ export async function getComposableDesigns(): Promise<ComposableDesign[]> {
         designId: d.id,
         imageId: img.id,
         imageUrl: img.imageUrl,
-        aspectRatio: img.aspectRatio as AspectRatio,
+        aspectRatio: img.aspectRatio,
       },
     ];
   });
@@ -243,14 +235,7 @@ export async function getProductForEdit(
   const imageId = placedImageId ?? d?.primaryImageId ?? null;
   if (!imageId) return null;
 
-  const [img] = await db
-    .select({
-      id: designImageTable.id,
-      imageUrl: designImageTable.imageUrl,
-      aspectRatio: designImageTable.aspectRatio,
-    })
-    .from(designImageTable)
-    .where(eq(designImageTable.id, imageId));
+  const img = (await resolveImagesByIds([imageId])).get(imageId);
   if (!img) return null;
 
   return {
@@ -264,7 +249,7 @@ export async function getProductForEdit(
       designId: product.designId,
       imageId: img.id,
       imageUrl: img.imageUrl,
-      aspectRatio: img.aspectRatio as AspectRatio,
+      aspectRatio: img.aspectRatio,
     },
   };
 }

--- a/src/app/design/__tests__/generation-races.integration.test.ts
+++ b/src/app/design/__tests__/generation-races.integration.test.ts
@@ -11,6 +11,7 @@
  */
 import { describe, it, expect, beforeEach, afterEach, vi, type Mock } from "vitest";
 import { createTestDb } from "@/lib/__tests__/test-db";
+import { makeSourceImage } from "@/lib/__tests__/factories";
 import * as schema from "@/lib/db/schema";
 import { eq } from "drizzle-orm";
 
@@ -97,11 +98,11 @@ async function seedDesign(generationCount = 0): Promise<string> {
 }
 
 async function seedSourceImage(designId: string, url: string): Promise<string> {
-  const [row] = await testDb
-    .insert(schema.designImage)
-    .values({ designId, aspectRatio: "1:1", imageUrl: url })
-    .returning();
-  return row.id;
+  return makeSourceImage(testDb, {
+    designId,
+    ownerId: "u1",
+    imageUrl: url,
+  });
 }
 
 async function sourceImages(designId: string) {

--- a/src/app/design/actions.ts
+++ b/src/app/design/actions.ts
@@ -14,6 +14,7 @@ import {
   order as orderTable,
   image as imageTable,
   conversationImage as conversationImageTable,
+  listing as listingTable,
 } from "@/lib/db/schema";
 import { eq, sql } from "drizzle-orm";
 import { buildImageRow, buildOutputLinkRow } from "@/lib/model-b-writes";
@@ -466,12 +467,15 @@ export async function getDesign(designId: string) {
 
   // Primary image's pinned backdrop color (#16) — /preview's color default
   // (§3): the design was published on this color, so show it on it.
+  // Read from the listing — it exists only while the image is published,
+  // which is exactly when the pinned backdrop applies.
   let backgroundColor: string | null = null;
   if (found.primaryImageId) {
-    const primary = await db.query.designImage.findFirst({
-      where: eq(designImageTable.id, found.primaryImageId),
-      columns: { backgroundColor: true },
-    });
+    const [primary] = await db
+      .select({ backgroundColor: listingTable.backgroundColor })
+      .from(listingTable)
+      .where(eq(listingTable.imageId, found.primaryImageId))
+      .limit(1);
     backgroundColor = primary?.backgroundColor ?? null;
   }
 

--- a/src/app/designs/actions.ts
+++ b/src/app/designs/actions.ts
@@ -60,14 +60,16 @@ export async function getUserDesigns() {
   >();
   if (primaryIds.length) {
     try {
+      // Publish state lives in `listing` now — a row exists iff published, so
+      // an unpublished primary is simply absent from the map.
       const primaryRows = await db
         .select({
-          id: designImageTable.id,
-          publishedAt: designImageTable.publishedAt,
-          backgroundColor: designImageTable.backgroundColor,
+          id: listingTable.imageId,
+          publishedAt: listingTable.publishedAt,
+          backgroundColor: listingTable.backgroundColor,
         })
-        .from(designImageTable)
-        .where(inArray(designImageTable.id, primaryIds));
+        .from(listingTable)
+        .where(inArray(listingTable.imageId, primaryIds));
       primaryById = new Map(
         primaryRows.map((r) => [
           r.id,
@@ -205,6 +207,9 @@ export async function publishImage(
   const session = await auth.api.getSession({ headers: await headers() });
   if (!session) throw new Error("Unauthorized");
 
+  // The publish-family actions still read design_image: an unpublished image
+  // has no listing row, so its is_hidden / feed_rank (which the new listing
+  // must snapshot) live nowhere else until the slice-4 writer cutover.
   const image = await db.query.designImage.findFirst({
     where: eq(designImageTable.id, imageId),
   });

--- a/src/app/orders/__tests__/get-user-orders.integration.test.ts
+++ b/src/app/orders/__tests__/get-user-orders.integration.test.ts
@@ -9,6 +9,7 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 import { eq } from "drizzle-orm";
 import { createTestDb } from "@/lib/__tests__/test-db";
 import * as schema from "@/lib/db/schema";
+import { makeSourceImage } from "@/lib/__tests__/factories";
 
 const h = vi.hoisted(() => ({
   db: null as unknown,
@@ -42,15 +43,16 @@ async function seedDesignWithImage(
     .insert(schema.design)
     .values({ userId })
     .returning();
-  const [image] = await db
-    .insert(schema.designImage)
-    .values({ designId: design.id, aspectRatio: "1:1", imageUrl })
-    .returning();
+  const imageId = await makeSourceImage(db, {
+    designId: design.id,
+    ownerId: userId,
+    imageUrl,
+  });
   await db
     .update(schema.design)
-    .set({ primaryImageId: image.id })
+    .set({ primaryImageId: imageId })
     .where(eq(schema.design.id, design.id));
-  return { designId: design.id, imageId: image.id };
+  return { designId: design.id, imageId };
 }
 
 beforeEach(async () => {

--- a/src/app/orders/actions.ts
+++ b/src/app/orders/actions.ts
@@ -7,11 +7,13 @@ import {
   order as orderTable,
   orderItem as orderItemTable,
   design as designTable,
-  designImage as designImageTable,
   user as userTable,
 } from "@/lib/db/schema";
 import { eq, asc, desc, inArray } from "drizzle-orm";
-import { resolveDesignDisplayImageUrls } from "@/lib/design-images";
+import {
+  resolveDesignDisplayImageUrls,
+  resolveImagesByIds,
+} from "@/lib/design-images";
 import { resolveOrderLines } from "@/lib/order-lines";
 import { designerAttribution } from "@/lib/order-attribution";
 
@@ -111,13 +113,10 @@ export async function getUserOrders() {
   // purchase time) over the design's current display image, so historical
   // orders keep showing what was actually printed.
   const fallbackUrls = await resolveDesignDisplayImageUrls(lineDesignIds);
-  const pinnedRows = pinnedImageIds.length
-    ? await db
-        .select({ id: designImageTable.id, imageUrl: designImageTable.imageUrl })
-        .from(designImageTable)
-        .where(inArray(designImageTable.id, pinnedImageIds))
-    : [];
-  const pinnedUrlById = new Map(pinnedRows.map((r) => [r.id, r.imageUrl]));
+  const pinnedById = await resolveImagesByIds(pinnedImageIds);
+  const pinnedUrlById = new Map(
+    [...pinnedById].map(([id, img]) => [id, img.imageUrl])
+  );
 
   const designerRows = lineDesignIds.length
     ? await db

--- a/src/app/shop/actions.ts
+++ b/src/app/shop/actions.ts
@@ -1,16 +1,14 @@
 "use server";
 
 import { headers } from "next/headers";
-import { eq, inArray } from "drizzle-orm";
+import { eq } from "drizzle-orm";
 import { auth, isAnonymousUser } from "@/lib/auth";
 import { db } from "@/lib/db";
 import { storesEnabled } from "@/lib/flags";
 import * as svc from "@/lib/store-service";
 import { canViewStore, canBuyStoreProduct, productIsListed } from "@/lib/stores";
-import {
-  design as designTable,
-  designImage as designImageTable,
-} from "@/lib/db/schema";
+import { design as designTable } from "@/lib/db/schema";
+import { resolveImagesByIds } from "@/lib/design-images";
 import {
   getBlank,
   getColorHex,
@@ -81,13 +79,8 @@ export async function getStorefront(slug: string): Promise<Storefront | null> {
   const imageIds = visible
     .map((p) => (p.placements ? Object.values(p.placements)[0] : undefined))
     .filter((id): id is string => Boolean(id));
-  const imgs = imageIds.length
-    ? await db
-        .select({ id: designImageTable.id, imageUrl: designImageTable.imageUrl })
-        .from(designImageTable)
-        .where(inArray(designImageTable.id, imageIds))
-    : [];
-  const urlById = new Map(imgs.map((r) => [r.id, r.imageUrl]));
+  const imgById = await resolveImagesByIds(imageIds);
+  const urlById = new Map([...imgById].map(([id, img]) => [id, img.imageUrl]));
 
   const products: StorefrontProduct[] = visible.flatMap((p) => {
     const imageId = p.placements ? Object.values(p.placements)[0] : undefined;
@@ -153,13 +146,7 @@ export async function getStoreProductForBuy(
 
   const imageId = await resolveProductImageId(product.placements, product.designId);
   if (!imageId) return null;
-  const [img] = await db
-    .select({
-      imageUrl: designImageTable.imageUrl,
-      aspectRatio: designImageTable.aspectRatio,
-    })
-    .from(designImageTable)
-    .where(eq(designImageTable.id, imageId));
+  const img = (await resolveImagesByIds([imageId])).get(imageId);
   if (!img) return null;
 
   const blank = getBlank(product.blankId);
@@ -171,7 +158,7 @@ export async function getStoreProductForBuy(
     blankId: product.blankId,
     blankName: blank?.name ?? product.blankId,
     imageUrl: img.imageUrl,
-    aspectRatio: img.aspectRatio as AspectRatio,
+    aspectRatio: img.aspectRatio,
     sizes: blank?.sizes ?? [],
     colors: blank?.colors ?? [],
     fixedPrice: product.price,
@@ -205,12 +192,9 @@ export async function buyStoreProduct(params: {
   }
 
   const imageId = await resolveProductImageId(product.placements, product.designId);
-  const [img] = imageId
-    ? await db
-        .select({ imageUrl: designImageTable.imageUrl })
-        .from(designImageTable)
-        .where(eq(designImageTable.id, imageId))
-    : [];
+  const img = imageId
+    ? (await resolveImagesByIds([imageId])).get(imageId)
+    : undefined;
 
   return createStripeCheckoutForOrder({
     userId: session.user.id,

--- a/src/lib/__tests__/back-sources.integration.test.ts
+++ b/src/lib/__tests__/back-sources.integration.test.ts
@@ -8,7 +8,7 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 import { eq } from "drizzle-orm";
 import { createTestDb } from "./test-db";
 import * as schema from "@/lib/db/schema";
-import { makeUser } from "./factories";
+import { makeUser, makeSourceImage } from "./factories";
 
 type Db = Awaited<ReturnType<typeof createTestDb>>;
 let testDb: Db;
@@ -37,17 +37,14 @@ async function makeDesignWithImage(
     .insert(schema.design)
     .values({ userId })
     .returning();
-  const [image] = await db
-    .insert(schema.designImage)
-    .values({
-      designId: design.id,
-      aspectRatio: "1:1",
-      imageUrl: `https://img.example/${design.id}.png`,
-      publishedAt: opts.published ? new Date() : null,
-      isHidden: opts.hidden ?? false,
-    })
-    .returning();
-  return { designId: design.id, imageId: image.id };
+  const imageId = await makeSourceImage(db, {
+    designId: design.id,
+    ownerId: userId,
+    imageUrl: `https://img.example/${design.id}.png`,
+    publishedAt: opts.published ? new Date() : null,
+    isHidden: opts.hidden ?? false,
+  });
+  return { designId: design.id, imageId };
 }
 
 describe("getBackSourceGroups / assertUsableBackImage (#72)", () => {
@@ -64,40 +61,31 @@ describe("getBackSourceGroups / assertUsableBackImage (#72)", () => {
       .insert(schema.design)
       .values({ userId: "nico" })
       .returning();
-    const [s1] = await testDb
-      .insert(schema.designImage)
-      .values({
-        designId: d1.id,
-        aspectRatio: "1:1",
-        imageUrl: "https://img.example/s1.png",
-      })
-      .returning();
-    const [s2] = await testDb
-      .insert(schema.designImage)
-      .values({
-        designId: d1.id,
-        aspectRatio: "1:1",
-        imageUrl: "https://img.example/s2.png",
-        publishedAt: new Date(),
-      })
-      .returning();
+    const s1 = await makeSourceImage(testDb, {
+      designId: d1.id,
+      ownerId: "nico",
+      imageUrl: "https://img.example/s1.png",
+    });
+    const s2 = await makeSourceImage(testDb, {
+      designId: d1.id,
+      ownerId: "nico",
+      imageUrl: "https://img.example/s2.png",
+      publishedAt: new Date(),
+    });
 
     // Another design of nico's, with a primary → My Designs.
     const [d2] = await testDb
       .insert(schema.design)
       .values({ userId: "nico" })
       .returning();
-    const [p2] = await testDb
-      .insert(schema.designImage)
-      .values({
-        designId: d2.id,
-        aspectRatio: "1:1",
-        imageUrl: "https://img.example/p2.png",
-      })
-      .returning();
+    const p2 = await makeSourceImage(testDb, {
+      designId: d2.id,
+      ownerId: "nico",
+      imageUrl: "https://img.example/p2.png",
+    });
     await testDb
       .update(schema.design)
-      .set({ primaryImageId: p2.id })
+      .set({ primaryImageId: p2 })
       .where(eq(schema.design.id, d2.id));
 
     // Nico design with no primary → excluded from My Designs.
@@ -113,7 +101,7 @@ describe("getBackSourceGroups / assertUsableBackImage (#72)", () => {
     });
     const priv = await makeDesignWithImage(testDb, "stranger", {});
 
-    return { d1: d1.id, s1: s1.id, s2: s2.id, d2: d2.id, p2: p2.id, pub, hidden, priv };
+    return { d1: d1.id, s1, s2, d2: d2.id, p2, pub, hidden, priv };
   }
 
   it("returns the three groups, scoped and filtered", async () => {
@@ -239,47 +227,38 @@ describe("getBuyPageBackSourceGroups (/d back picker)", () => {
       .insert(schema.design)
       .values({ userId: "seller" })
       .returning();
-    const [privImg] = await testDb
-      .insert(schema.designImage)
-      .values({
-        designId: sold.id,
-        aspectRatio: "1:1",
-        imageUrl: "https://img.example/priv.png",
-      })
-      .returning();
-    const [pubImg] = await testDb
-      .insert(schema.designImage)
-      .values({
-        designId: sold.id,
-        aspectRatio: "1:1",
-        imageUrl: "https://img.example/pub.png",
-        publishedAt: new Date(),
-      })
-      .returning();
+    const privImgId = await makeSourceImage(testDb, {
+      designId: sold.id,
+      ownerId: "seller",
+      imageUrl: "https://img.example/priv.png",
+    });
+    const pubImgId = await makeSourceImage(testDb, {
+      designId: sold.id,
+      ownerId: "seller",
+      imageUrl: "https://img.example/pub.png",
+      publishedAt: new Date(),
+    });
 
     // Buyer's own design with a primary → My Designs.
     const [mine] = await testDb
       .insert(schema.design)
       .values({ userId: "buyer" })
       .returning();
-    const [mineImg] = await testDb
-      .insert(schema.designImage)
-      .values({
-        designId: mine.id,
-        aspectRatio: "1:1",
-        imageUrl: "https://img.example/mine.png",
-      })
-      .returning();
+    const mineImgId = await makeSourceImage(testDb, {
+      designId: mine.id,
+      ownerId: "buyer",
+      imageUrl: "https://img.example/mine.png",
+    });
     await testDb
       .update(schema.design)
-      .set({ primaryImageId: mineImg.id })
+      .set({ primaryImageId: mineImgId })
       .where(eq(schema.design.id, mine.id));
 
     return {
       soldDesignId: sold.id,
-      privImgId: privImg.id,
-      pubImgId: pubImg.id,
-      mineImgId: mineImg.id,
+      privImgId,
+      pubImgId,
+      mineImgId,
     };
   }
 

--- a/src/lib/__tests__/design-publish.test.ts
+++ b/src/lib/__tests__/design-publish.test.ts
@@ -237,13 +237,13 @@ describe("dedupeFeedByDesign", () => {
 });
 
 describe("canUseAsPlacementSource (#72)", () => {
-  const base = { designId: "d-other", publishedAt: null, isHidden: false };
+  const base = { publishedAt: null, isHidden: false };
   const ctx = { imageOwnerId: "owner", orderDesignId: "d-order", userId: "buyer" };
 
   it("allows an unpublished image from the order's design when the user owns it (This design on /preview)", () => {
     expect(
       canUseAsPlacementSource({
-        image: { ...base, designId: "d-order" },
+        image: base,
         ...ctx,
         imageOwnerId: "buyer",
       })
@@ -255,7 +255,7 @@ describe("canUseAsPlacementSource (#72)", () => {
     // forged id from that thread must not print the seller's private work.
     expect(
       canUseAsPlacementSource({
-        image: { ...base, designId: "d-order" },
+        image: base,
         ...ctx,
       })
     ).toBe(false);

--- a/src/lib/__tests__/discover-feed.integration.test.ts
+++ b/src/lib/__tests__/discover-feed.integration.test.ts
@@ -6,8 +6,7 @@
  */
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { createTestDb } from "./test-db";
-import * as schema from "@/lib/db/schema";
-import { makeUser, makeDesign } from "./factories";
+import { makeUser, makeDesign, makeSourceImage } from "./factories";
 import { orderFeedByRank, compareFeedOrder } from "@/lib/discover-feed";
 
 type Db = Awaited<ReturnType<typeof createTestDb>>;
@@ -100,19 +99,16 @@ describe("getPublishedFeed (real DB)", () => {
     }
   ) {
     const designId = opts.designId ?? (await makeDesign(testDb, userId)).id;
-    const [img] = await testDb
-      .insert(schema.designImage)
-      .values({
-        designId,
-        aspectRatio: "1:1",
-        imageUrl: `https://img.example/${crypto.randomUUID()}.png`,
-        publishedAt:
-          opts.published === false ? null : at(opts.publishedMinutesAgo),
-        isHidden: opts.hidden ?? false,
-        feedRank: opts.feedRank ?? null,
-      })
-      .returning();
-    return { designId, imageId: img.id };
+    const imageId = await makeSourceImage(testDb, {
+      designId,
+      ownerId: userId,
+      imageUrl: `https://img.example/${crypto.randomUUID()}.png`,
+      publishedAt:
+        opts.published === false ? null : at(opts.publishedMinutesAgo),
+      isHidden: opts.hidden ?? false,
+      feedRank: opts.feedRank ?? null,
+    });
+    return { designId, imageId };
   }
 
   it("serves ranked designs first, then the rest newest first", async () => {

--- a/src/lib/__tests__/factories.ts
+++ b/src/lib/__tests__/factories.ts
@@ -19,3 +19,86 @@ export async function makeDesign(db: Db, userId: string) {
   const [d] = await db.insert(schema.design).values({ userId }).returning();
   return d;
 }
+
+/**
+ * Seed a source image the way production writes one: `design_image` plus the
+ * Model B mirrors (`image` + `conversation_image(role=output)`, and a
+ * `listing` when published) under one shared id.
+ *
+ * Tests that insert design_image alone are invisible to the slice-2 readers,
+ * so anything exercising a read path seeds through here. `ownerId` must be
+ * the design's owner — image.ownerId is the denormalized copy the guards read.
+ */
+export async function makeSourceImage(
+  db: Db,
+  params: {
+    designId: string;
+    ownerId: string;
+    imageUrl: string;
+    aspectRatio?: string;
+    prompt?: string | null;
+    generationCost?: number;
+    parentImageId?: string | null;
+    seedImageId?: string | null;
+    originalDesignerId?: string | null;
+    createdAt?: Date;
+    publishedAt?: Date | null;
+    isHidden?: boolean;
+    title?: string | null;
+    description?: string | null;
+    backgroundColor?: string | null;
+    feedRank?: number | null;
+  }
+): Promise<string> {
+  const aspectRatio = params.aspectRatio ?? "1:1";
+  const [row] = await db
+    .insert(schema.designImage)
+    .values({
+      designId: params.designId,
+      aspectRatio,
+      imageUrl: params.imageUrl,
+      prompt: params.prompt ?? null,
+      generationCost: params.generationCost ?? 0,
+      parentImageId: params.parentImageId ?? null,
+      publishedAt: params.publishedAt ?? null,
+      isHidden: params.isHidden ?? false,
+      title: params.title ?? null,
+      description: params.description ?? null,
+      backgroundColor: params.backgroundColor ?? null,
+      feedRank: params.feedRank ?? null,
+      ...(params.createdAt ? { createdAt: params.createdAt } : {}),
+    })
+    .returning();
+
+  await db.insert(schema.image).values({
+    id: row.id,
+    ownerId: params.ownerId,
+    imageUrl: params.imageUrl,
+    aspectRatio,
+    prompt: params.prompt ?? null,
+    generationCost: params.generationCost ?? 0,
+    parentImageId: params.parentImageId ?? null,
+    seedImageId: params.seedImageId ?? null,
+    originalDesignerId: params.originalDesignerId ?? null,
+    sourceDesignId: params.designId,
+    ...(params.createdAt ? { createdAt: params.createdAt } : {}),
+  });
+  await db.insert(schema.conversationImage).values({
+    designId: params.designId,
+    imageId: row.id,
+    role: "output",
+  });
+
+  if (params.publishedAt) {
+    await db.insert(schema.listing).values({
+      imageId: row.id,
+      publishedAt: params.publishedAt,
+      isHidden: params.isHidden ?? false,
+      title: params.title ?? null,
+      description: params.description ?? null,
+      backgroundColor: params.backgroundColor ?? null,
+      feedRank: params.feedRank ?? null,
+    });
+  }
+  return row.id;
+}

--- a/src/lib/__tests__/image-readers.integration.test.ts
+++ b/src/lib/__tests__/image-readers.integration.test.ts
@@ -1,0 +1,369 @@
+/**
+ * Model B slice-2 read swap (docs/model-b-migration-plan.md). Every reader in
+ * design-images / back-sources / discover-feed now resolves against `image`,
+ * `conversation_image`, `listing` and `placement_render`. This file drives them
+ * against a real in-memory libSQL in both shapes that exist in production:
+ *
+ *  - dual-written: rows the live write paths landed (insertDesignImage).
+ *  - legacy/backfilled: rows that only ever existed as design_image, promoted
+ *    by scripts/backfill-model-b.ts.
+ *
+ * Both must read identically — that equivalence is the whole safety argument
+ * for the swap. Also locks the id-reuse contract (§2/§5): a pinned placement id
+ * resolves whether it was minted as an artifact or as a placement render.
+ */
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { eq } from "drizzle-orm";
+import { createTestDb } from "./test-db";
+import * as schema from "@/lib/db/schema";
+import { makeUser } from "./factories";
+import { backfillModelB } from "../../../scripts/backfill-model-b";
+
+type Db = Awaited<ReturnType<typeof createTestDb>>;
+let testDb: Db;
+
+vi.mock("@/lib/db", () => ({
+  get db() {
+    return testDb;
+  },
+}));
+
+const {
+  insertDesignImage,
+  getDesignSourceImages,
+  getDesignImageById,
+  getDesignImageWithOwner,
+  getDesignPlacementRenders,
+  findPlacementRender,
+  findDesignImageByUrl,
+  resolveImagesByIds,
+  resolveOrderImageUrls,
+  resolveDesignDisplayImageUrls,
+} = await import("@/lib/design-images");
+const { getPublishedFeed } = await import("@/lib/discover-feed");
+const { getBackSourceGroups } = await import("@/lib/back-sources");
+
+const at = (minutesAgo: number) =>
+  new Date(Date.UTC(2026, 0, 1, 12, 0) - minutesAgo * 60_000);
+
+beforeEach(async () => {
+  testDb = await createTestDb();
+});
+
+/**
+ * A design whose images exist ONLY as design_image rows — the pre-Model-B
+ * shape every historical row is in until the backfill runs.
+ */
+async function seedLegacyDesign(userId: string) {
+  const [design] = await testDb
+    .insert(schema.design)
+    .values({ userId })
+    .returning();
+
+  const [first] = await testDb
+    .insert(schema.designImage)
+    .values({
+      designId: design.id,
+      aspectRatio: "1:1",
+      imageUrl: "https://cdn/legacy/1.png",
+      prompt: "a fox",
+      createdAt: at(120),
+    })
+    .returning();
+  const [second] = await testDb
+    .insert(schema.designImage)
+    .values({
+      designId: design.id,
+      aspectRatio: "1:1",
+      imageUrl: "https://cdn/legacy/2.png",
+      prompt: "a fox, bolder",
+      parentImageId: first.id,
+      publishedAt: at(60),
+      title: "Fox",
+      description: "A fox",
+      backgroundColor: "Black",
+      createdAt: at(90),
+    })
+    .returning();
+  const [render] = await testDb
+    .insert(schema.designImage)
+    .values({
+      designId: design.id,
+      aspectRatio: "1:2",
+      productId: "bella-canvas-3001",
+      placementId: "back",
+      parentImageId: second.id,
+      imageUrl: "https://cdn/legacy/back.png",
+      createdAt: at(30),
+    })
+    .returning();
+
+  await testDb
+    .update(schema.design)
+    .set({ primaryImageId: second.id })
+    .where(eq(schema.design.id, design.id));
+
+  return {
+    designId: design.id,
+    firstId: first.id,
+    secondId: second.id,
+    renderId: render.id,
+  };
+}
+
+describe("readers on legacy rows promoted by the backfill", () => {
+  async function seed() {
+    await makeUser(testDb, "nico");
+    const ids = await seedLegacyDesign("nico");
+    await backfillModelB(testDb);
+    return ids;
+  }
+
+  it("serves the thread gallery oldest → newest with publish state", async () => {
+    const ids = await seed();
+    const sources = await getDesignSourceImages(ids.designId);
+    // The render is not an artifact — it never appears in the gallery.
+    expect(sources.map((s) => s.id)).toEqual([ids.firstId, ids.secondId]);
+    expect(sources[0].publishedAt).toBeNull();
+    expect(sources[1].publishedAt).toEqual(at(60));
+    expect(sources[1].prompt).toBe("a fox, bolder");
+  });
+
+  it("resolves an id whether it was an artifact or a render (id reuse)", async () => {
+    const ids = await seed();
+
+    const artifact = await getDesignImageById(ids.secondId);
+    expect(artifact?.imageUrl).toBe("https://cdn/legacy/2.png");
+    expect(artifact?.designId).toBe(ids.designId);
+    expect(artifact?.publishedAt).toEqual(at(60));
+
+    const render = await getDesignImageById(ids.renderId);
+    expect(render?.imageUrl).toBe("https://cdn/legacy/back.png");
+    expect(render?.designId).toBe(ids.designId);
+    expect(render?.publishedAt).toBeNull();
+
+    const both = await resolveImagesByIds([ids.secondId, ids.renderId, "nope"]);
+    expect(both.get(ids.secondId)?.imageUrl).toBe("https://cdn/legacy/2.png");
+    expect(both.get(ids.renderId)?.aspectRatio).toBe("1:2");
+    expect(both.has("nope")).toBe(false);
+  });
+
+  it("carries the owner and moderation state onto the guard input", async () => {
+    const ids = await seed();
+    const img = await getDesignImageWithOwner(ids.secondId);
+    expect(img?.ownerId).toBe("nico");
+    expect(img?.isHidden).toBe(false);
+    expect(img?.publishedAt).toEqual(at(60));
+
+    // A render's owner comes from its conversation.
+    const render = await getDesignImageWithOwner(ids.renderId);
+    expect(render?.ownerId).toBe("nico");
+  });
+
+  it("keeps the placement-render cache keyed on design/blank/placement/source", async () => {
+    const ids = await seed();
+    const hit = await findPlacementRender(
+      ids.designId,
+      "bella-canvas-3001",
+      "back",
+      ids.secondId
+    );
+    expect(hit?.id).toBe(ids.renderId);
+    // Anchored on a different source → miss.
+    expect(
+      await findPlacementRender(
+        ids.designId,
+        "bella-canvas-3001",
+        "back",
+        ids.firstId
+      )
+    ).toBeNull();
+
+    const groups = await getDesignPlacementRenders(ids.designId);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].productId).toBe("bella-canvas-3001");
+    expect(groups[0].images.map((i) => i.id)).toEqual([ids.renderId]);
+    expect(groups[0].images[0].placementId).toBe("back");
+  });
+
+  it("pins an order's image by url and resolves it back", async () => {
+    const ids = await seed();
+    const pinned = await findDesignImageByUrl(
+      ids.designId,
+      "https://cdn/legacy/2.png"
+    );
+    expect(pinned).toBe(ids.secondId);
+
+    const urls = await resolveOrderImageUrls(
+      [
+        { id: "o1", designId: ids.designId, placements: { front: pinned! } },
+        { id: "o2", designId: ids.designId, placements: { front: ids.renderId } },
+        { id: "o3", designId: ids.designId, placements: null },
+      ],
+      new Map([[ids.designId, "https://cdn/fallback.png"]])
+    );
+    expect(urls.get("o1")).toBe("https://cdn/legacy/2.png");
+    expect(urls.get("o2")).toBe("https://cdn/legacy/back.png");
+    expect(urls.get("o3")).toBe("https://cdn/fallback.png");
+  });
+
+  it("resolves the display image via primary, then latest artifact", async () => {
+    const ids = await seed();
+    let urls = await resolveDesignDisplayImageUrls([ids.designId]);
+    expect(urls.get(ids.designId)).toBe("https://cdn/legacy/2.png");
+
+    // Drop the primary pointer → newest output artifact wins (which the
+    // backfill's carried-over timestamps make deterministic).
+    await testDb
+      .update(schema.design)
+      .set({ primaryImageId: null })
+      .where(eq(schema.design.id, ids.designId));
+    urls = await resolveDesignDisplayImageUrls([ids.designId]);
+    expect(urls.get(ids.designId)).toBe("https://cdn/legacy/2.png");
+  });
+
+  it("lists the published image in the feed and the Shop back-source group", async () => {
+    const ids = await seed();
+
+    const feed = await getPublishedFeed();
+    expect(feed.map((r) => r.imageId)).toEqual([ids.secondId]);
+    expect(feed[0].title).toBe("Fox");
+    expect(feed[0].backgroundColor).toBe("Black");
+    expect(feed[0].designerName).toBe("nico");
+    expect(feed[0].designerId).toBe("nico");
+
+    // From another user's thread, the same image is the Shop group.
+    await makeUser(testDb, "stranger");
+    const [other] = await testDb
+      .insert(schema.design)
+      .values({ userId: "stranger" })
+      .returning();
+    const groups = await getBackSourceGroups({
+      designId: other.id,
+      userId: "stranger",
+    });
+    expect(
+      groups.find((g) => g.id === "shop")?.images.map((i) => i.id)
+    ).toEqual([ids.secondId]);
+  });
+
+  it("moves fork lineage onto the image graph", async () => {
+    await makeUser(testDb, "nico");
+    const seedIds = await seedLegacyDesign("nico");
+    const [forked] = await testDb
+      .insert(schema.design)
+      .values({
+        userId: "nico",
+        forkedFromImageId: seedIds.secondId,
+        originalDesignerId: "nico",
+      })
+      .returning();
+    await testDb.insert(schema.designImage).values({
+      designId: forked.id,
+      aspectRatio: "1:1",
+      imageUrl: "https://cdn/forked/1.png",
+    });
+    await backfillModelB(testDb);
+
+    const [child] = await testDb
+      .select()
+      .from(schema.image)
+      .where(eq(schema.image.sourceDesignId, forked.id));
+    expect(child.seedImageId).toBe(seedIds.secondId);
+    expect(child.originalDesignerId).toBe("nico");
+
+    const seedLinks = await testDb
+      .select()
+      .from(schema.conversationImage)
+      .where(eq(schema.conversationImage.role, "seed"));
+    expect(seedLinks.map((l) => l.designId)).toEqual([forked.id]);
+  });
+});
+
+describe("readers on dual-written rows", () => {
+  async function seed() {
+    await makeUser(testDb, "nico");
+    const [design] = await testDb
+      .insert(schema.design)
+      .values({ userId: "nico" })
+      .returning();
+
+    const firstId = await insertDesignImage({
+      designId: design.id,
+      imageUrl: "https://cdn/live/1.png",
+      aspectRatio: "1:1",
+      prompt: "a fox",
+      generationCost: 0.03,
+    });
+    const secondId = await insertDesignImage({
+      designId: design.id,
+      imageUrl: "https://cdn/live/2.png",
+      aspectRatio: "1:1",
+      prompt: "a fox, bolder",
+      generationCost: 0.03,
+    });
+    const renderId = await insertDesignImage({
+      designId: design.id,
+      imageUrl: "https://cdn/live/back.png",
+      aspectRatio: "1:2",
+      generationCost: 0.03,
+      productId: "bella-canvas-3001",
+      placementId: "back",
+      parentImageId: secondId,
+    });
+    return { designId: design.id, firstId, secondId, renderId };
+  }
+
+  it("serves the gallery, the render cache, and the id lookups", async () => {
+    const ids = await seed();
+
+    const sources = await getDesignSourceImages(ids.designId);
+    expect(sources.map((s) => s.id)).toEqual([ids.firstId, ids.secondId]);
+
+    // The provenance chain anchors on the previous artifact, not the render.
+    const [second] = await testDb
+      .select()
+      .from(schema.image)
+      .where(eq(schema.image.id, ids.secondId));
+    expect(second.parentImageId).toBe(ids.firstId);
+
+    expect(
+      (await findPlacementRender(
+        ids.designId,
+        "bella-canvas-3001",
+        "back",
+        ids.secondId
+      ))?.id
+    ).toBe(ids.renderId);
+    expect((await getDesignImageById(ids.renderId))?.imageUrl).toBe(
+      "https://cdn/live/back.png"
+    );
+    expect(
+      await findDesignImageByUrl(ids.designId, "https://cdn/live/back.png")
+    ).toBe(ids.renderId);
+  });
+
+  it("an unpublished image reads as unpublished and not hidden", async () => {
+    const ids = await seed();
+    const img = await getDesignImageWithOwner(ids.firstId);
+    expect(img?.publishedAt).toBeNull();
+    expect(img?.isHidden).toBe(false);
+    expect(img?.ownerId).toBe("nico");
+    expect(await getPublishedFeed()).toEqual([]);
+  });
+
+  it("a hidden listing leaves the feed but stays resolvable by id", async () => {
+    const ids = await seed();
+    await testDb.insert(schema.listing).values({
+      imageId: ids.secondId,
+      publishedAt: at(5),
+      isHidden: true,
+      title: "Hidden",
+    });
+
+    expect(await getPublishedFeed()).toEqual([]);
+    const img = await getDesignImageWithOwner(ids.secondId);
+    expect(img?.isHidden).toBe(true);
+    expect(img?.publishedAt).toEqual(at(5));
+  });
+});

--- a/src/lib/__tests__/model-b-backfill.integration.test.ts
+++ b/src/lib/__tests__/model-b-backfill.integration.test.ts
@@ -93,6 +93,49 @@ describe("backfillModelB", () => {
     });
   });
 
+  it("carries created_at across, so the slice-2 ordering reads survive", async () => {
+    await seedUser("u1");
+    const [design] = await db
+      .insert(schema.design)
+      .values({ userId: "u1" })
+      .returning();
+    const older = new Date(Date.UTC(2026, 0, 1, 12, 0));
+    const newer = new Date(Date.UTC(2026, 0, 2, 12, 0));
+    const [a] = await db
+      .insert(schema.designImage)
+      .values({
+        designId: design.id,
+        aspectRatio: "1:1",
+        imageUrl: "https://cdn/a.png",
+        createdAt: older,
+      })
+      .returning();
+    const [b] = await db
+      .insert(schema.designImage)
+      .values({
+        designId: design.id,
+        aspectRatio: "1:2",
+        productId: "bella-canvas-3001",
+        placementId: "back",
+        imageUrl: "https://cdn/b.png",
+        createdAt: newer,
+      })
+      .returning();
+
+    await backfillModelB(db);
+
+    const [img] = await db
+      .select()
+      .from(schema.image)
+      .where(eq(schema.image.id, a.id));
+    expect(img.createdAt).toEqual(older);
+    const [pr] = await db
+      .select()
+      .from(schema.placementRender)
+      .where(eq(schema.placementRender.id, b.id));
+    expect(pr.createdAt).toEqual(newer);
+  });
+
   it("coalesces a null placement to 'default'", async () => {
     await seedUser("u1");
     const [design] = await db.insert(schema.design).values({ userId: "u1" }).returning();

--- a/src/lib/back-sources.ts
+++ b/src/lib/back-sources.ts
@@ -14,12 +14,14 @@
 import { db } from "@/lib/db";
 import {
   design as designTable,
-  designImage as designImageTable,
+  image as imageTable,
+  listing as listingTable,
 } from "@/lib/db/schema";
-import { eq, and, ne, desc, inArray, isNotNull } from "drizzle-orm";
+import { eq, and, ne, desc, isNotNull } from "drizzle-orm";
 import {
   getDesignSourceImages,
   getDesignImageWithOwner,
+  resolveImagesByIds,
 } from "@/lib/design-images";
 import {
   dedupeFeedByDesign,
@@ -182,16 +184,12 @@ async function getOtherDesignPrimaries(
     .filter((v): v is string => Boolean(v));
   if (primaryIds.length === 0) return [];
 
-  const imageRows = await db
-    .select({ id: designImageTable.id, imageUrl: designImageTable.imageUrl })
-    .from(designImageTable)
-    .where(inArray(designImageTable.id, primaryIds));
-  const byId = new Map(imageRows.map((r) => [r.id, r.imageUrl]));
+  const byId = await resolveImagesByIds(primaryIds);
 
   // Preserve the designs' recency order; drop dangling primary pointers.
   const out: BackSourceImage[] = [];
   for (const d of designs) {
-    const url = d.primaryImageId ? byId.get(d.primaryImageId) : undefined;
+    const url = d.primaryImageId ? byId.get(d.primaryImageId)?.imageUrl : undefined;
     if (d.primaryImageId && url) out.push({ id: d.primaryImageId, imageUrl: url });
   }
   return out;
@@ -210,25 +208,30 @@ async function getShopImages(
 ): Promise<BackSourceImage[]> {
   const rows = await db
     .select({
-      id: designImageTable.id,
-      designId: designImageTable.designId,
-      imageUrl: designImageTable.imageUrl,
-      publishedAt: designImageTable.publishedAt,
+      id: imageTable.id,
+      designId: imageTable.sourceDesignId,
+      imageUrl: imageTable.imageUrl,
+      publishedAt: listingTable.publishedAt,
     })
-    .from(designImageTable)
+    .from(listingTable)
+    .innerJoin(imageTable, eq(imageTable.id, listingTable.imageId))
     .where(
       and(
-        isNotNull(designImageTable.publishedAt),
-        eq(designImageTable.isHidden, false),
+        eq(listingTable.isHidden, false),
         ...(excludeDesignId
-          ? [ne(designImageTable.designId, excludeDesignId)]
+          ? [ne(imageTable.sourceDesignId, excludeDesignId)]
           : [])
       )
     )
-    .orderBy(desc(designImageTable.publishedAt))
+    .orderBy(desc(listingTable.publishedAt))
     .limit(GROUP_LIMIT * 4);
 
-  return dedupeFeedByDesign(rows.map((r) => ({ ...r, publishedAt: r.publishedAt! })))
+  // A listing row exists iff the image is published, so the old
+  // published_at IS NOT NULL filter is the join itself. An image with no
+  // source conversation is its own dedupe group.
+  return dedupeFeedByDesign(
+    rows.map((r) => ({ ...r, designId: r.designId ?? r.id }))
+  )
     .slice(0, GROUP_LIMIT)
     .map((r) => ({ id: r.id, imageUrl: r.imageUrl }));
 }

--- a/src/lib/design-images.ts
+++ b/src/lib/design-images.ts
@@ -1,3 +1,16 @@
+/**
+ * Image reads + the design_image write choke point.
+ *
+ * Slice 2 of the Model B migration (docs/model-b-migration-plan.md): every read
+ * in here resolves against the new tables — `image` + `conversation_image` for
+ * source artifacts, `placement_render` for the render cache, `listing` for
+ * publish state. Writes still land both shapes (slice 4 is the writer cutover),
+ * so a revert of this file alone restores the old behavior with no data loss.
+ *
+ * Id reuse (§2) is what makes the swap invisible to callers: a pinned
+ * placement id resolves whether it was minted as an artifact or a render, which
+ * is why the id lookups check both tables (resolveImagesByIds).
+ */
 import { db } from "@/lib/db";
 import {
   design as designTable,
@@ -6,15 +19,24 @@ import {
   image as imageTable,
   conversationImage as conversationImageTable,
   placementRender as placementRenderTable,
+  listing as listingTable,
   type ChatMessage,
 } from "@/lib/db/schema";
-import { eq, and, asc, desc, inArray, isNull, isNotNull, sql } from "drizzle-orm";
+import { eq, and, asc, desc, inArray, sql } from "drizzle-orm";
 import { getBlank, type AspectRatio } from "@/lib/blanks";
 import {
   buildImageRow,
   buildOutputLinkRow,
   buildPlacementRenderRow,
 } from "@/lib/model-b-writes";
+
+// created_at is second-resolution, so rows written in the same second tie.
+// rowid breaks the tie by insert order — which is what the old design_image
+// reads got implicitly from the table scan.
+const IMAGE_SEQ_ASC = sql`image.rowid asc`;
+const IMAGE_SEQ_DESC = sql`image.rowid desc`;
+const RENDER_SEQ_ASC = sql`placement_render.rowid asc`;
+const RENDER_SEQ_DESC = sql`placement_render.rowid desc`;
 
 /**
  * Atomically reserve `count` generation numbers for a design in a single
@@ -123,11 +145,19 @@ export async function insertDesignImage(params: {
 }): Promise<string> {
   let parentImageId = params.parentImageId ?? null;
   if (parentImageId === null) {
+    // Latest artifact in the thread. Renders are excluded (they live in
+    // placement_render now) — the provenance chain is between artifacts.
     const latest = await db
-      .select({ id: designImageTable.id })
-      .from(designImageTable)
-      .where(eq(designImageTable.designId, params.designId))
-      .orderBy(desc(designImageTable.createdAt))
+      .select({ id: imageTable.id })
+      .from(conversationImageTable)
+      .innerJoin(imageTable, eq(imageTable.id, conversationImageTable.imageId))
+      .where(
+        and(
+          eq(conversationImageTable.designId, params.designId),
+          eq(conversationImageTable.role, "output")
+        )
+      )
+      .orderBy(desc(imageTable.createdAt), IMAGE_SEQ_DESC)
       .limit(1);
     parentImageId = latest[0]?.id ?? null;
   }
@@ -215,22 +245,22 @@ export async function findPlacementRender(
 ): Promise<{ id: string; imageUrl: string; aspectRatio: AspectRatio } | null> {
   const rows = await db
     .select({
-      id: designImageTable.id,
-      imageUrl: designImageTable.imageUrl,
-      aspectRatio: designImageTable.aspectRatio,
+      id: placementRenderTable.id,
+      imageUrl: placementRenderTable.imageUrl,
+      aspectRatio: placementRenderTable.aspectRatio,
     })
-    .from(designImageTable)
+    .from(placementRenderTable)
     .where(
       and(
-        eq(designImageTable.designId, designId),
-        eq(designImageTable.productId, productId),
-        eq(designImageTable.placementId, placementId),
+        eq(placementRenderTable.designId, designId),
+        eq(placementRenderTable.blankId, productId),
+        eq(placementRenderTable.placementId, placementId),
         ...(sourceImageId
-          ? [eq(designImageTable.parentImageId, sourceImageId)]
+          ? [eq(placementRenderTable.sourceImageId, sourceImageId)]
           : [])
       )
     )
-    .orderBy(desc(designImageTable.createdAt))
+    .orderBy(desc(placementRenderTable.createdAt), RENDER_SEQ_DESC)
     .limit(1);
   if (!rows[0]) return null;
   return {
@@ -240,102 +270,198 @@ export async function findPlacementRender(
   };
 }
 
-/**
- * Fetch a single design_image by id. Returns null if not found.
- */
-export async function getDesignImageById(
-  id: string
-): Promise<{
+export type ImageRef = {
   id: string;
-  designId: string;
+  imageUrl: string;
+  aspectRatio: AspectRatio;
+};
+
+/**
+ * Resolve image ids to their URL + aspect across BOTH artifact tables.
+ *
+ * An id minted by a generation lives in `image`; one minted by a placement
+ * render lives in `placement_render`. Orders, cart lines and organizer
+ * products pin whichever they were shown, and id reuse (§2) means the id
+ * alone doesn't say which — so every id lookup checks both. Missing ids are
+ * simply absent from the map.
+ */
+export async function resolveImagesByIds(
+  ids: string[]
+): Promise<Map<string, ImageRef>> {
+  const out = new Map<string, ImageRef>();
+  const unique = [...new Set(ids)];
+  if (unique.length === 0) return out;
+
+  const artifacts = await db
+    .select({
+      id: imageTable.id,
+      imageUrl: imageTable.imageUrl,
+      aspectRatio: imageTable.aspectRatio,
+    })
+    .from(imageTable)
+    .where(inArray(imageTable.id, unique));
+  for (const r of artifacts) {
+    out.set(r.id, { ...r, aspectRatio: r.aspectRatio as AspectRatio });
+  }
+
+  const missing = unique.filter((id) => !out.has(id));
+  if (missing.length === 0) return out;
+
+  const renders = await db
+    .select({
+      id: placementRenderTable.id,
+      imageUrl: placementRenderTable.imageUrl,
+      aspectRatio: placementRenderTable.aspectRatio,
+    })
+    .from(placementRenderTable)
+    .where(inArray(placementRenderTable.id, missing));
+  for (const r of renders) {
+    out.set(r.id, { ...r, aspectRatio: r.aspectRatio as AspectRatio });
+  }
+  return out;
+}
+
+export type ImageRow = {
+  id: string;
+  /** The conversation that produced it. Null only for an artifact with no
+   * output link and no source design (nothing writes that shape today). */
+  designId: string | null;
   imageUrl: string;
   aspectRatio: AspectRatio;
   prompt: string | null;
   publishedAt: Date | null;
-} | null> {
-  const rows = await db
-    .select({
-      id: designImageTable.id,
-      designId: designImageTable.designId,
-      imageUrl: designImageTable.imageUrl,
-      aspectRatio: designImageTable.aspectRatio,
-      prompt: designImageTable.prompt,
-      publishedAt: designImageTable.publishedAt,
-    })
-    .from(designImageTable)
-    .where(eq(designImageTable.id, id))
-    .limit(1);
-  if (!rows[0]) return null;
+};
+
+/**
+ * Fetch a single image by id — artifact first, then the render cache (id
+ * reuse, see resolveImagesByIds). Returns null if neither has it.
+ */
+export async function getDesignImageById(id: string): Promise<ImageRow | null> {
+  const full = await getDesignImageWithOwner(id);
+  if (!full) return null;
   return {
-    id: rows[0].id,
-    designId: rows[0].designId,
-    imageUrl: rows[0].imageUrl,
-    aspectRatio: rows[0].aspectRatio as AspectRatio,
-    prompt: rows[0].prompt,
-    publishedAt: rows[0].publishedAt,
+    id: full.id,
+    designId: full.designId,
+    imageUrl: full.imageUrl,
+    aspectRatio: full.aspectRatio,
+    prompt: full.prompt,
+    publishedAt: full.publishedAt,
   };
 }
 
 /**
- * Fetch a design_image plus the fields the placement-source guard needs:
- * publish/moderation state and the owning design's user id (#72). One
- * joined query so checkout/preview call sites can gate a cross-design
- * back pick without a second round trip.
+ * Fetch an image plus the fields the placement-source guard needs: publish /
+ * moderation state (from `listing`) and the owner (#72). `image.ownerId` is
+ * denormalized, so the artifact path no longer joins `design`; renders still
+ * do, since only their conversation carries an owner.
  */
 export async function getDesignImageWithOwner(
   id: string
-): Promise<{
-  id: string;
-  designId: string;
-  imageUrl: string;
-  aspectRatio: AspectRatio;
-  prompt: string | null;
-  publishedAt: Date | null;
-  isHidden: boolean;
-  ownerId: string;
-} | null> {
-  const rows = await db
+): Promise<(ImageRow & { isHidden: boolean; ownerId: string }) | null> {
+  const [artifact] = await db
     .select({
-      id: designImageTable.id,
-      designId: designImageTable.designId,
-      imageUrl: designImageTable.imageUrl,
-      aspectRatio: designImageTable.aspectRatio,
-      prompt: designImageTable.prompt,
-      publishedAt: designImageTable.publishedAt,
-      isHidden: designImageTable.isHidden,
+      id: imageTable.id,
+      sourceDesignId: imageTable.sourceDesignId,
+      linkDesignId: conversationImageTable.designId,
+      imageUrl: imageTable.imageUrl,
+      aspectRatio: imageTable.aspectRatio,
+      prompt: imageTable.prompt,
+      ownerId: imageTable.ownerId,
+      publishedAt: listingTable.publishedAt,
+      isHidden: listingTable.isHidden,
+    })
+    .from(imageTable)
+    .leftJoin(
+      conversationImageTable,
+      and(
+        eq(conversationImageTable.imageId, imageTable.id),
+        eq(conversationImageTable.role, "output")
+      )
+    )
+    .leftJoin(listingTable, eq(listingTable.imageId, imageTable.id))
+    .where(eq(imageTable.id, id))
+    .limit(1);
+
+  if (artifact) {
+    return {
+      id: artifact.id,
+      designId: artifact.sourceDesignId ?? artifact.linkDesignId,
+      imageUrl: artifact.imageUrl,
+      aspectRatio: artifact.aspectRatio as AspectRatio,
+      prompt: artifact.prompt,
+      // No listing row = not published. isHidden is listing-only state, so an
+      // unpublished image reads as not hidden — same as the old columns.
+      publishedAt: artifact.publishedAt,
+      isHidden: artifact.isHidden ?? false,
+      ownerId: artifact.ownerId,
+    };
+  }
+
+  const [render] = await db
+    .select({
+      id: placementRenderTable.id,
+      designId: placementRenderTable.designId,
+      imageUrl: placementRenderTable.imageUrl,
+      aspectRatio: placementRenderTable.aspectRatio,
       ownerId: designTable.userId,
     })
-    .from(designImageTable)
-    .innerJoin(designTable, eq(designTable.id, designImageTable.designId))
-    .where(eq(designImageTable.id, id))
+    .from(placementRenderTable)
+    .innerJoin(designTable, eq(designTable.id, placementRenderTable.designId))
+    .where(eq(placementRenderTable.id, id))
     .limit(1);
-  if (!rows[0]) return null;
-  return { ...rows[0], aspectRatio: rows[0].aspectRatio as AspectRatio };
+  if (!render) return null;
+
+  // Renders are never published in their own right.
+  return {
+    id: render.id,
+    designId: render.designId,
+    imageUrl: render.imageUrl,
+    aspectRatio: render.aspectRatio as AspectRatio,
+    prompt: null,
+    publishedAt: null,
+    isHidden: false,
+    ownerId: render.ownerId,
+  };
 }
 
 /**
- * Find the design_image row whose imageUrl matches a target URL, scoped
- * to a design. Used at order-creation time to pin the order to the
- * specific image that was on screen when the customer clicked checkout.
- * Returns null if no matching row (e.g. pre-Phase-2 designs that haven't
- * been backfilled).
+ * Find the image whose imageUrl matches a target URL, scoped to a design.
+ * Used at order-creation time to pin the order to the specific image that was
+ * on screen when the customer clicked checkout. Artifacts first, then the
+ * render cache (a URL can come from either surface). Null if neither matches
+ * (e.g. pre-Phase-2 designs that haven't been backfilled).
  */
 export async function findDesignImageByUrl(
   designId: string,
   imageUrl: string
 ): Promise<string | null> {
-  const rows = await db
-    .select({ id: designImageTable.id })
-    .from(designImageTable)
+  const artifacts = await db
+    .select({ id: imageTable.id })
+    .from(conversationImageTable)
+    .innerJoin(imageTable, eq(imageTable.id, conversationImageTable.imageId))
     .where(
       and(
-        eq(designImageTable.designId, designId),
-        eq(designImageTable.imageUrl, imageUrl)
+        eq(conversationImageTable.designId, designId),
+        eq(conversationImageTable.role, "output"),
+        eq(imageTable.imageUrl, imageUrl)
       )
     )
-    .orderBy(desc(designImageTable.createdAt))
+    .orderBy(desc(imageTable.createdAt), IMAGE_SEQ_DESC)
     .limit(1);
-  return rows[0]?.id ?? null;
+  if (artifacts[0]) return artifacts[0].id;
+
+  const renders = await db
+    .select({ id: placementRenderTable.id })
+    .from(placementRenderTable)
+    .where(
+      and(
+        eq(placementRenderTable.designId, designId),
+        eq(placementRenderTable.imageUrl, imageUrl)
+      )
+    )
+    .orderBy(desc(placementRenderTable.createdAt), RENDER_SEQ_DESC)
+    .limit(1);
+  return renders[0]?.id ?? null;
 }
 
 /**
@@ -359,17 +485,12 @@ export async function resolveOrderImageUrls(
     .map((o) => o.placements?.front)
     .filter((v): v is string => Boolean(v));
 
-  const imageRows =
-    imageIds.length > 0
-      ? await db
-          .select({ id: designImageTable.id, imageUrl: designImageTable.imageUrl })
-          .from(designImageTable)
-          .where(inArray(designImageTable.id, imageIds))
-      : [];
-  const byId = new Map(imageRows.map((r) => [r.id, r.imageUrl]));
+  const byId = await resolveImagesByIds(imageIds);
 
   for (const o of orders) {
-    const pinned = o.placements?.front ? byId.get(o.placements.front) : undefined;
+    const pinned = o.placements?.front
+      ? byId.get(o.placements.front)?.imageUrl
+      : undefined;
     out.set(o.id, pinned ?? fallback.get(o.designId) ?? null);
   }
   return out;
@@ -385,30 +506,32 @@ export type SourceImage = {
 };
 
 /**
- * Fetch all source images for a design (rows with product_id IS NULL —
- * the exploratory 1:1 generations and user uploads). Ordered oldest →
- * newest so the chat-thread gallery scrolls forward in time.
+ * Fetch all source images for a design — the conversation's `output` links
+ * (exploratory 1:1 generations and user uploads). Ordered oldest → newest so
+ * the chat-thread gallery scrolls forward in time.
  */
 export async function getDesignSourceImages(
   designId: string
 ): Promise<SourceImage[]> {
   const rows = await db
     .select({
-      id: designImageTable.id,
-      imageUrl: designImageTable.imageUrl,
-      aspectRatio: designImageTable.aspectRatio,
-      prompt: designImageTable.prompt,
-      createdAt: designImageTable.createdAt,
-      publishedAt: designImageTable.publishedAt,
+      id: imageTable.id,
+      imageUrl: imageTable.imageUrl,
+      aspectRatio: imageTable.aspectRatio,
+      prompt: imageTable.prompt,
+      createdAt: imageTable.createdAt,
+      publishedAt: listingTable.publishedAt,
     })
-    .from(designImageTable)
+    .from(conversationImageTable)
+    .innerJoin(imageTable, eq(imageTable.id, conversationImageTable.imageId))
+    .leftJoin(listingTable, eq(listingTable.imageId, imageTable.id))
     .where(
       and(
-        eq(designImageTable.designId, designId),
-        isNull(designImageTable.productId)
+        eq(conversationImageTable.designId, designId),
+        eq(conversationImageTable.role, "output")
       )
     )
-    .orderBy(asc(designImageTable.createdAt));
+    .orderBy(asc(imageTable.createdAt), IMAGE_SEQ_ASC);
 
   return rows.map((r) => ({
     id: r.id,
@@ -435,50 +558,43 @@ export type ProductVersionGroup = {
 };
 
 /**
- * Fetch placement-targeted renders for a design (rows with non-null
- * product_id), grouped by product. Each group's `images` is ordered
- * oldest → newest. Products with no renders for this design are
- * omitted entirely.
+ * Fetch placement-targeted renders for a design, grouped by blank. Each
+ * group's `images` is ordered oldest → newest. Blanks with no renders for
+ * this design are omitted entirely.
  */
 export async function getDesignPlacementRenders(
   designId: string
 ): Promise<ProductVersionGroup[]> {
   const rows = await db
     .select({
-      id: designImageTable.id,
-      imageUrl: designImageTable.imageUrl,
-      aspectRatio: designImageTable.aspectRatio,
-      productId: designImageTable.productId,
-      placementId: designImageTable.placementId,
-      createdAt: designImageTable.createdAt,
+      id: placementRenderTable.id,
+      imageUrl: placementRenderTable.imageUrl,
+      aspectRatio: placementRenderTable.aspectRatio,
+      blankId: placementRenderTable.blankId,
+      placementId: placementRenderTable.placementId,
+      createdAt: placementRenderTable.createdAt,
     })
-    .from(designImageTable)
-    .where(
-      and(
-        eq(designImageTable.designId, designId),
-        isNotNull(designImageTable.productId)
-      )
-    )
-    .orderBy(asc(designImageTable.createdAt));
+    .from(placementRenderTable)
+    .where(eq(placementRenderTable.designId, designId))
+    .orderBy(asc(placementRenderTable.createdAt), RENDER_SEQ_ASC);
 
   const byProduct = new Map<string, ProductVersionGroup>();
   for (const r of rows) {
-    if (!r.productId) continue;
-    let group = byProduct.get(r.productId);
+    let group = byProduct.get(r.blankId);
     if (!group) {
-      const product = getBlank(r.productId);
+      const product = getBlank(r.blankId);
       group = {
-        productId: r.productId,
-        productName: product?.name ?? r.productId,
+        productId: r.blankId,
+        productName: product?.name ?? r.blankId,
         images: [],
       };
-      byProduct.set(r.productId, group);
+      byProduct.set(r.blankId, group);
     }
     group.images.push({
       id: r.id,
       imageUrl: r.imageUrl,
       aspectRatio: r.aspectRatio as AspectRatio,
-      placementId: r.placementId ?? "default",
+      placementId: r.placementId,
       createdAt: r.createdAt,
     });
   }
@@ -525,23 +641,13 @@ export async function resolveDesignDisplayImageUrls(
     .map((d) => d.primaryImageId)
     .filter((v): v is string => Boolean(v));
 
-  const primaryRows =
-    primaryIds.length > 0
-      ? await db
-          .select({
-            id: designImageTable.id,
-            imageUrl: designImageTable.imageUrl,
-          })
-          .from(designImageTable)
-          .where(inArray(designImageTable.id, primaryIds))
-      : [];
-  const urlByImageId = new Map(primaryRows.map((r) => [r.id, r.imageUrl]));
+  const urlByImageId = await resolveImagesByIds(primaryIds);
 
   // First pass: pick up everything with a working primary pointer.
   const needFallback: string[] = [];
   for (const d of designRows) {
     const url = d.primaryImageId
-      ? urlByImageId.get(d.primaryImageId)
+      ? urlByImageId.get(d.primaryImageId)?.imageUrl
       : undefined;
     if (url) {
       out.set(d.id, url);
@@ -550,22 +656,22 @@ export async function resolveDesignDisplayImageUrls(
     }
   }
 
-  // Fallback: latest source image (product_id IS NULL) per design.
+  // Fallback: the design's latest output artifact.
   if (needFallback.length > 0) {
     const fallbackRows = await db
       .select({
-        designId: designImageTable.designId,
-        imageUrl: designImageTable.imageUrl,
-        createdAt: designImageTable.createdAt,
+        designId: conversationImageTable.designId,
+        imageUrl: imageTable.imageUrl,
       })
-      .from(designImageTable)
+      .from(conversationImageTable)
+      .innerJoin(imageTable, eq(imageTable.id, conversationImageTable.imageId))
       .where(
         and(
-          inArray(designImageTable.designId, needFallback),
-          isNull(designImageTable.productId)
+          inArray(conversationImageTable.designId, needFallback),
+          eq(conversationImageTable.role, "output")
         )
       )
-      .orderBy(desc(designImageTable.createdAt));
+      .orderBy(desc(imageTable.createdAt), IMAGE_SEQ_DESC);
 
     for (const r of fallbackRows) {
       if (!out.has(r.designId)) out.set(r.designId, r.imageUrl);
@@ -605,15 +711,16 @@ export async function deleteDesignImageRow(
   ]);
 
   const remaining = await db
-    .select({ id: designImageTable.id })
-    .from(designImageTable)
+    .select({ id: imageTable.id })
+    .from(conversationImageTable)
+    .innerJoin(imageTable, eq(imageTable.id, conversationImageTable.imageId))
     .where(
       and(
-        eq(designImageTable.designId, designId),
-        isNull(designImageTable.productId)
+        eq(conversationImageTable.designId, designId),
+        eq(conversationImageTable.role, "output")
       )
     )
-    .orderBy(desc(designImageTable.createdAt))
+    .orderBy(desc(imageTable.createdAt), IMAGE_SEQ_DESC)
     .limit(1);
 
   return { newPrimaryId: remaining[0]?.id ?? null };

--- a/src/lib/design-publish.ts
+++ b/src/lib/design-publish.ts
@@ -85,8 +85,9 @@ export function canBuyPublishedImage(image: {
  * and the guard agree.
  */
 export function canUseAsPlacementSource(params: {
+  /** Publish state only — Model B keeps it in `listing`, and the guard has
+   * never had a thread-membership grant to spend a designId on. */
   image: {
-    designId: string;
     publishedAt: Date | null;
     isHidden: boolean;
   };

--- a/src/lib/discover-feed.ts
+++ b/src/lib/discover-feed.ts
@@ -2,18 +2,17 @@
  * Shop feed query + ordering.
  *
  * The feed (homepage grid + /prints) lists published, non-hidden images,
- * one card per design. Position is admin-controlled via
- * `design_image.feed_rank` (/admin/published): ranked images list first,
- * lowest rank first; unranked images follow, newest published first —
- * exactly the pre-rank behavior.
+ * one card per design. Position is admin-controlled via `listing.feed_rank`
+ * (/admin/published): ranked images list first, lowest rank first; unranked
+ * images follow, newest published first — exactly the pre-rank behavior.
  */
 import { db } from "@/lib/db";
 import {
-  design as designTable,
-  designImage as designImageTable,
+  image as imageTable,
+  listing as listingTable,
   user as userTable,
 } from "@/lib/db/schema";
-import { eq, and, isNotNull, desc, asc, sql } from "drizzle-orm";
+import { eq, desc, asc, sql } from "drizzle-orm";
 
 export type FeedRow = {
   imageId: string;
@@ -71,36 +70,35 @@ export function orderFeedByRank<
  * ranked rows are never cut off by the over-fetch window.
  */
 export async function getPublishedFeed(limit = 60): Promise<FeedRow[]> {
+  // A listing row exists iff the image is published, so the join replaces the
+  // old published_at IS NOT NULL filter. The designer comes off image.ownerId
+  // (denormalized in Model B) — no design join left.
   const rows = await db
     .select({
-      imageId: designImageTable.id,
-      designId: designImageTable.designId,
-      imageUrl: designImageTable.imageUrl,
-      title: designImageTable.title,
-      description: designImageTable.description,
-      backgroundColor: designImageTable.backgroundColor,
-      publishedAt: designImageTable.publishedAt,
-      feedRank: designImageTable.feedRank,
+      imageId: imageTable.id,
+      designId: imageTable.sourceDesignId,
+      imageUrl: imageTable.imageUrl,
+      title: listingTable.title,
+      description: listingTable.description,
+      backgroundColor: listingTable.backgroundColor,
+      publishedAt: listingTable.publishedAt,
+      feedRank: listingTable.feedRank,
       designerName: userTable.name,
       designerId: userTable.id,
     })
-    .from(designImageTable)
-    .innerJoin(designTable, eq(designTable.id, designImageTable.designId))
-    .innerJoin(userTable, eq(userTable.id, designTable.userId))
-    .where(
-      and(
-        isNotNull(designImageTable.publishedAt),
-        eq(designImageTable.isHidden, false)
-      )
-    )
+    .from(listingTable)
+    .innerJoin(imageTable, eq(imageTable.id, listingTable.imageId))
+    .innerJoin(userTable, eq(userTable.id, imageTable.ownerId))
+    .where(eq(listingTable.isHidden, false))
     .orderBy(
-      sql`${designImageTable.feedRank} is null`,
-      asc(designImageTable.feedRank),
-      desc(designImageTable.publishedAt)
+      sql`${listingTable.feedRank} is null`,
+      asc(listingTable.feedRank),
+      desc(listingTable.publishedAt)
     )
     .limit(Math.min(limit * 4, 240));
 
+  // An image with no source conversation is its own dedupe group.
   return orderFeedByRank(
-    rows.map((r) => ({ ...r, publishedAt: r.publishedAt! }))
+    rows.map((r) => ({ ...r, designId: r.designId ?? r.imageId }))
   ).slice(0, limit);
 }

--- a/src/lib/model-b-writes.ts
+++ b/src/lib/model-b-writes.ts
@@ -64,9 +64,14 @@ export function buildImageRow(params: {
   parentImageId?: string | null;
   seedImageId?: string | null;
   originalDesignerId?: string | null;
+  /** Backfill only: carries the design_image timestamp across, so the
+   * chronological reads (thread gallery order, latest-source fallback) keep
+   * working on rows that predate the table. Live writes omit it → now. */
+  createdAt?: Date;
 }): ImageRow {
   return {
     id: params.id,
+    ...(params.createdAt ? { createdAt: params.createdAt } : {}),
     ownerId: params.ownerId,
     r2Key: r2KeyFromUrl(params.imageUrl),
     imageUrl: params.imageUrl,
@@ -109,9 +114,13 @@ export function buildPlacementRenderRow(params: {
   imageUrl: string;
   aspectRatio: string;
   generationCost: number;
+  /** Backfill only — see buildImageRow. findPlacementRender takes the most
+   * recent match, so the original timestamp has to survive. */
+  createdAt?: Date;
 }): PlacementRenderRow {
   return {
     id: params.id,
+    ...(params.createdAt ? { createdAt: params.createdAt } : {}),
     designId: params.designId,
     sourceImageId: params.sourceImageId ?? null,
     blankId: params.blankId,


### PR DESCRIPTION
Slice 2 of `docs/model-b-migration-plan.md`. Every display read moves off `design_image` onto `image` / `conversation_image` / `listing` / `placement_render`. Function signatures are unchanged, so call sites don't churn. Writes stay dual — the writer cutover is slice 4.

## MERGE GATE — blocked on the prod backfill

**Do not merge until `scripts/backfill-model-b.ts` has run against prod.** Prod currently has ~2 dual-written `image` rows against 154 `design_image` rows; merging before the backfill would make every historical design read as empty.

Run it **from this branch**, not from main — this PR fixes the backfill to carry `created_at` (see Deviations), and the inserts are `onConflictDoNothing`, so re-running later would not correct rows written with a run timestamp.

📋 **COPY THE BELOW — run the prod backfill (idempotent):**
```
DATABASE_URL=libsql://prntd-nicolovejoy.aws-us-west-2.turso.io DATABASE_AUTH_TOKEN=$(turso db tokens create prntd) npx tsx scripts/backfill-model-b.ts
```

`prntd-preview` needs the same run before its Vercel preview works (migration 0005 is already applied there).

## What changed

- `design-images.ts` — thread gallery (`output` links), `getDesignImageById` / `getDesignImageWithOwner` (owner from `image.owner_id`, publish state from `listing`), `findPlacementRender` / `getDesignPlacementRenders`, `findDesignImageByUrl`, display resolvers. New `resolveImagesByIds` checks both artifact tables, so a pinned placement id resolves whether it was minted as a generation or as a render (id reuse, §2/§5).
- `back-sources.ts`, `discover-feed.ts`, `/d` (`getPublishedImage`, fork chain over `image.seed_image_id`), `/admin/published`, `/designs` cards, and the orders / shop / dashboard image lookups.
- `canUseAsPlacementSource` takes publish state only — the `designId` it deliberately never used is gone (plan's slice-2 note). Its tests port over intact, including the /d forged-id case.
- Publish-family actions still read `design_image` on purpose: an unpublished image has no listing row, so the `is_hidden` / `feed_rank` a new listing must snapshot live nowhere else until slice 4.
- `e2e/helpers/db.ts` `seedDesign` dual-writes `image` + `conversation_image` the way production does (it wrote only `design_image`, so no spec would have exercised the swapped reads); cleanup clears the Model B rows.

No schema change.

## Deviations from the plan

1. **Backfill carries `created_at`.** The slice-2 readers order the gallery, the latest-artifact fallback and the render cache by it; without the carry every backfilled row would share the backfill run's timestamp. `buildImageRow` / `buildPlacementRenderRow` take an optional `createdAt` (backfill only). This is why the backfill must be run from this branch.
2. **`rowid` tiebreak.** `created_at` is second-resolution, so same-second rows tie. The ordering reads add `rowid`, which is the insert order the old `design_image` scans got implicitly.

Both are noted in the plan doc.

## Tests

716 → 731. New `src/lib/__tests__/image-readers.integration.test.ts` (11) runs every swapped reader against both production shapes — legacy rows promoted by the backfill, and dual-written rows — plus the id-reuse lookup and the hidden-listing case. Existing real-DB suites now seed through a shared `makeSourceImage` factory that writes both shapes; `/d` gained `getPublishedImage` + seed-lineage coverage; the backfill suite asserts the timestamp carry.

`npm run lint`, `npm test`, `npm run typecheck`, `npm run build` all pass.

## Smoke on preview after the backfill

/d buy page, back-source picker, order history thumbnails, admin published grid, /designs cards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
