### PR TITLE
ci: migration drift gate + post-deploy prod smoke

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,29 @@ jobs:
 
       - run: npm run typecheck
 
+      # Migration drift gate. Nothing else in CI notices a schema.ts edit with
+      # no matching migration: the test harness derives DDL from schema.ts
+      # directly, so drift only surfaces later, when a manual `db:migrate`
+      # against prod/preview leaves the deployed app on an older schema (what
+      # stranded the #26 launch).
+      #
+      # `drizzle-kit generate` reads schema.ts + drizzle/meta only — no DB
+      # credentials, no network — and writes nothing when the chain is current.
+      # (`drizzle-kit check` in 0.31.x validates journal collisions, not
+      # schema-vs-migration drift, so it can't stand in here.) On a rename it
+      # wants an interactive prompt and exits non-zero rather than hanging.
+      - name: Migration drift check
+        run: |
+          if ! npm run db:generate; then
+            echo "::error::drizzle-kit generate failed. If it asked about a column/table rename, answer it locally with 'npm run db:generate' and commit drizzle/."
+            exit 1
+          fi
+          if [ -n "$(git status --porcelain drizzle/)" ]; then
+            git status --porcelain drizzle/
+            echo "::error::schema.ts changed with no matching migration. Run 'npm run db:generate' and commit drizzle/ (CLAUDE.md → Migration discipline)."
+            exit 1
+          fi
+
       # Runs the full suite with v8 coverage; the text-summary totals print in
       # the job log. No coverage threshold gates the build yet (baseline first).
       - run: npm run test:coverage

--- a/.github/workflows/prod-smoke.yml
+++ b/.github/workflows/prod-smoke.yml
@@ -1,0 +1,122 @@
+name: Prod smoke
+
+# Since #108 the e2e job boots its own compiled server, so no CI job touches a
+# real Vercel deployment. Missing/mis-scoped Production env vars and flags now
+# surface only when a human notices prod is broken. This waits for main's
+# production deploy, then curls the public surface. Public URLs only — no
+# secrets, no bypass header.
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  deployments: read
+  issues: write
+
+# Two pushes in quick succession would race for the same domain; queue instead.
+concurrency:
+  group: prod-smoke
+  cancel-in-progress: false
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      BASE_URL: https://prntd.org
+    steps:
+      # Mirrors the preview wait ci.yml carried before #108: Vercel records a
+      # GitHub deployment per commit and posts a status when the build lands.
+      # No checkout needed — `gh api` works off GITHUB_REPOSITORY.
+      - name: Wait for Vercel production deploy
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SHA: ${{ github.sha }}
+        run: |
+          set +e # "not deployed yet" is the expected case while polling
+          state=""
+          for i in $(seq 1 60); do
+            id=$(gh api "repos/$GITHUB_REPOSITORY/deployments?sha=$SHA&environment=Production" \
+              --jq '.[0].id // empty' 2>/dev/null)
+            if [ -n "$id" ]; then
+              state=$(gh api "repos/$GITHUB_REPOSITORY/deployments/$id/statuses" \
+                --jq '[.[] | select(.state=="success")][0].state // empty' 2>/dev/null)
+              [ "$state" = "success" ] && break
+            fi
+            echo "waiting for production deployment ($i)…"
+            sleep 15
+          done
+          if [ "$state" != "success" ]; then
+            echo "::error::deploy never appeared — no successful Production deployment for $SHA within 15 min (a failed or missing Vercel build is itself the finding)"
+            exit 1
+          fi
+          echo "production deployment succeeded for $SHA"
+
+      # The deployment status fires when the build lands; the prntd.org alias
+      # can take a few more seconds to point at it.
+      - name: Wait for prntd.org to answer
+        run: |
+          for i in $(seq 1 12); do
+            code=$(curl -sS -o /dev/null --max-time 20 -w '%{http_code}' "$BASE_URL/" || echo 000)
+            [ "$code" = "200" ] && exit 0
+            echo "GET / → $code ($i)"
+            sleep 10
+          done
+          echo "::error::$BASE_URL/ never returned 200"
+          exit 1
+
+      # Markers are structural, not marketing copy (copy sweeps rewrite copy):
+      #   /            maker-hero testid — the app rendered at all
+      #   /prints      published-grid testid — only present when the
+      #                server-side feed query returned rows, so it fails on
+      #                broken DATABASE_URL/DATABASE_AUTH_TOKEN (and on an
+      #                unexpectedly empty Shop, which is also worth knowing)
+      #   /robots.txt  the AI-crawler policy is actually served
+      #   /api/auth/…  better-auth mounted and booted (200 + body `null` when
+      #                signed out); catches a missing BETTER_AUTH_SECRET
+      - name: Smoke prntd.org
+        run: |
+          fail=0
+          probe() { # probe <path> [marker]
+            code=$(curl -sS -o /tmp/smoke-body --max-time 20 -w '%{http_code}' "$BASE_URL$1" || echo 000)
+            if [ "$code" != "200" ]; then
+              echo "FAIL $1 → HTTP $code"
+              fail=1
+              return
+            fi
+            if [ -n "${2:-}" ] && ! grep -qF "$2" /tmp/smoke-body; then
+              echo "FAIL $1 → 200 but missing marker: $2"
+              fail=1
+              return
+            fi
+            echo "ok   $1"
+          }
+
+          probe "/" 'data-testid="maker-hero"'
+          probe "/prints" 'data-testid="published-grid"'
+          probe "/robots.txt" "GPTBot"
+          probe "/api/auth/get-session"
+
+          [ "$fail" = "0" ] || { echo "::error::prod smoke failed — see the per-check lines above"; exit 1; }
+
+      # A red smoke must not be silent: file a tracking issue, or comment on
+      # the open one so repeated failures land in a single thread.
+      - name: Report failure
+        if: failure()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          run_url="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+          body="Prod smoke failed for ${{ github.sha }}: $run_url"
+          existing=$(gh issue list --repo "$GITHUB_REPOSITORY" --label prod-smoke --state open --json number --jq '.[0].number // empty')
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --repo "$GITHUB_REPOSITORY" --body "$body"
+          else
+            gh issue create --repo "$GITHUB_REPOSITORY" \
+              --title "Prod smoke failed" \
+              --label prod-smoke \
+              --body "$body"$'\n\n'"Later failures dedupe onto this issue while it stays open. Close it once prntd.org is healthy again."
+          fi

--- a/src/components/maker-hero.tsx
+++ b/src/components/maker-hero.tsx
@@ -12,6 +12,10 @@ import { minRetailPrice } from "@/lib/pricing";
  * generation. Unlike the in-chat chips (which prefill), landing chips
  * navigate immediately: here they demo the product. The sub-line is the
  * one-line basics of the offer (#75); price comes from minRetailPrice().
+ *
+ * data-testid="maker-hero" is the post-deploy prod smoke's "the app rendered"
+ * marker (.github/workflows/prod-smoke.yml) — copy sweeps rewrite the
+ * headline, this doesn't.
  */
 export function MakerHero() {
   const router = useRouter();
@@ -24,7 +28,10 @@ export function MakerHero() {
   }
 
   return (
-    <main className="flex-1 flex flex-col items-center justify-center px-4 py-6 sm:py-16 text-center">
+    <main
+      data-testid="maker-hero"
+      className="flex-1 flex flex-col items-center justify-center px-4 py-6 sm:py-16 text-center"
+    >
       <div className="w-full max-w-2xl space-y-4 sm:space-y-6">
         <h1 className="text-2xl sm:text-5xl font-bold tracking-tight">
           Your idea, on a shirt.

--- a/src/components/published-grid.tsx
+++ b/src/components/published-grid.tsx
@@ -6,6 +6,10 @@ import { publishedBackdrop } from "@/lib/blanks";
  * Shared grid of published (Shop, /prints) designs. Each card links to the
  * buy page at /d/[imageId]. The viewer's own designs are tagged "by you"
  * (set on PublishedImage.isOwn by the feed query).
+ *
+ * data-testid="published-grid" is the post-deploy prod smoke's DB canary
+ * (.github/workflows/prod-smoke.yml): it only reaches the HTML when the
+ * server-side feed query returned rows.
  */
 export function PublishedGrid({
   images,
@@ -17,7 +21,10 @@ export function PublishedGrid({
 }) {
   const suffix = from ? `?from=${encodeURIComponent(from)}` : "";
   return (
-    <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4">
+    <div
+      data-testid="published-grid"
+      className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4"
+    >
       {images.map((img) => {
         const backdrop = publishedBackdrop(img.backgroundColor);
         return (


### PR DESCRIPTION
Two CI gates from today's testing review. No product behaviour changes.

## Gate 1 — migration drift (`check` job, ci.yml)

Editing `src/lib/db/schema.ts` without generating a migration passes CI today: the test harness derives DDL from `schema.ts` via `drizzle-kit/api`, so nothing compares it to `drizzle/`. Drift only shows up later, when a manual `db:migrate` leaves prod/preview on an older schema — the #26 launch failure.

New step runs `npm run db:generate` and fails if `git status --porcelain drizzle/` is non-empty, telling the author to generate and commit.

- `drizzle-kit generate` needs **no DB credentials or network** — it reads `schema.ts` + `drizzle/meta` only. Verified locally with `DATABASE_URL` unset (dotenv logs `injecting env (0)`, generate still runs).
- `drizzle-kit check` (0.31.10) validates journal collisions, not schema-vs-migration drift, so it can't stand in.
- On a *rename* drizzle-kit wants an interactive prompt; in a non-TTY it errors out immediately rather than hanging (verified). The step catches that exit and points at running it locally.

Validated locally on drizzle-kit v0.31.10:

- clean tree → `No schema changes, nothing to migrate`, `git status --porcelain drizzle/` empty, gate passes.
- scratch column added to `listing` → generate writes `drizzle/0006_*.sql` + `meta/0006_snapshot.json` and modifies `_journal.json`; gate fails with the guidance message. Reverted.

## Gate 2 — post-deploy prod smoke (`prod-smoke.yml`)

Since #108 the e2e job boots its own compiled server, so **nothing in CI touches a real Vercel deployment**. Missing Production env vars/flags surface only when a human notices prod is broken.

On push to main (plus `workflow_dispatch`): poll the GitHub deployments API for a successful `Production` deployment of the pushed SHA (≈15 min ceiling, distinct "deploy never appeared" error — a failed/missing Vercel build is itself the finding), wait for `prntd.org` to answer 200 (alias propagation), then four `curl` checks:

| URL | assert |
| --- | --- |
| `/` | 200 + `data-testid="maker-hero"` |
| `/prints` | 200 + `data-testid="published-grid"` |
| `/robots.txt` | 200 + `GPTBot` |
| `/api/auth/get-session` | 200 |

`published-grid` only reaches the HTML when the server-side feed query returned rows, so it's the DB canary — broken `DATABASE_URL`/`DATABASE_AUTH_TOKEN` fails it. `get-session` proves better-auth booted (catches a missing `BETTER_AUTH_SECRET`); it returns `200` with body `null` when signed out. Markers are structural testids, not marketing copy, so a copy sweep can't silently disarm the smoke.

Failure opens (or comments on) a `prod-smoke` issue, mirroring `stripe-e2e.yml`'s Report failure step. The `prod-smoke` label already exists on the repo.

**No secrets** — every URL is public, `github.token` covers the deployments API and issue write.

## Validation

- `npm run lint` (0 errors, 17 pre-existing warnings), `npm test` (716 pass), `npm run build` — all green.
- `actionlint` 1.7.12 (with shellcheck 0.11.0) clean on both workflows.
- Smoke shell run verbatim against live prntd.org with today's markers substituted: `/`, `/prints`, `/robots.txt`, `/api/auth/get-session` all ok; a bogus path and a missing marker both fail as intended.

## Caveats

- **Neither workflow can be fully exercised from a PR.** `prod-smoke.yml` only triggers on push to main, so its first real run is the merge of this PR. The new testids ship in that same push, so the deployment it smokes will have them.
- The `/prints` marker couples the smoke to the Shop feed being non-empty. Prod has ~60 published designs; an empty feed would fail the smoke, which seems like the right answer.
- Drift gate assumes `drizzle-kit generate` stays credential-free; a future drizzle-kit that validates `dbCredentials` for `generate` would break the `check` job (loudly, on the next PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
