### PR TITLE
fix: cart flake #101 — /preview navigation undone by a late server action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,13 +135,15 @@ jobs:
       # (npm run build && npm run start -p 3100) with the funnel flags on,
       # against the ephemeral DB in DATABASE_URL/DATABASE_AUTH_TOKEN.
       #
-      # Flake #101 ("cart: 0 line items") is an intermittent, self-clearing
-      # ~30s stall in the cart page's client-side load (a server action whose
-      # response is occasionally delayed) — it reproduces even for a single
-      # cart test run alone, and recovers on the next attempt, so it is NOT
-      # inter-run DB contention (the per-run ephemeral DB rules that out) nor
-      # project concurrency. The cart page now retries its own load
-      # (src/app/cart/page.tsx); belt-and-suspenders here:
+      # Flake #101 ("cart: 0 line items") was root-caused from the
+      # run-29888905717 traces and reproduced locally: the cart page loaded fine
+      # (getCart returned in 90ms) and the browser then navigated BACK to
+      # /preview ~200ms later, so the assertion ran against the wrong page.
+      # Next's server-action reducer ends every action by navigating to the
+      # canonicalUrl the action was dispatched from; /preview always has a
+      # background action in flight, and one landing after router.push("/cart")
+      # undoes the push. /preview now leaves via a document navigation
+      # (src/app/preview/page.tsx). These flags stay as belt-and-suspenders:
       #   --workers=1  : serialize the two projects so they don't add load to
       #                  one self-hosted server (local `npm run e2e` keeps
       #                  default parallelism — unchanged).

--- a/e2e/cart.spec.ts
+++ b/e2e/cart.spec.ts
@@ -22,6 +22,14 @@ async function shippingAmount(page: Page): Promise<number> {
   return Number(match![1]);
 }
 
+async function sessionCookie(page: Page): Promise<string> {
+  const cookies = await page.context().cookies();
+  return (
+    cookies.find((c) => c.name.endsWith("better-auth.session_token"))?.value ??
+    ""
+  );
+}
+
 async function addToCartFromPreviewPage(page: Page, designId: string) {
   // URL `size` pre-selects visibly (no silent default), so no extra click.
   await page.goto(
@@ -32,6 +40,14 @@ async function addToCartFromPreviewPage(page: Page, designId: string) {
   await expect(page.getByText("Total")).toBeVisible({ timeout: 30_000 });
   await page.getByRole("button", { name: "Add to cart" }).click();
   await page.waitForURL(/\/cart/);
+
+  // #101 guard. The flake was never "the cart is empty" — the browser landed
+  // on /cart and then bounced back to /preview a beat later, when a /preview
+  // server action that was still in flight resolved and Next navigated to the
+  // URL that action had been dispatched from. Hold the URL for a moment so a
+  // bounce fails here, loudly, instead of as a mystery 0-line-items count.
+  await page.waitForTimeout(1_000);
+  await expect(page).toHaveURL(/\/cart/);
 }
 
 test("guest cart: two items, bundled shipping, sign-in gate at checkout", async ({
@@ -55,6 +71,11 @@ test("guest cart: two items, bundled shipping, sign-in gate at checkout", async 
     await expect(page.getByTestId("cart-line-item")).toHaveCount(1, {
       timeout: 30_000,
     });
+    // The cart is owner-scoped, so a session swap mid-flow reads as an empty
+    // cart. ensureGuestSession used to mint a second anonymous user whenever
+    // the session lookup errored; assert the identity we seeded against is
+    // still the one the cart is read under.
+    expect(await sessionCookie(page)).toBe(cookie);
     const oneItemShipping = await shippingAmount(page);
 
     // Second item — bundled shipping must not scale with item count.

--- a/src/app/cart/__tests__/cart-page.test.tsx
+++ b/src/app/cart/__tests__/cart-page.test.tsx
@@ -1,0 +1,92 @@
+/**
+ * A cart that failed to load must not read as an empty cart. The old fallback
+ * rendered "Your cart is empty." after five silent failures, which is both a
+ * lie to the customer and invisible to the e2e suite.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import type { CartView } from "../actions";
+import CartPage from "../page";
+
+const getCart = vi.fn();
+
+vi.mock("../actions", () => ({
+  getCart: (...args: unknown[]) => getCart(...args),
+  removeCartItem: vi.fn(),
+  checkoutCart: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+}));
+
+const EMPTY: CartView = { items: [], itemSubtotal: 0, shipping: 0, total: 0 };
+
+const ONE_ITEM: CartView = {
+  items: [
+    {
+      id: "line-1",
+      designId: "d1",
+      productId: "bella-canvas-3001",
+      productName: "Classic Tee",
+      size: "M",
+      color: "Black",
+      placements: null,
+      hasBack: false,
+      quantity: 1,
+      unitPrice: 19.43,
+      imageUrl: null,
+    },
+  ],
+  itemSubtotal: 19.43,
+  shipping: 4.69,
+  total: 24.12,
+};
+
+beforeEach(() => {
+  getCart.mockReset();
+});
+
+describe("CartPage load states", () => {
+  it("shows the empty state for a genuinely empty cart", async () => {
+    getCart.mockResolvedValue(EMPTY);
+    render(<CartPage />);
+
+    expect(await screen.findByText("Your cart is empty.")).toBeInTheDocument();
+    expect(screen.queryByTestId("cart-load-error")).not.toBeInTheDocument();
+  });
+
+  it("shows an error, not an empty cart, when every load attempt fails", async () => {
+    getCart.mockRejectedValue(new Error("boom"));
+    render(<CartPage />);
+
+    expect(await screen.findByTestId("cart-load-error")).toBeInTheDocument();
+    expect(screen.getByText("Couldn't load your cart.")).toBeInTheDocument();
+    expect(screen.queryByText("Your cart is empty.")).not.toBeInTheDocument();
+  });
+
+  it("recovers on Retry", async () => {
+    getCart
+      .mockRejectedValueOnce(new Error("boom"))
+      .mockRejectedValueOnce(new Error("boom"))
+      .mockResolvedValue(ONE_ITEM);
+    render(<CartPage />);
+
+    fireEvent.click(await screen.findByRole("button", { name: "Retry" }));
+
+    await waitFor(() =>
+      expect(screen.getAllByTestId("cart-line-item")).toHaveLength(1)
+    );
+    expect(screen.queryByTestId("cart-load-error")).not.toBeInTheDocument();
+  });
+
+  it("absorbs a single transient failure without surfacing an error", async () => {
+    getCart.mockRejectedValueOnce(new Error("boom")).mockResolvedValue(ONE_ITEM);
+    render(<CartPage />);
+
+    await waitFor(() =>
+      expect(screen.getAllByTestId("cart-line-item")).toHaveLength(1)
+    );
+    expect(screen.queryByTestId("cart-load-error")).not.toBeInTheDocument();
+  });
+});

--- a/src/app/cart/actions.ts
+++ b/src/app/cart/actions.ts
@@ -10,7 +10,6 @@ import {
   orderItem as orderItemTable,
   design as designTable,
 } from "@/lib/db/schema";
-import { revalidatePath } from "next/cache";
 import {
   getBlank,
   getVariantId,
@@ -73,6 +72,12 @@ async function currentUserId(): Promise<string | null> {
  * cart re-parents to their account on sign-in. Resolves the front placement
  * from the design's pinned primary image (same as createCheckoutSession), and
  * honors a back image only when MULTI_PLACEMENT_ENABLED.
+ *
+ * No revalidatePath here, nor in removeCartItem/clearCart: nothing renders cart
+ * data on the server. /cart is a client page that calls getCart() itself and
+ * the header count calls getCartCount(), so the only thing the revalidation
+ * bought was a RefreshAll on the navigation Next appends to every server
+ * action.
  */
 export async function addToCart(params: {
   designId: string;
@@ -115,7 +120,6 @@ export async function addToCart(params: {
     placements,
   });
 
-  revalidatePath("/cart");
   return { ok: true, count: await getCartCount() };
 }
 
@@ -126,14 +130,12 @@ export async function removeCartItem(id: string): Promise<void> {
   await db
     .delete(cartItemTable)
     .where(and(eq(cartItemTable.id, id), eq(cartItemTable.userId, userId)));
-  revalidatePath("/cart");
 }
 
 export async function clearCart(): Promise<void> {
   const userId = await currentUserId();
   if (!userId) return;
   await db.delete(cartItemTable).where(eq(cartItemTable.userId, userId));
-  revalidatePath("/cart");
 }
 
 export async function getCartCount(): Promise<number> {

--- a/src/app/cart/page.tsx
+++ b/src/app/cart/page.tsx
@@ -8,8 +8,6 @@ import { Button } from "@/components/ui";
 import { Breadcrumbs } from "@/components/breadcrumbs";
 import { breadcrumbTrail } from "@/lib/nav";
 
-const EMPTY_CART: CartView = { items: [], itemSubtotal: 0, shipping: 0, total: 0 };
-
 /** Reject if `p` doesn't settle within `ms` — so one slow/lost server-action
  * response doesn't strand the load forever (a retry issues a fresh call). */
 function withTimeout<T>(p: Promise<T>, ms: number): Promise<T> {
@@ -24,6 +22,11 @@ function withTimeout<T>(p: Promise<T>, ms: number): Promise<T> {
 export default function CartPage() {
   const router = useRouter();
   const [cart, setCart] = useState<CartView | null>(null);
+  // A failed load is its own state. Falling back to an empty cart made a
+  // broken load look identical to "you have nothing in your cart" — wrong for
+  // tests and worse for a customer who is about to walk away.
+  const [loadFailed, setLoadFailed] = useState(false);
+  const [attempt, setAttempt] = useState(0);
   const [removing, setRemoving] = useState<string | null>(null);
   const [checkingOut, setCheckingOut] = useState(false);
 
@@ -32,31 +35,29 @@ export default function CartPage() {
   }
 
   useEffect(() => {
-    // Resilient initial load. getCart is a server action whose response can be
-    // slow or lost under concurrent load; a single-shot fetch with no recovery
-    // left the page stuck on "Loading…" (showing 0 items) — the #101 flake.
-    // Retry with a per-attempt timeout until the cart resolves. A genuinely
-    // empty cart is accepted after the first clean read. No ensureGuestSession
-    // here: getCart resolves the existing session server-side and returns an
-    // empty cart for a true guest — minting a fresh anon user client-side only
-    // risked stomping the real session under load.
+    // getCart is a server action whose response can be slow or lost; one silent
+    // retry absorbs that, and anything past it surfaces as an error the visitor
+    // can act on. No ensureGuestSession here: getCart resolves the existing
+    // session server-side and returns an empty cart for a true guest — minting
+    // a fresh anon user client-side only risked stomping the real session.
     let cancelled = false;
+    setLoadFailed(false);
     (async () => {
-      for (let attempt = 0; attempt < 5 && !cancelled; attempt++) {
+      for (let i = 0; i < 2 && !cancelled; i++) {
         try {
           const view = await withTimeout(getCart(), 8000);
           if (!cancelled) setCart(view);
           return;
         } catch {
-          if (attempt === 4 && !cancelled) setCart(EMPTY_CART);
-          else await new Promise((r) => setTimeout(r, 800));
+          if (i === 0) await new Promise((r) => setTimeout(r, 800));
         }
       }
+      if (!cancelled) setLoadFailed(true);
     })();
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [attempt]);
 
   async function handleRemove(id: string) {
     setRemoving(id);
@@ -82,7 +83,7 @@ export default function CartPage() {
     }
   }
 
-  const empty = cart !== null && cart.items.length === 0;
+  const empty = !loadFailed && cart !== null && cart.items.length === 0;
 
   return (
     <div className="min-h-screen flex flex-col items-center py-6 md:py-12 px-4 pb-24 md:pb-12">
@@ -95,7 +96,21 @@ export default function CartPage() {
       <div className="w-full max-w-2xl">
         <h1 className="text-xl font-semibold mb-6">Your cart</h1>
 
-        {cart === null && <p className="text-text-muted">Loading…</p>}
+        {cart === null && !loadFailed && (
+          <p className="text-text-muted">Loading…</p>
+        )}
+
+        {loadFailed && (
+          <div
+            data-testid="cart-load-error"
+            className="text-center py-12 space-y-4"
+          >
+            <p className="text-text-muted">Couldn&apos;t load your cart.</p>
+            <Button size="lg" onClick={() => setAttempt((n) => n + 1)}>
+              Retry
+            </Button>
+          </div>
+        )}
 
         {empty && (
           <div className="text-center py-12 space-y-4">

--- a/src/app/preview/page.tsx
+++ b/src/app/preview/page.tsx
@@ -83,6 +83,10 @@ function PreviewPageInner() {
   const [pinnedColor, setPinnedColor] = useState<string | null>(null);
   const productTouched = useRef(false);
   const colorTouched = useRef(false);
+  // Set the moment a navigation away from /preview starts (add-to-cart,
+  // checkout). Late async state must not rewrite history after that — see the
+  // URL-sync effect below (#101).
+  const navigatingAway = useRef(false);
 
   const [renderState, setRenderState] = useState<RenderState>({ status: "idle" });
   // Bumped to re-run the placement-render effect (retry after an error).
@@ -295,7 +299,16 @@ function PreviewPageInner() {
   // Sync selections to the URL so they survive Stripe cancel → back and
   // reloads. replaceState, not router.replace — a router.replace issued next
   // to a server-action call gets cancelled by the action.
+  //
+  // Two guards, both because Next turns every history.replaceState into a
+  // router ACTION_RESTORE for the URL passed in — so a redundant or late call
+  // is a real navigation, not a no-op (the #101 class of bug):
+  //   - skip once a navigation away has started, so late-landing async state
+  //     (remembered defaults, pinned color, a mockup settling) can't restore
+  //     /preview on top of it;
+  //   - skip when the URL already matches, which is most renders.
   useEffect(() => {
+    if (navigatingAway.current) return;
     const params = new URLSearchParams(window.location.search);
     if (size) params.set("size", size);
     else params.delete("size");
@@ -303,11 +316,10 @@ function PreviewPageInner() {
     params.set("product", productId);
     if (backImageId) params.set("back", backImageId);
     else params.delete("back");
-    window.history.replaceState(
-      null,
-      "",
-      `${window.location.pathname}?${params.toString()}`
-    );
+    const next = `${window.location.pathname}?${params.toString()}`;
+    if (next === `${window.location.pathname}${window.location.search}`) return;
+    // Keep the existing history state rather than clearing it to null.
+    window.history.replaceState(window.history.state, "", next);
   }, [size, colorName, productId, backImageId]);
 
   // Resolve the design image to render for the current
@@ -551,6 +563,7 @@ function PreviewPageInner() {
   async function handleAddToCart() {
     if (!designId || !size) return;
     setAddingToCart(true);
+    navigatingAway.current = true;
     try {
       await addToCart({
         designId,
@@ -559,8 +572,15 @@ function PreviewPageInner() {
         productId,
         ...(backActive ? { back: backImageId! } : {}),
       });
-      router.push("/cart");
+      // Hard navigation, not router.push (#101). Next's server-action reducer
+      // finishes every action by navigating to the canonicalUrl the action was
+      // dispatched from. This page always has background actions in flight
+      // (mockup render, price), and any one of them landing after a client-side
+      // push drags the router straight back to /preview — the cart page had
+      // already rendered. A document navigation can't be undone that way.
+      window.location.href = "/cart";
     } catch {
+      navigatingAway.current = false;
       setAddingToCart(false);
     }
   }

--- a/src/lib/__tests__/ensure-guest-session.test.ts
+++ b/src/lib/__tests__/ensure-guest-session.test.ts
@@ -1,0 +1,99 @@
+/**
+ * ensureGuestSession only mints an anonymous user on a *clean* no-session read.
+ * A failed session lookup (5xx, network) also has `data: null`, and treating it
+ * as "no session" swaps the visitor's session cookie for a fresh anonymous
+ * user — orphaning their designs, cart and orders on the old user id.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const getSession = vi.fn();
+const signInAnonymous = vi.fn();
+
+vi.mock("../auth-client", () => ({
+  authClient: {
+    getSession: (...args: unknown[]) => getSession(...args),
+    signIn: { anonymous: (...args: unknown[]) => signInAnonymous(...args) },
+  },
+}));
+
+// Fresh module per test: ensureGuestSession memoizes its result at module scope.
+async function loadFresh() {
+  vi.resetModules();
+  return (await import("../ensure-guest-session")).ensureGuestSession;
+}
+
+beforeEach(() => {
+  getSession.mockReset();
+  signInAnonymous.mockReset();
+  signInAnonymous.mockResolvedValue({ data: {}, error: null });
+});
+
+describe("ensureGuestSession", () => {
+  it("mints an anonymous session when there is genuinely none", async () => {
+    getSession.mockResolvedValue({ data: null, error: null });
+    const ensureGuestSession = await loadFresh();
+
+    await ensureGuestSession();
+
+    expect(signInAnonymous).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not mint when the session lookup fails", async () => {
+    getSession.mockResolvedValue({
+      data: null,
+      error: { status: 500, statusText: "Internal Server Error" },
+    });
+    const ensureGuestSession = await loadFresh();
+
+    await ensureGuestSession();
+
+    expect(signInAnonymous).not.toHaveBeenCalled();
+  });
+
+  it("retries on the next call after a failed lookup", async () => {
+    getSession
+      .mockResolvedValueOnce({ data: null, error: { status: 500 } })
+      .mockResolvedValueOnce({ data: null, error: null });
+    const ensureGuestSession = await loadFresh();
+
+    await ensureGuestSession();
+    expect(signInAnonymous).not.toHaveBeenCalled();
+
+    await ensureGuestSession();
+    expect(signInAnonymous).toHaveBeenCalledTimes(1);
+  });
+
+  it("is a no-op when a session already exists", async () => {
+    getSession.mockResolvedValue({
+      data: { user: { id: "u1" }, session: { id: "s1" } },
+      error: null,
+    });
+    const ensureGuestSession = await loadFresh();
+
+    await ensureGuestSession();
+
+    expect(signInAnonymous).not.toHaveBeenCalled();
+  });
+
+  it("memoizes a successful check across callers", async () => {
+    getSession.mockResolvedValue({ data: { user: { id: "u1" } }, error: null });
+    const ensureGuestSession = await loadFresh();
+
+    await Promise.all([ensureGuestSession(), ensureGuestSession()]);
+
+    expect(getSession).toHaveBeenCalledTimes(1);
+  });
+
+  it("clears the memo when getSession rejects outright", async () => {
+    getSession
+      .mockRejectedValueOnce(new Error("network down"))
+      .mockResolvedValueOnce({ data: null, error: null });
+    const ensureGuestSession = await loadFresh();
+
+    await expect(ensureGuestSession()).rejects.toThrow("network down");
+    expect(signInAnonymous).not.toHaveBeenCalled();
+
+    await ensureGuestSession();
+    expect(signInAnonymous).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/lib/ensure-guest-session.ts
+++ b/src/lib/ensure-guest-session.ts
@@ -12,11 +12,24 @@ let ensured: Promise<void> | null = null;
  * Safe to call regardless of GUEST_FUNNEL_ENABLED: when the flag is off the
  * middleware redirects sessionless visitors away from the funnel before this
  * runs, and a real user's existing session short-circuits the mint.
+ *
+ * Only a *clean* no-session read mints. Better-Auth's client returns
+ * `{ data, error }`: no session is `data: null, error: null` (200 + null body),
+ * while a 5xx/network failure is `data: null` with `error` set. Treating the
+ * latter as "no session" would mint a second anonymous user and swap the
+ * session cookie out from under whatever the visitor already owns — their
+ * designs, cart and orders stay on the old user id.
  */
 export function ensureGuestSession(): Promise<void> {
   if (!ensured) {
     ensured = (async () => {
-      const { data } = await authClient.getSession();
+      const { data, error } = await authClient.getSession();
+      if (error) {
+        // Lookup failed — we don't know whether a session exists. Do nothing
+        // and let the next call retry rather than risk swapping the session.
+        ensured = null;
+        return;
+      }
       if (!data) {
         await authClient.signIn.anonymous();
       }

--- a/src/lib/printful.ts
+++ b/src/lib/printful.ts
@@ -1,21 +1,44 @@
+import { withTimeout } from "./timeout";
+
 const PRINTFUL_API = "https://api.printful.com";
 
-async function printfulFetch(path: string, options?: RequestInit) {
-  const res = await fetch(`${PRINTFUL_API}${path}`, {
-    ...options,
-    headers: {
-      Authorization: `Bearer ${process.env.PRINTFUL_API_KEY}`,
-      "Content-Type": "application/json",
-      ...options?.headers,
-    },
+/**
+ * Upper bound on any single Printful call. Generous on purpose: order
+ * submission is the one call we must not cut short, and Printful's mockup
+ * endpoints are slow by design. The point is that a hung connection can't
+ * stall a request forever — every caller that renders a page (cart shipping
+ * quote, mockups) sits behind this.
+ */
+const PRINTFUL_TIMEOUT_MS = 30_000;
+
+/** Tighter bound for calls that render a page and have a graceful fallback. */
+const QUOTE_TIMEOUT_MS = 10_000;
+
+async function printfulFetch(
+  path: string,
+  options?: RequestInit,
+  timeoutMs: number = PRINTFUL_TIMEOUT_MS
+) {
+  return withTimeout(`printful ${path}`, timeoutMs, async () => {
+    const res = await fetch(`${PRINTFUL_API}${path}`, {
+      // AbortSignal actually cancels the socket; withTimeout is what stops the
+      // caller waiting (it also covers a stalled body read).
+      signal: AbortSignal.timeout(timeoutMs),
+      ...options,
+      headers: {
+        Authorization: `Bearer ${process.env.PRINTFUL_API_KEY}`,
+        "Content-Type": "application/json",
+        ...options?.headers,
+      },
+    });
+
+    if (!res.ok) {
+      const error = await res.text();
+      throw new Error(`Printful API error: ${res.status} ${error}`);
+    }
+
+    return res.json();
   });
-
-  if (!res.ok) {
-    const error = await res.text();
-    throw new Error(`Printful API error: ${res.status} ${error}`);
-  }
-
-  return res.json();
 }
 
 export async function getProducts() {
@@ -212,7 +235,9 @@ export async function estimateOrderCosts(params: {
   if (process.env.PRINTFUL_DRY_RUN === "true") return null;
 
   try {
-    const data = await printfulFetch("/orders/estimate-costs", {
+    const data = await printfulFetch(
+      "/orders/estimate-costs",
+      {
       method: "POST",
       body: JSON.stringify({
         recipient: {
@@ -235,7 +260,11 @@ export async function estimateOrderCosts(params: {
             : {}),
         })),
       }),
-    });
+      },
+      // This one sits on a page render (cart shipping row) and degrades to
+      // flat shipping, so it gets a tighter bound than the 30s default.
+      QUOTE_TIMEOUT_MS
+    );
     return parseEstimateCosts(data.result ?? {});
   } catch (err) {
     console.error("estimateOrderCosts failed, falling back to flat shipping:", err);


### PR DESCRIPTION
Closes #101.

## What was actually happening

Not an empty cart. The CI traces from run 29888905717 (artifacts were still
live) show the cart page loading fine — `POST /cart` (getCart) returned in
90ms — and then the browser navigating **back to /preview** ~200ms later. The
`cart-line-item` assertion spent its 30s against the preview page. Frame
snapshots from both the first attempt and retry 1:

```
/preview → /cart (33010ms) → /preview (33270ms) → … → /preview at failure
```

Cause: Next's server-action reducer ends every action by navigating to
`state.canonicalUrl` — the URL the action was *dispatched from*. `/preview`
always has a background action in flight (mockup render, price), so one
resolving after `router.push("/cart")` navigates the router back to /preview.
It bites intermittently because it depends on whether the push commits first;
it bites more on the second add, when `/cart` is already in the router cache
and the push commits instantly.

Reproduced locally: **7 failures in 16 runs** before, **0 in 16** after. Full
e2e suite green.

## The hypothesis in the brief did not hold

`ensureGuestSession` minting a second anon user is a real defect, but it is not
this flake. In the failing trace all three `/api/auth/get-session` calls
returned 200 and there was exactly one `POST /api/auth/sign-in/anonymous`, on
`/design`, as designed. No cookie swap. The cart page's 5-attempt fallback
isn't implicated either — `getCart` succeeded on the first try. And
`printfulFetch` is dry-run in the e2e webServer, so it can't stall there.

An intermediate theory — that `/preview`'s `window.history.replaceState`
(which Next converts into a router `ACTION_RESTORE`) was the trigger — was also
disproven: instrumenting `history.*` showed the effect's own no-op guard
already suppressing it, and the bounce still happened.

## Changes

Root cause:
- `src/app/preview/page.tsx` — leave for `/cart` via a document navigation, as
  `handleCheckout` already does. A router push is not durable against its own
  page's in-flight actions.
- `src/app/preview/page.tsx` — the URL-sync effect no longer rewrites history
  when the URL already matches, or once a navigation away has started. Next
  turns every `replaceState` into a router restore, so a redundant call is a
  real navigation.
- `src/app/cart/actions.ts` — drop `revalidatePath("/cart")`. Nothing renders
  cart data on the server (`/cart` is a client page calling `getCart`, the
  header calls `getCartCount`); all it bought was a `RefreshAll` on the
  navigation Next appends to every action.

Adjacent defects from the same review:
- `src/lib/ensure-guest-session.ts` — a failed session lookup (`data: null`
  *with* `error`) was treated as "no session" and minted a second anonymous
  user, swapping the cookie out from under whatever the visitor already owned.
  Only a clean read mints now; an error leaves the memo clear so the next call
  retries.
- `src/app/cart/page.tsx` — a load failure rendered "Your cart is empty." after
  five silent retries, indistinguishable from an empty cart for a customer as
  well as for the suite. Now one silent retry, then "Couldn't load your cart."
  with a Retry button.
- `src/lib/printful.ts` — `printfulFetch` had no timeout, so every cart render
  waited on Printful unbounded. Shared `withTimeout` + `AbortSignal`, 30s
  default (generous for `createOrder`), 10s override for the shipping quote,
  which already falls back to flat.

## Tests

726 (was 716).
- `src/lib/__tests__/ensure-guest-session.test.ts` — 6 tests: mints on genuine
  no-session, does not mint on error, retries after an error, no-op with a
  session, memoization, memo cleared on reject.
- `src/app/cart/__tests__/cart-page.test.tsx` — 4 tests: empty vs failed load,
  Retry recovers, one transient failure stays silent.
- `e2e/cart.spec.ts` — holds the URL for a second after add-to-cart and asserts
  it is still `/cart` (this caught the bounce directly), plus the session
  cookie is unchanged across the flow.

`npm run lint`, `npm run typecheck`, `npm test`, `npm run build` all pass.
E2E run locally against an ephemeral Turso branch (destroyed after).

## Note

The CI e2e comment about #101 is updated; `--workers=1 --retries=2` are left in
place as belt-and-suspenders. Worth removing in a later PR once this has held.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
